### PR TITLE
docs/feat: Allow and document integration with Azure Container Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE = $(IMAGE_NAME):$(TAG)
 IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v1.1.5
+TAG = v1.2.0
 
 .PHONY: all docker certs install unistall upgrade annihilate
 

--- a/connaisseur/notary_api.py
+++ b/connaisseur/notary_api.py
@@ -23,6 +23,12 @@ def health_check(host: str):
     if not host:
         return False
 
+    # The ACR does not expose the notary health endpoint: https://github.com/Azure/acr/issues/475
+    # As a consequence, Connaisseur Pods will not appear as unhealthy if they cannot connect to the ACR
+    # This behavior differs from behavior for all other notaries
+    if is_acr():
+        return True
+
     url = f"https://{host}/_notary_server/health"
 
     request_kwargs = {"url": url}
@@ -31,6 +37,14 @@ def health_check(host: str):
     response = requests.get(**request_kwargs)
 
     return response.status_code == 200
+
+
+def is_acr():
+    """
+    Checks whether the notary server should be considered to be the
+    Azure Container Registry (ACR).
+    """
+    return os.environ.get("IS_ACR", "0") == "1"
 
 
 def is_notary_selfsigned():
@@ -295,7 +309,10 @@ def get_auth_token(url: str):
     response.raise_for_status()
 
     try:
-        token = response.json()["token"]
+        if is_acr():
+            token = response.json()["access_token"]
+        else:
+            token = response.json()["token"]
     except KeyError:
         raise NotFoundException(
             "no token in authentication server response.", {"auth_url": url}

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -31,3 +31,6 @@ data:
   {{- if .Values.detection_mode }}
   DETECTION_MODE: "1"
   {{- end}}
+  {{- if .Values.notary.isAcr }}
+  IS_ACR: "1"
+  {{- end}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisser deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.1.5
+  image: securesystemsengineering/connaisseur:v1.2.0
   imagePullPolicy: Always
   resources: {}
   # limits:
@@ -45,6 +45,10 @@ notary:
   rootPubKey: |
     -----BEGIN PUBLIC KEY-----
     -----END PUBLIC KEY-----
+  # if you use Azure Container Registry (ACR) for your notary
+  # changes some behaviour, such as health probes and how to retrieve auth tokens
+  # for compatibility with ACR set to `true`
+  isAcr: false
 
 # the image policy, which defines all repositories that need to be
 # verified. more detail in the git repo README.md

--- a/setup/README.md
+++ b/setup/README.md
@@ -12,7 +12,7 @@ The guide below offers a simple default configuration for setting up Connaisseur
 
 Two further specialized guides exist:
 1. **Local setup ([Minikube](https://github.com/kubernetes/minikube) & [Harbor](https://github.com/goharbor/harbor))**: Connaisseur can be run completely locally with a minikube instance paired with a local Harbor installation that combines registry and notary servers. This setup is a bit more cumbersome since it does not use existing public infrastructure such as PKI. However, it is entirely based on open-source solutions, does not require continuous access to the internet and you control every part of the installation. This makes it specifically suited e.g. for security researchers and users interested in the inner workings of DCT and Connaisseur. Head over to [the respective README](local/README.md) to try it out.
-2. TODO: **[Azure Kubernetes Services](https://docs.microsoft.com/en-us/azure/aks/) with [Azure Container Registry (ACR)](https://docs.microsoft.com/en-us/azure/container-registry/)**: Microsoft Azure is currently the only one of the big cloud providers with a managed Kubernetes and container registry that supports DCT.
+2. **[Azure Kubernetes Services](https://docs.microsoft.com/en-us/azure/aks/) with [Azure Container Registry (ACR)](https://docs.microsoft.com/en-us/azure/container-registry/)**: Microsoft Azure is currently the only one of the big cloud providers with a managed Kubernetes and container registry that supports DCT. If you want to set up Connaisseur with ACR, head over to [the specialized setup guide](acr/README.md).
 
 
 ## Requirements
@@ -190,7 +190,7 @@ service/sample created
 Error from server: error when creating "STDIN": admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/testingconny/testimage:unsigned" in trust data.
 ```
 
-> Note that while the container is blocked Kubernetes still creates the service, because it does not reference an image and is thus not denied by Connaisseur. You can clean it up by calling `kubectl delete service sample`.
+> Note that while the container is blocked Kubernetes still creates the service, because it does not reference an image and is thus not denied by Connaisseur. You can clean it up by executing `kubectl delete service sample`.
 
 Finally, make sure that Connaisseur will deploy the signed image and isn't just rejecting all images:
 
@@ -242,6 +242,8 @@ This deployment should be accepted with
 deployment.apps/sample-deployment created
 service/sample created
 ```
+
+Your signed images were allowed through, in contrast to those unsigned ones with unknown content. DCT, not in a nutshell, but in Kubernetes!
 
 ### 2. Cleanup
 

--- a/setup/acr/README.md
+++ b/setup/acr/README.md
@@ -1,0 +1,68 @@
+# Connaisseur with AKS and ACR
+This guide will show you how to set up Connaisseur on your Azure Kubernetes Service (AKS) cluster using the Azure Container Registry (ACR) as both the registry and the notary.
+
+# Requirements
+
+For this tutorial, we assume you have a working AKS cluster and an ACR with [enabled Docker Content Trust](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-content-trust#enable-registry-content-trust).
+
+> This requires the `Premium` version of ACR. If you do not wish to use the ACR as either registry or notary, use the [general setup guide](../README.md).
+
+Your AKS cluster [should be authenticated to pull images from your ACR](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration) (you can also use pull secrets instead of integrating both components, in which case some commands of the general setup guide might need small adaptations). Your Azure Active Directory user will need the `AcrImageSigner` role assignment for the ACR, otherwise you will not be able to push signed images to it.
+
+Furthermore, we assume you have `az`, `docker`, `git`, `helm`, `jq`,  `kubectl` and `make` installed and ready to use in your CLI, i.e. you executed `az acr login`, `az aks get-credentials` and `kubectl use-context` to login to the ACR and switch to the appropriate Kubernetes context.
+
+> The tutorial was tested on a machine running Ubuntu 20.04, but since we're not doing much of anything client-side pretty much any other OS should work as well.
+
+# Setting up Connaisseur
+
+For the most part, this tutorial will be the same as [for a regular Kubernetes cluster](../README.md). However, the setup for ACR is a bit different from how it would usually be used. Interactions with the ACR usually happen via the CLI that has previously been authenticated with `az acr login --name YOUR-REGISTRY`. Currently, Connaisseur only support BasicAuth for connecting to a registry, so the default authentication schemes for both tools are incompatible. Hence, we need to work around this fact by providing a username/password combination to Connaisseur. Additionally, Connaisseur will have to workaround a few oddities of the APIs exposed by the ACR, since these are not quite the same as for all other notaries we've encountered so far.
+
+### 1. Get Connaisseur
+
+First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate:
+
+```bash
+# You can/have to change these values to match your environment
+REGISTRY_NAME=connyregistry
+REPOSITORY_NAME=test
+IMAGE_NAME=testimage
+
+REGISTRY_URL=$(echo "${REGISTRY_NAME}.azurecr.io")
+IMAGE_PATH=$(echo "${REGISTRY_URL}/${REPOSITORY_NAME}/${IMAGE_NAME}")
+NOTARY_URL=$(echo "${REGISTRY_NAME}.azurecr.io")
+
+git clone https://github.com/sse-secure-systems/connaisseur.git
+cd connaisseur
+```
+
+### 2. Configure specifcs for the ACR
+
+First we want to tell Connaisseur that the notary it connects to is the ACR. Unfortunately, the notary API exposed by ACR is slightly different from other notaries, so Connaisseur needs to know in order to adapt:
+
+```bash
+sed -i "s/isAcr: false/isAcr: true/" helm/values.yaml
+```
+
+The second specific change to be done when deploying Connaisseur in an environment with the ACR is to create a Service Principal (SP) that gives Connaisseur a username/password combination to retrieve an access token via BasicAuth:
+
+```bash
+# As above, you can change this to your liking
+CONNAISSEUR_SP_NAME=connaisseur-registry-sp
+
+# Retrieve the ID of your registry
+REGISTRY_ID=$(az acr show --name ${REGISTRY_NAME} | jq -r '.id')
+
+# Create a service principal with the Reader role on your registry
+SP_CREDENTIALS=$(az ad sp create-for-rbac --name "${CONNAISSEUR_SP_NAME}" --role Reader --scopes ${REGISTRY_ID})
+
+NOTARY_USER=$(echo ${SP_CREDENTIALS} | jq -r '.appId')
+NOTARY_PASSWORD=$(echo ${SP_CREDENTIALS} | jq -r '.password')
+```
+
+> If something goes wrong with the creation of the Service Principal, check that you actually have sufficient privileges to create a Service Principal.
+
+At this point, the adaptations specific to AKS and ACR are complete and you can continue with the [second step of the general Kubernetes guide](../README.md#2-set-up-docker-content-trust).
+
+Once finished setting up Connaisseur, you may be interested in how to use DCT with Azure Pipelines. Further information is provided by Azure, check out [their documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/containers/content-trust).
+
+Stay safe!

--- a/setup/signedapp.py
+++ b/setup/signedapp.py
@@ -3,10 +3,10 @@ from flask import Flask
 app = Flask(__name__)
 
 
-@app.route('/')
+@app.route("/")
 def hello_world():
-    return 'Welcome to the world of signed images!'
+    return "Welcome to the world of signed images!"
 
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+if __name__ == "__main__":
+    app.run(host="0.0.0.0")

--- a/setup/unsignedapp.py
+++ b/setup/unsignedapp.py
@@ -3,10 +3,10 @@ from flask import Flask
 app = Flask(__name__)
 
 
-@app.route('/')
+@app.route("/")
 def hello_world():
-    return 'Running images without integrity checks? I, too, like to live dangerously!'
+    return "Running images without integrity checks? I, too, like to live dangerously!"
 
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+if __name__ == "__main__":
+    app.run(host="0.0.0.0")


### PR DESCRIPTION
Since the Azure Container Registry has a slightly different API than other notaries, some Connaisseur internals had to be adapted. In addition, there's a guide to integrate the ACR starting differently than the general Kubernetes guide.