### PR TITLE
feat: implement detection mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE = $(IMAGE_NAME):$(TAG)
 IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v0.3
+TAG = v0.4
 POD = not-smooth-app
 
 .PHONY: all docker certs install unistall upgrade annihilate

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Connaisseur is an admission controller for Kubernetes that integrates Image Sign
 - [How it works](#how-it-works)
 - [Getting Started](#getting-started)
   * [Image Policy](#image-policy)
+  * [Detection Mode](#detection-mode)
 - [Threat Model](#threat-model)
   * [(1) Developer/User](#-1--developer-user)
   * [(2) Connaisseur Service](#-2--connaisseur-service)
@@ -57,7 +58,7 @@ git clone git@github.com:sse-secure-systems/connaisseur.git
 If your Notary uses a self-signed certificate, `.notary.selfsigned` should be set to `true` and the certificate has to be added to `.notary.selfsignedCert`. In case your Notary instance is authenticated (which it should), set the `.notary.auth.enabled` to `true` and enter the credentials either directly or as a predefined secret. Lastly enter the public root key in `.notary.rootPubKey`, which is used for verifying the image signatures. For further details, please checkout the [setup guide](setup/README.md).
 4. **Deploy**: Switch to the cluster where you would like to install Connaisseur, and run `make install`.
 
-> :warning: **WARNING!** Be careful when installing Connaisseur in minikube and restarting the cluster!  ​When stopping the cluster with `minikube stop` while Connaisseur is still installed and running, restarting it with `minikube start` will not work. The command will freeze at some point, as long as Connaisseur is running, since Connaisseur per default will block some resources from staring up. At that point you can still access the cluster and delete Connaisseur manually, then the `minikube start` process will finish.
+> :warning: **WARNING!** Be careful when installing Connaisseur in minikube and restarting the cluster!  ​When stopping the cluster with `minikube stop` while Connaisseur is still installed and running, restarting it with `minikube start` will not work. The command will freeze at some point, as long as Connaisseur is running, since Connaisseur per default will block some resources from staring up. At that point you can still access the cluster and delete Connaisseur manually, then the `minikube start` process will finish. You can use [Detection Mode](#detection-mode) to avoid interruptions during testing.
 
 ### Image Policy
 
@@ -84,6 +85,11 @@ The policy consists of a set of rules. Each rule starts with a pattern that need
 3. Return the most specific rule.
 
 In addition to the pattern, rules can also contain a `verify` flag which specifies whether the image requires a signature or can skip verification. If `verify` is set to `true`, a valid signature is required; otherwise, the image is admitted. Additionally, a rule can have `delegations` which correspond to Notary delegation roles. These are to be understood as specific signers that need to be present in the Notary trust data in order for signature verification to be successful.
+
+### Detection Mode
+A detection mode is available in order to avoid interruptions of a running cluster, to support initial rollout or for testing purposes. In detection mode, Connaisseur will admit all images to the cluster, but logs an error message for images that do not comply with the policy or in case of other unexpected failures.
+
+To activate the detection mode, set the `detection_mode` flag to `true` in `helm/values.yaml`.
 
 ## Threat Model
 

--- a/connaisseur/__main__.py
+++ b/connaisseur/__main__.py
@@ -12,7 +12,9 @@ if __name__ == "__main__":
         {
             "version": 1,
             "formatters": {
-                "default": {"format": "[%(asctime)s] %(levelname)s: %(message)s",}
+                "default": {
+                    "format": "[%(asctime)s] %(levelname)s: %(message)s",
+                }
             },
             "handlers": {
                 "wsgi": {

--- a/connaisseur/exceptions.py
+++ b/connaisseur/exceptions.py
@@ -1,4 +1,7 @@
 # pylint: disable=dangerous-default-value
+import os
+
+
 class BaseConnaisseurException(Exception):
     """
     Base exception that can take an error message and context information as a
@@ -7,14 +10,23 @@ class BaseConnaisseurException(Exception):
 
     message: str
     context: dict
+    detection_mode: bool
 
     def __init__(self, message: str, context: dict = {}):
         self.message = message
         self.context = context
+        self.detection_mode = os.environ.get("DETECTION_MODE", "0") == "1"
         super().__init__()
 
     def __str__(self):
-        return str({"message": self.message, "context": self.context})
+        return str(self.__dict__)
+
+    @property
+    def user_msg(self):
+        msg = self.message
+        if self.detection_mode:
+            msg += " (not denied due to DETECTION_MODE)"
+        return msg
 
 
 class InvalidFormatException(BaseConnaisseurException):

--- a/connaisseur/tests/test_exceptions.py
+++ b/connaisseur/tests/test_exceptions.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+import connaisseur.exceptions
+
+
+@pytest.fixture
+def excep():
+    return connaisseur.exceptions
+
+
+def test_exceptions(excep):
+    ex = excep.BaseConnaisseurException("Hallo", {"du": "da"})
+    assert ex.message == "Hallo"
+    assert ex.context == {"du": "da"}
+    assert ex.detection_mode == False
+
+
+def test_exception_str(excep):
+    ex = excep.BaseConnaisseurException("Hallo", {"du": "da"})
+    assert str(ex) == str(
+        {"message": "Hallo", "context": {"du": "da"}, "detection_mode": False}
+    )
+
+
+@pytest.mark.parametrize(
+    "msg, dm, out",
+    [
+        ("Hallo", "0", "Hallo"),
+        ("Hallo", "1", "Hallo (not denied due to DETECTION_MODE)"),
+    ],
+)
+def test_exception_user_msg(excep, msg, dm, out):
+    os.environ["DETECTION_MODE"] = dm
+    ex = excep.BaseConnaisseurException(msg, {"du": "da"})
+    assert ex.user_msg == out

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -82,6 +82,7 @@ ad_review1 = {
     "response": {
         "uid": "3a3a7b38-5512-4a85-94bb-3562269e0a6a",
         "allowed": True,
+        "status": {"code": 202},
         "patchType": "JSONPatch",
         "patch": (
             "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL3RlbXBsYXRlL3NwZWMvY29udGFpbmVy"
@@ -94,7 +95,11 @@ ad_review1 = {
 ad_review2 = {
     "apiVersion": "admission.k8s.io/v1beta1",
     "kind": "AdmissionReview",
-    "response": {"uid": "f8c8b687-fe68-48e2-8e2b-329567556307", "allowed": True},
+    "response": {
+        "uid": "f8c8b687-fe68-48e2-8e2b-329567556307",
+        "allowed": True,
+        "status": {"code": 202},
+    },
 }
 policy = {
     "rules": [

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -21,3 +21,6 @@ data:
   {{- else }}
   LOG_LEVEL: INFO
   {{- end }}
+  {{- if .Values.detection_mode }}
+  DETECTION_MODE: "1"
+  {{- end}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisser deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v0.3
+  image: securesystemsengineering/connaisseur:v0.4
   imagePullPolicy: Always
   resources: {}
   # limits:
@@ -55,5 +55,10 @@ policy:
     verify: false
   - pattern: "docker.io/securesystemsengineering/connaisseur:*"
     verify: false
+
+# in detection mode, deployment will not be denied, but only prompted
+# and logged. This allows testing the functionality without
+# interrupting operation.
+detection_mode: false
 
 # debug: true


### PR DESCRIPTION
The detection mode allows Connaisseur to run in non-strict mode, letting non-compliant images pass, but logging the error. As of Kubernetes version 1.19, a warning is issued to the user (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).