### PR TITLE
fix: Default to Docker Hub notary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE = $(IMAGE_NAME):$(TAG)
 IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v1.1.3
+TAG = v1.1.4
 POD = not-smooth-app
 
 .PHONY: all docker certs install unistall upgrade annihilate

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -9,7 +9,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- if .Values.notary.host }}
   NOTARY_SERVER: {{ .Values.notary.host }}
+  {{- else }}
+  NOTARY_SERVER: notary.docker.io
+  {{- end }}
   {{- if .Values.notary.selfsigned }}
   SELFSIGNED_NOTARY: "1"
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisser deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.1.3
+  image: securesystemsengineering/connaisseur:v1.1.4
   imagePullPolicy: Always
   resources: {}
   # limits:
@@ -21,8 +21,8 @@ service:
 
 # configure access to the notary server
 notary:
-  # domain to the notary server. can be `null`, to use the public docker hub
-  # notary server
+  # domain to the notary server. can be `null` or non-existant to use
+  # the public Docker Hub notary server
   host: notary.docker.io
   # only for insecure notary instances with selfsigned certificates.
   selfsigned: false


### PR DESCRIPTION
Previously we incorrectly stated that a notary host value of null would default to the Docker Hub notary. The actual behavior now matches the stated one.

Fix #13