### PR TITLE
docs: add and adjust external and mailto links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We are happy you made it here! If you want to raise any bugs you found, discuss 
 
 While issues are a great way to discuss problems, bugs and new features, a direct proposal via a pull request can sometimes say more than a thousand words. So be bold and contribute to the code as described in the [next section](#contribute-to-source-code)!
 
-In case you require a more private communication, you can reach us via [connaisseur@securesystems.de](mailto:connaisseur@securesystems.de).
+In case you require a more private communication, you can reach us via [connaisseur@securesystems.dev](mailto:connaisseur@securesystems.dev).
 
 ## Contribute to Source Code
 The following steps will help you make code contributions to Connaisseur and ensure good code quality and workflow. This includes the following steps:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In the last few years, deploying applications became increasingly easy, thanks t
 
 However, as one might have already guessed, this convenience has its drawbacks. The contents of an image are not always evident at a glance, and could include rather unwanted or even malicious components. This holds true for images from public registries, but also for self-built ones (from your pipelines). Obviously, there is a need for protecting one's images from malicious modifications, and luckily, there is!
 
-Enter *Docker Content Trust (DCT)*, a solution that offers a way to digitally sign images. It uses *Notary*, an implementation of *The Update Framework*, to store a manifest file linking the latest image digest with its tag, which then is signed with a private key. As the digest uniquely identifies an image with specific contents, this allows making a cryptographic guarantee about the integrity of an image based on its tag. DCT can be used on Docker Hub to sign images and overall offers a good experience with Docker. Sadly, it does not work with Kubernetes out of the box, even though Kubernetes uses Docker. Kubernetes is unaware whether the underlying Docker daemon has DCT enabled or not, and deploys any kind of images, regardless of their signature status.
+Enter [*Docker Content Trust (DCT)*](https://docs.docker.com/engine/security/trust/), a solution that offers a way to digitally sign images. It uses *Notary*, an implementation of *The Update Framework*, to store a manifest file linking the latest image digest with its tag, which then is signed with a private key. As the digest uniquely identifies an image with specific contents, this allows making a cryptographic guarantee about the integrity of an image based on its tag. DCT can be used on Docker Hub to sign images and overall offers a good experience with Docker. Sadly, it does not work with Kubernetes out of the box, even though Kubernetes uses Docker. Kubernetes is unaware whether the underlying Docker daemon has DCT enabled or not, and deploys any kind of images, regardless of their signature status.
 
 **Connaisseur** solves this problem by bringing image signature verification into Kubernetes. It uses the already existing Docker Content Trust solution and adds it to the cluster as a mutating admission controller. It pulls trust data from *Notary* and verifies it before any commitment to Kubernetes happens.
 
@@ -146,4 +146,4 @@ We hope to steer development of Connaisseur from demand of the community and are
 We are grateful for any community support reporting vulnerabilities! How to submit a report is described in our [Security Policy](SECURITY.md).
 
 ## Contact
-You can reach us via email under [connaisseur@securesystems.de](mailto:connaisseur@securesystems.de).
+You can reach us via email under [connaisseur@securesystems.dev](mailto:connaisseur@securesystems.dev).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ At the current stage of the project, we are not working with actual releases. Pl
 
 ## Reporting a Vulnerability
 
-We are very grateful for reports on vulnerabilities discovered in the project, specifically as it is intended to increase security for the community. We aim to investigate and fix these as soon as possible. Please submit vulnerabilities to [connaisseur@securesystems.de](mailto:connaisseur@securesystems.de).
+We are very grateful for reports on vulnerabilities discovered in the project, specifically as it is intended to increase security for the community. We aim to investigate and fix these as soon as possible. Please submit vulnerabilities to [connaisseur@securesystems.dev](mailto:connaisseur@securesystems.dev).


### PR DESCRIPTION
The reference to the external documentation of DCT has been added, since it is important for the underlying functionality. The mailto links for reaching out to the team were adjusted to use the .dev domain.