### PR TITLE
fix: extend validation schemas to allow dates across all timezones and all possible tag values

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  RELEASE_VERSION: v0.3
+  RELEASE_VERSION: v1.1.3
   RELEASE_IMAGE: securesystemsengineering/connaisseur
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE = $(IMAGE_NAME):$(TAG)
 IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v0.4
+TAG = v1.1.3
 POD = not-smooth-app
 
 .PHONY: all docker certs install unistall upgrade annihilate

--- a/connaisseur/__main__.py
+++ b/connaisseur/__main__.py
@@ -27,6 +27,4 @@ if __name__ == "__main__":
         }
     )
 
-    APP.run(
-        host="0.0.0.0", ssl_context=("/etc/certs/tls.crt", "/etc/certs/tls.key")
-    )
+    APP.run(host="0.0.0.0", ssl_context=("/etc/certs/tls.crt", "/etc/certs/tls.key"))

--- a/connaisseur/res/root_schema.json
+++ b/connaisseur/res/root_schema.json
@@ -12,7 +12,7 @@
                 },
                 "expires": {
                     "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6,10}\\+\\d{2}:\\d{2}$"
+                    "format": "date-time"
                 },
                 "version": {
                     "type": "integer"

--- a/connaisseur/res/snapshot_schema.json
+++ b/connaisseur/res/snapshot_schema.json
@@ -12,7 +12,7 @@
                 },
                 "expires": {
                     "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6,10}Z$"
+                    "format": "date-time"
                 },
                 "version": {
                     "type": "integer"

--- a/connaisseur/res/targets_schema.json
+++ b/connaisseur/res/targets_schema.json
@@ -12,7 +12,7 @@
                 },
                 "expires": {
                     "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6,10}\\+\\d{2}:\\d{2}$"
+                    "format": "date-time"
                 },
                 "version": {
                     "type": "integer"
@@ -100,7 +100,7 @@
                 "targets": {
                     "type": "object",
                     "patternProperties": {
-                        "^\\w*$": {
+                        "^[\\w\\.-]*$": {
                             "type": "object",
                             "properties": {
                                 "hashes": {

--- a/connaisseur/res/timestamp_schema.json
+++ b/connaisseur/res/timestamp_schema.json
@@ -12,7 +12,7 @@
                 },
                 "expires": {
                     "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6,10}Z$"
+                    "format": "date-time"
                 },
                 "version": {
                     "type": "integer"

--- a/connaisseur/res/trust_schema.json
+++ b/connaisseur/res/trust_schema.json
@@ -12,7 +12,7 @@
                 },
                 "expires": {
                     "type": "string",
-                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{9}\\+\\d{2}:\\d{2}$"
+                    "format": "date-time"
                 },
                 "version": {
                     "type": "integer"

--- a/connaisseur/tests/data/sample3_targets.json
+++ b/connaisseur/tests/data/sample3_targets.json
@@ -1,0 +1,38 @@
+{
+    "signed": {
+        "_type": "Targets",
+        "delegations": {
+            "keys": {},
+            "roles": []
+        },
+        "expires": "2023-10-01T17:30:20.690484705+02:00",
+        "targets": {
+            "v1.0.9": {
+                "hashes": {
+                    "sha256": "VI55/vvzrpsAqPDn1nClK32rr5DYwz41SF7TsoFnGbQ="
+                },
+                "length": 1993
+            },
+            "v1.0.9-slim-fat_image": {
+                "hashes": {
+                    "sha256": "VI55/vvzrpsAqPDn1nClK32rr5DYwz41SF7TsoFnGbQ="
+                },
+                "length": 1993
+            },
+            "v382": {
+                "hashes": {
+                    "sha256": "tAfAA8UtSApRNvCHLlZx/6c6x8jHgKGQRZeGEfDu1vE="
+                },
+                "length": 1993
+            }
+        },
+        "version": 4
+    },
+    "signatures": [
+        {
+            "keyid": "fb77b27209b581031fa11e548a56bcacb617ce3ca9b15846fb146d786a6ce29c",
+            "method": "ecdsa",
+            "sig": "D1agOvq32JIhRxamPCzC8TD/QVRa86kZx2PBSQl1ms/VSTyUXBeFDdJUbRSn76+nLSIXqCMHGiWxW0o4b5pVnw=="
+        }
+    ]
+}

--- a/connaisseur/tests/data/sample3_timestamp.json
+++ b/connaisseur/tests/data/sample3_timestamp.json
@@ -1,0 +1,24 @@
+{
+    "signed": {
+      "_type": "Timestamp",
+      "expires": "2020-15-15T15:30:21.227951409Z",
+      "meta": {
+        "snapshot": {
+          "hashes": {
+            "sha256": "bRkQwW0EUt4Z/sV4nMv/TFHuMUedGNdlreLn2OxKDg0=",
+            "sha512": "uw/WbvjcCq8CWy0G0fZ+8YO9Vk77A3KbNHrTJEHjsL64Idn7cldd7Aw11bVp8WOOh9DuEmaK1LA+qU0d/2+Dww=="
+          },
+          "length": 683
+        }
+      },
+      "version": 3
+    },
+    "signatures": [
+      {
+        "keyid": "c0abd5ddb2f64fe8ce0b35f0852ebfb26a4a27bb4087ed57d36a3ffb669c25fb",
+        "method": "ecdsa",
+        "sig": "N8E9UEhYqr0qsIOf7vCNyT0O2v75YFScxfm3pBYcXF3AYAp7/x12XhdXE0Syu7G+SP22si7TNyWTCSvOLj6EDw=="
+      }
+    ]
+  }
+  

--- a/connaisseur/tests/data/sample4_targets.json
+++ b/connaisseur/tests/data/sample4_targets.json
@@ -1,0 +1,26 @@
+{
+    "signed": {
+        "_type": "Targets",
+        "delegations": {
+            "keys": {},
+            "roles": []
+        },
+        "expires": "2023-10-02T01:30:15.999340461-07:00",
+        "targets": {
+            "v1.0.0-alpha": {
+                "hashes": {
+                    "sha256": "VI55/vvzrpsAqPDn1nClK32rr5DYwz41SF7TsoFnGbQ="
+                },
+                "length": 1993
+            }
+        },
+        "version": 2
+    },
+    "signatures": [
+        {
+            "keyid": "c5b6bd08a76e7ed728b922e3292c03b24cc8c87e6be73b88e3ab3390a61db264",
+            "method": "ecdsa",
+            "sig": "6RrBLhK/J6mlgByPar3HP0uf7Vxm3G1KZDXzeeveACF3LLQexNiDmueHjN3IUq/s7AqrgrfwU+m89DZrK/ZCHA=="
+        }
+    ]
+}

--- a/connaisseur/tests/data/sample5_root.json
+++ b/connaisseur/tests/data/sample5_root.json
@@ -1,0 +1,71 @@
+{
+    "signed": {
+        "_type": "Root",
+        "consistent_snapshot": false,
+        "expires": "2027-09-30T00:03:21.57118765+02:00",
+        "keys": {
+            "59752a99a56142b0d0af030ed78768f313946fcfe17f153b31f6a4c3e95ba778": {
+                "keytype": "ecdsa",
+                "keyval": {
+                    "private": null,
+                    "public": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnvvEn/Y3CG9ZqPxKdnPPmMLsLwc4d7+qIU6gYNC0782kyRZYm8rG2NMi45UsZm+fgrRolBezbPGrmTGT2j5EbA=="
+                }
+            },
+            "654647b9543690aafc97f608ec604f265f01fdf05d2d488d4b3cd332a2db9d43": {
+                "keytype": "ecdsa-x509",
+                "keyval": {
+                    "private": null,
+                    "public": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJqRENDQVRHZ0F3SUJBZ0lRU3FrTnV5Zk91RGkybzZ6KzJNTVAvekFLQmdncWhrak9QUVFEQWpBc01Tb3cKS0FZRFZRUURFeUZ5WldkcGMzUnllUzVsZUdGdGNHeGxMbXh2WTJGc09qVXdNREF2YzI1aGEyVXdIaGNOTVRjeApNREF4TWpJd01UUTNXaGNOTWpjd09USTVNakl3TVRRM1dqQXNNU293S0FZRFZRUURFeUZ5WldkcGMzUnllUzVsCmVHRnRjR3hsTG14dlkyRnNPalV3TURBdmMyNWhhMlV3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkMKQUFRTHZpdU5raVFETzNjMUw4TDlVVU9Xajk3bGRJcEEyaVYzN3dMbFFaQk5YaHNiL0o5Z3MrVWd3aytIaHFjSApRYk13MlhxYzN0eFZkcWxhby85QzdlTDFvelV3TXpBT0JnTlZIUThCQWY4RUJBTUNCYUF3RXdZRFZSMGxCQXd3CkNnWUlLd1lCQlFVSEF3TXdEQVlEVlIwVEFRSC9CQUl3QURBS0JnZ3Foa2pPUFFRREFnTkpBREJHQWlFQXlhUHYKcjgzNTBwNzJsQlNrM0dyOTlqTXBOUzczc2UrMlFHQ0pKemtMQTdvQ0lRRDlwUmt3YnFzemVxNVl4U2Y2YTg4ZQp5aHRXSEpmQ2lkVXFKb3pWSndiaWV3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+                }
+            },
+            "a2ebe51f9399e25ce14fd40a1fde6e2508542d0443b3954bdb4ca5283d1cda6f": {
+                "keytype": "ecdsa",
+                "keyval": {
+                    "private": null,
+                    "public": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQEg7Lk6JgVgweEaxq4KebqkhH7QD65GKdST5I8+mJZyIpPVL+nQGOb2DX6W1Q0AN8Z3Ny/+n5oGqQfWCaXw3Zw=="
+                }
+            },
+            "fe3d087fbca4a9f9edd21813e5eb464e7c0dcb3814a5fe21b968744a0f45f027": {
+                "keytype": "ecdsa",
+                "keyval": {
+                    "private": null,
+                    "public": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEN3ILa0E1/P6QB/cauouggwlZZwuvnOBAzAnSLJjyOZnvwIzrfrSp/E0OpoiPcKMhlVQbFQyEkhb874On6Dl1dQ=="
+                }
+            }
+        },
+        "roles": {
+            "root": {
+                "keyids": [
+                    "654647b9543690aafc97f608ec604f265f01fdf05d2d488d4b3cd332a2db9d43"
+                ],
+                "threshold": 1
+            },
+            "snapshot": {
+                "keyids": [
+                    "fe3d087fbca4a9f9edd21813e5eb464e7c0dcb3814a5fe21b968744a0f45f027"
+                ],
+                "threshold": 1
+            },
+            "targets": {
+                "keyids": [
+                    "a2ebe51f9399e25ce14fd40a1fde6e2508542d0443b3954bdb4ca5283d1cda6f"
+                ],
+                "threshold": 1
+            },
+            "timestamp": {
+                "keyids": [
+                    "59752a99a56142b0d0af030ed78768f313946fcfe17f153b31f6a4c3e95ba778"
+                ],
+                "threshold": 1
+            }
+        },
+        "version": 1
+    },
+    "signatures": [
+        {
+            "keyid": "654647b9543690aafc97f608ec604f265f01fdf05d2d488d4b3cd332a2db9d43",
+            "method": "ecdsa",
+            "sig": "IqiPu7Jys9V6eLnXIk94w7kK8H6xrqL4q6R8QslzEz1cuap4JcM+va6hRaQdnLC5cogkoVjuJELFtZPDygg00A=="
+        }
+    ]
+}

--- a/connaisseur/tests/data/sample5_targets.json
+++ b/connaisseur/tests/data/sample5_targets.json
@@ -1,0 +1,26 @@
+{
+    "signed": {
+        "_type": "Targets",
+        "delegations": {
+            "keys": {},
+            "roles": []
+        },
+        "expires": "2020-10-01T00:03:21.590854616+02:00",
+        "targets": {
+            "v42": {
+                "hashes": {
+                    "sha256": "9sfkkms0+VUC+gmv9kGTHbXyapio8WmaRLedxPKqrOk="
+                },
+                "length": 2217
+            }
+        },
+        "version": 2
+    },
+    "signatures": [
+        {
+            "keyid": "a2ebe51f9399e25ce14fd40a1fde6e2508542d0443b3954bdb4ca5283d1cda6f",
+            "method": "ecdsa",
+            "sig": "7oKogdGQul2/LudZh+4JEOCGyA665qd7eRuk/+5TUCjxdBzSlbHZxMIjWr7NmC+Q/PEpEBgdS5MhByB4+jGpbA=="
+        }
+    ]
+}

--- a/connaisseur/tests/data/sample5_timestamp.json
+++ b/connaisseur/tests/data/sample5_timestamp.json
@@ -1,0 +1,23 @@
+{
+    "signed": {
+        "_type": "Timestamp",
+        "expires": "2017-10-15T22:03:21.639815645Z",
+        "meta": {
+            "snapshot": {
+                "hashes": {
+                    "sha256": "xM9z6qukHZrvmLZ2BdXOeYJU/075OLaSI4ci+IlNTbU=",
+                    "sha512": "4vJuOHDIHIg6P7CZYhXORiB2I1l8qAyCDsk/+xJNuKN6Y4dWZxGLhKzGn7ro9Aw/X7AqO8p2w9D/jZuKfYewEQ=="
+                },
+                "length": 683
+            }
+        },
+        "version": 1
+    },
+    "signatures": [
+        {
+            "keyid": "59752a99a56142b0d0af030ed78768f313946fcfe17f153b31f6a4c3e95ba778",
+            "method": "ecdsa",
+            "sig": "B4ldaV1PqPkjQhdUbaEX9Kzey9uq3RuKsREKtWrDGZ1LZ/t9PBN/I2brFrmCPEqq4wkXC4eQgQADA8C7itHeiw=="
+        }
+    ]
+}

--- a/connaisseur/tests/data/sample6_root.json
+++ b/connaisseur/tests/data/sample6_root.json
@@ -1,0 +1,41 @@
+{
+    "signed": {
+        "_type": "Root",
+        "consistent_snapshot": false,
+        "expires": "2030-01-10T16:54:54.556992289+01:00",
+        "roles": {
+            "root": {
+                "keyids": [
+                    "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798"
+                ],
+                "threshold": 1
+            },
+            "snapshot": {
+                "keyids": [
+                    "7dbacd611d5933ca3f0fad581ed233881c501229343613f63f2d4b5771ee4299"
+                ],
+                "threshold": 1
+            },
+            "targets": {
+                "keyids": [
+                    "7c62922e6be165f1ea08252f77410152b9e4ec0d7bf4e69c1cc43f0e6c73da20"
+                ],
+                "threshold": 1
+            },
+            "timestamp": {
+                "keyids": [
+                    "f1997e14be3d33c5677282b6a73060d8124f4020f464644e27ab76f703eb6f7e"
+                ],
+                "threshold": 1
+            }
+        },
+        "version": 1
+    },
+    "signatures": [
+        {
+            "keyid": "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798",
+            "method": "ecdsa",
+            "sig": "77lGn17vJPsru39/mO6quh+yuMQvhLyqz4PhvMySLpnpzYu2x+YIsXfH2gngP8hYzOWvovE6iQPKBoJv3zWMsQ=="
+        }
+    ]
+}

--- a/connaisseur/tests/test_image.py
+++ b/connaisseur/tests/test_image.py
@@ -40,7 +40,14 @@ def im():
         ),
         ("registry.io/image:tag", "image", "tag", None, "", "registry.io"),
         ("path/to/repo/image:tag", "image", "tag", None, "path/to/repo", "docker.io"),
-        ("reg.com:12345/path/to/repo/image:tag", "image", "tag", None, "path/to/repo", "reg.com:12345"),
+        (
+            "reg.com:12345/path/to/repo/image:tag",
+            "image",
+            "tag",
+            None,
+            "path/to/repo",
+            "reg.com:12345",
+        ),
         ("image:tag", "image", "tag", None, "", "docker.io"),
         (
             "sub.registry.io/path/image:tag",
@@ -68,8 +75,11 @@ def test_image(
     [
         ("image/", '"image/" is not a valid image format.'),
         ("registry:", '"registry:" is not a valid image format.'),
-        ("registry:123456789/repo/image:tag", '"registry:123456789/repo/image:tag" is not a valid image format.')
-    ]
+        (
+            "registry:123456789/repo/image:tag",
+            '"registry:123456789/repo/image:tag" is not a valid image format.',
+        ),
+    ],
 )
 def test_image_error(im, image: str, error: str):
     with pytest.raises(BaseConnaisseurException) as err:

--- a/connaisseur/tests/test_trust_data.py
+++ b/connaisseur/tests/test_trust_data.py
@@ -63,6 +63,63 @@ root_keys = {
         },
     },
 }
+root_keys_sample5 = {
+    "59752a99a56142b0d0af030ed78768f313946fcfe17f153b31f6a4c3e95ba778": {
+        "keytype": "ecdsa",
+        "keyval": {
+            "private": None,
+            "public": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnvvEn/Y3CG9ZqPxKdnPPmM"
+                "LsLwc4d7+qIU6gYNC0782kyRZYm8rG2NMi45UsZm+fgrRolBezbPGrmTGT"
+                "2j5EbA=="
+            ),
+        },
+    },
+    "654647b9543690aafc97f608ec604f265f01fdf05d2d488d4b3cd332a2db9d43": {
+        "keytype": "ecdsa-x509",
+        "keyval": {
+            "private": None,
+            "public": (
+                "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJqRENDQVRHZ0F3SU"
+                "JBZ0lRU3FrTnV5Zk91RGkybzZ6KzJNTVAvekFLQmdncWhrak9QUVFEQWpB"
+                "c01Tb3cKS0FZRFZRUURFeUZ5WldkcGMzUnllUzVsZUdGdGNHeGxMbXh2WT"
+                "JGc09qVXdNREF2YzI1aGEyVXdIaGNOTVRjeApNREF4TWpJd01UUTNXaGNO"
+                "TWpjd09USTVNakl3TVRRM1dqQXNNU293S0FZRFZRUURFeUZ5WldkcGMzUn"
+                "llUzVsCmVHRnRjR3hsTG14dlkyRnNPalV3TURBdmMyNWhhMlV3V1RBVEJn"
+                "Y3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkMKQUFRTHZpdU5raVFETzNjMU"
+                "w4TDlVVU9Xajk3bGRJcEEyaVYzN3dMbFFaQk5YaHNiL0o5Z3MrVWd3aytI"
+                "aHFjSApRYk13MlhxYzN0eFZkcWxhby85QzdlTDFvelV3TXpBT0JnTlZIUT"
+                "hCQWY4RUJBTUNCYUF3RXdZRFZSMGxCQXd3CkNnWUlLd1lCQlFVSEF3TXdE"
+                "QVlEVlIwVEFRSC9CQUl3QURBS0JnZ3Foa2pPUFFRREFnTkpBREJHQWlFQX"
+                "lhUHYKcjgzNTBwNzJsQlNrM0dyOTlqTXBOUzczc2UrMlFHQ0pKemtMQTdv"
+                "Q0lRRDlwUmt3YnFzemVxNVl4U2Y2YTg4ZQp5aHRXSEpmQ2lkVXFKb3pWSn"
+                "diaWV3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+            ),
+        },
+    },
+    "a2ebe51f9399e25ce14fd40a1fde6e2508542d0443b3954bdb4ca5283d1cda6f": {
+        "keytype": "ecdsa",
+        "keyval": {
+            "private": None,
+            "public": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQEg7Lk6JgVgweEaxq4Kebqkh"
+                "H7QD65GKdST5I8+mJZyIpPVL+nQGOb2DX6W1Q0AN8Z3Ny/+n5oGqQfWCaXw3"
+                "Zw=="
+            ),
+        },
+    },
+    "fe3d087fbca4a9f9edd21813e5eb464e7c0dcb3814a5fe21b968744a0f45f027": {
+        "keytype": "ecdsa",
+        "keyval": {
+            "private": None,
+            "public": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEN3ILa0E1/P6QB/cauouggwlZ"
+                "ZwuvnOBAzAnSLJjyOZnvwIzrfrSp/E0OpoiPcKMhlVQbFQyEkhb874On6Dl1"
+                "dQ=="
+            ),
+        },
+    },
+}
 targets_keys = {
     "6984a67934a29955b3f969835c58ee0dd09158f5bec43726d319515b56b0a878": {
         "keytype": "ecdsa",
@@ -199,6 +256,14 @@ def mock_keystore(monkeypatch):
                 "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0xl8F5nwIV3IAru1Pf85WCo4cf"
                 "TOQ91jhxVaQ3xHMeW430q7R4H/tJmAXUZBe+nOTX8pgtmrLpT+Hu/H7pUhw=="
             ),
+            "a2ebe51f9399e25ce14fd40a1fde6e2508542d0443b3954bdb4ca5283d1cda6f": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQEg7Lk6JgVgweEaxq4KebqkhH7Q"
+                "D65GKdST5I8+mJZyIpPVL+nQGOb2DX6W1Q0AN8Z3Ny/+n5oGqQfWCaXw3Zw=="
+            ),
+            "fb77b27209b581031fa11e548a56bcacb617ce3ca9b15846fb146d786a6ce29c": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExK/3GbTTNE6qG3/rByaDurVQ41D"
+                "PqkYN4ge13exMeGZzRtv5fcaEHEyt4zK/bPyXpc2laxLiIHEZMU6WQYVD2A=="
+            ),
         }
         self.hashes = {
             "root": ("wlaYz21+0NezlHjqkldQQBf3KWtifimy07A+fOEyCTo=", 2401),
@@ -244,13 +309,31 @@ def test_trust_data_error(td):
     assert str(err.value) == "could not find class with name trust."
 
 
-def test_validate_schema_error(td, mock_schema_path):
-    data = trust_data("tests/data/sample_root.json")
-    del data["signed"]["keys"]
-
+@pytest.mark.parametrize(
+    "trustdata, role",
+    [
+        (trust_data("tests/data/sample6_root.json"), "root"),
+        (trust_data("tests/data/sample3_timestamp.json"), "timestamp"),
+    ],
+)
+def test_validate_schema_error(td, mock_schema_path, trustdata: dict, role: str):
     with pytest.raises(ValidationError) as err:
-        td.TrustData(data, "root")
+        td.TrustData(trustdata, role)
     assert "trust data has invalid format." in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "trustdata, role",
+    [
+        (trust_data("tests/data/sample_root.json"), "root"),
+        (trust_data("tests/data/sample_snapshot.json"), "snapshot"),
+        (trust_data("tests/data/sample_timestamp.json"), "timestamp"),
+        (trust_data("tests/data/sample3_targets.json"), "targets"),
+        (trust_data("tests/data/sample4_targets.json"), "targets"),
+    ],
+)
+def test_validate_schema(td, mock_schema_path, trustdata: dict, role: str):
+    data = td.TrustData(trustdata, role)
 
 
 @pytest.mark.parametrize(
@@ -312,6 +395,7 @@ def test_validate_hash_error(td, mock_schema_path, mock_keystore):
     [
         (trust_data("tests/data/sample_snapshot.json"), "snapshot"),
         (trust_data("tests/data/sample_timestamp.json"), "timestamp"),
+        (trust_data("tests/data/sample4_targets.json"), "targets"),
     ],
 )
 def test_validate_trust_data_expiry(td, mock_schema_path, data: dict, role: str):
@@ -323,9 +407,12 @@ def test_validate_trust_data_expiry(td, mock_schema_path, data: dict, role: str)
     assert trust_data_._validate_expiry() is None
 
 
-def test_validate_trust_data_expiry_error(td, mock_schema_path):
-    data = trust_data("tests/data/sample_timestamp.json")
-    trust_data_ = td.TrustData(data, "timestamp")
+@pytest.mark.parametrize(
+    "data, role",
+    [(trust_data("tests/data/sample_timestamp.json"), "timestamp")],
+)
+def test_validate_trust_data_expiry_error(td, mock_schema_path, data: dict, role: str):
+    trust_data_ = td.TrustData(data, role)
     time = dt.datetime.now(pytz.utc) - dt.timedelta(hours=1)
     time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
     trust_data_.signed["expires"] = time.strftime(time_format)
@@ -343,6 +430,7 @@ def test_validate_trust_data_expiry_error(td, mock_schema_path):
         (trust_data("tests/data/sample_timestamp.json"), "timestamp", {}),
         (trust_data("tests/data/sample_targets.json"), "targets", targets_keys),
         (trust_data("tests/data/sample_releases.json"), "targets/releases", {}),
+        (trust_data("tests/data/sample5_root.json"), "root", root_keys_sample5),
     ],
 )
 def test_get_keys(td, mock_schema_path, data: dict, role: str, keys: dict):
@@ -397,6 +485,10 @@ def test_get_delegations(td, mock_schema_path, data: dict, out: list):
     [
         (trust_data("tests/data/sample_targets.json"), []),
         (trust_data("tests/data/sample2_targets.json"), ["hai"]),
+        (
+            trust_data("tests/data/sample3_targets.json"),
+            ["v1.0.9", "v1.0.9-slim-fat_image", "v382"],
+        ),
     ],
 )
 def test_get_tags(td, mock_schema_path, data: dict, out: list):
@@ -422,6 +514,11 @@ def test_get_tags(td, mock_schema_path, data: dict, out: list):
             "v2",
             "uKOFIodqniVQ1YLOUaHYfr3GxXDl5YXQhWC/1kb3+AQ=",
         ),
+        (
+            trust_data("tests/data/sample3_targets.json"),
+            "v1.0.9-slim-fat_image",
+            "VI55/vvzrpsAqPDn1nClK32rr5DYwz41SF7TsoFnGbQ=",
+        ),
     ],
 )
 def test_get_digest(td, mock_schema_path, data: dict, tag: str, digest: str):
@@ -434,3 +531,57 @@ def test_get_digest_error(td, mock_schema_path):
     with pytest.raises(NotFoundException) as err:
         _trust_data.get_digest("hurr")
     assert 'could not find digest for tag "hurr".' in str(err.value)
+
+
+# This test will fail in January 2023 due to the expiry date in the test data
+# TODO: Autogenerate test data with "up-to-date" expiry dates
+@pytest.mark.parametrize(
+    "data, role", [(trust_data("tests/data/sample_snapshot.json"), "snapshot")]
+)
+def test_validate(td, mock_schema_path, mock_keystore, data: dict, role: str):
+    ks = KeyStore()
+    _trust_data = td.TrustData(data, role)
+    _trust_data.validate(ks)
+
+
+@pytest.mark.parametrize(
+    "data, role",
+    [
+        (trust_data("tests/data/sample_timestamp.json"), "timestamp"),
+        (trust_data("tests/data/sample5_targets.json"), "targets"),
+    ],
+)
+def test_validate_for_expiry_error(
+    td, mock_schema_path, mock_keystore, data: dict, role: str
+):
+    ks = KeyStore()
+    _trust_data = td.TrustData(data, role)
+    with pytest.raises(ValidationError) as err:
+        _trust_data.validate(ks)
+    assert "trust data expired." in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "data, role", [(trust_data("tests/data/sample4_targets.json"), "targets")]
+)
+def test_validation_for_missing_key_error(
+    td, mock_schema_path, mock_keystore, data: dict, role: str
+):
+    ks = KeyStore()
+    _trust_data = td.TrustData(data, role)
+    with pytest.raises(NotFoundException) as err:
+        _trust_data.validate(ks)
+    assert "could not find key id" in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "data, role", [(trust_data("tests/data/sample3_targets.json"), "targets")]
+)
+def test_validation_for_signature_validation_error(
+    td, mock_schema_path, mock_keystore, data: dict, role: str
+):
+    ks = KeyStore()
+    _trust_data = td.TrustData(data, role)
+    with pytest.raises(ValidationError) as err:
+        _trust_data.validate(ks)
+    assert "failed to verify signature of trust data." in str(err.value)

--- a/connaisseur/trust_data.py
+++ b/connaisseur/trust_data.py
@@ -7,6 +7,7 @@ import pytz
 from dateutil import parser
 from jsonschema import validate as json_validate
 from jsonschema import ValidationError as JValidationError
+from jsonschema import FormatChecker as JFormatChecker
 from connaisseur.key_store import KeyStore
 from connaisseur.crypto import verify_signature
 from connaisseur.exceptions import NotFoundException, ValidationError, NoSuchClassError
@@ -57,7 +58,7 @@ class TrustData:
             schema = json.load(schema_file)
 
         try:
-            json_validate(instance=data, schema=schema)
+            json_validate(instance=data, schema=schema, format_checker=JFormatChecker())
         except JValidationError:
             raise ValidationError(
                 "trust data has invalid format.", {"trust_data_type": self.kind}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisser deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v0.4
+  image: securesystemsengineering/connaisseur:v1.1.3
   imagePullPolicy: Always
   resources: {}
   # limits:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask~=1.1.2
 requests~=2.24.0
+rfc3339-validator~=0.1.2
 pytest-cov~=2.10.0
 ecdsa~=0.15
 jsonschema~=3.2.0


### PR DESCRIPTION
The current schemas for trust data validation neither allow timezones with negative offsets nor tags containing dashes. This fixes both and adds additional tests.

Fix #10