### PR TITLE
fix: added subjectAltNames to TLS certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ testing-env/aks/k8s/deployment.yaml
 .scannerwork/
 samples/*
 demo/
-ca.conf
-tls.conf
+tls-*.conf

--- a/connaisseur/__main__.py
+++ b/connaisseur/__main__.py
@@ -26,5 +26,5 @@ if __name__ == "__main__":
     )
 
     APP.run(
-        host="0.0.0.0", ssl_context=("/etc/certs/tls-crt.pem", "/etc/certs/tls-key.pem")
+        host="0.0.0.0", ssl_context=("/etc/certs/tls.crt", "/etc/certs/tls.key")
     )

--- a/helm/certs/gen_certs.sh
+++ b/helm/certs/gen_certs.sh
@@ -4,40 +4,17 @@ SCRIPT_PATH=$(dirname $0)
 SERVICE_NAME=$(yq r $SCRIPT_PATH/../Chart.yaml name)
 
 cd $SCRIPT_PATH
-openssl genrsa -out ca.key 4096
-
-cat <<EOF > ca.conf
-[ req ]
-default_bits       = 4096
-default_md         = sha512
-default_keyfile    = ca.key
-prompt             = no
-encrypt_key        = yes
-
-# base request
-distinguished_name = req_distinguished_name
-
-# distinguished_name
-[ req_distinguished_name ]
-countryName            = "DE"
-stateOrProvinceName    = "Berlin"
-localityName           = "Berlin"
-organizationName       = "SSE"
-organizationalUnitName = "Engineering Department"
-commonName             = "connaisseur.internal"
-emailAddress           = "no-reply@securesystems.de"
-EOF
-openssl req -new -x509 -key ca.key -out ca.crt -config ca.conf
-
-openssl genrsa -out tls-key.pem 4096
-cat <<EOF > tls.conf
+openssl genrsa -out tls.key 4096
+cat <<EOF > tls-csr.conf
 [req]
 req_extensions = v3_req
 distinguished_name = req_distinguished_name
+
 [ req_distinguished_name ]
+
 [ v3_req ]
-basicConstraints=CA:FALSE
-subjectAltName=@alt_names
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 
@@ -47,5 +24,20 @@ DNS.2 = $SERVICE_NAME-svc.$SERVICE_NAME
 DNS.3 = $SERVICE_NAME-svc.$SERVICE_NAME.svc
 DNS.4 = $SERVICE_NAME-svc.$SERVICE_NAME.svc.cluster.local
 EOF
-openssl req -new -key tls-key.pem -subj "/CN=$SERVICE_NAME-svc.$SERVICE_NAME.svc" -out tls.csr -config tls.conf
-openssl x509 -req -in tls.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls-crt.pem
+
+cat <<EOF > tls-crt.conf
+[ v3_ca]
+basicConstraints = CA:FALSE
+subjectAltName = @alt_names
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ alt_names ]
+DNS.1 = $SERVICE_NAME-svc
+DNS.2 = $SERVICE_NAME-svc.$SERVICE_NAME
+DNS.3 = $SERVICE_NAME-svc.$SERVICE_NAME.svc
+DNS.4 = $SERVICE_NAME-svc.$SERVICE_NAME.svc.cluster.local
+EOF
+
+openssl req -new -key tls.key -sha256 -config tls-csr.conf -subj "/CN=$SERVICE_NAME-svc.$SERVICE_NAME.svc" -out tls.csr
+openssl x509 -req -days 36500 -in tls.csr -signkey tls.key -sha256 -extensions v3_ca -extfile tls-crt.conf -out tls.crt

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  tls-crt.pem: {{ .Files.Get "certs/tls-crt.pem" | b64enc }}
-  tls-key.pem: {{ .Files.Get "certs/tls-key.pem" | b64enc }}
+  tls.crt: {{ .Files.Get "certs/tls.crt" | b64enc }}
+  tls.key: {{ .Files.Get "certs/tls.key" | b64enc }}
   {{- if .Values.notary.selfsigned}}
   notary.crt: {{ .Values.notary.selfsignedCert | b64enc }}
   {{- end }}

--- a/helm/templates/webhook/webhook.yaml
+++ b/helm/templates/webhook/webhook.yaml
@@ -16,7 +16,7 @@ webhooks:
         name: {{ .Chart.Name }}-svc
         namespace: {{ .Release.Namespace }}
         path: /mutate
-      caBundle: {{ .Files.Get "certs/tls-crt.pem" | b64enc | quote }}
+      caBundle: {{ .Files.Get "certs/tls.crt" | b64enc | quote }}
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]


### PR DESCRIPTION
Kubernetes v1.19 requires subjectAltNames to be present on the TLS certificates or otherwise will break. Even though the TLS config file already added those, an OpenSSL bug prevented them to be actually propagated to the actual certificates.

closes #4