### PR TITLE
feat: harden image and deploy with kubernetes security context

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,16 @@ FROM python:alpine
 
 WORKDIR /app
 
+# Harden image
+COPY docker/harden.sh /
+RUN sh /harden.sh && rm /harden.sh
+
 # Copy source code and install packages
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt
 COPY connaisseur /app/connaisseur
+
+USER 1000:2000
 
 LABEL maintainer="Philipp Belitz <philipp.belitz@securesystems.de>"
 

--- a/docker/harden.sh
+++ b/docker/harden.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -euo pipefail
+
+# Update packages and remove apk
+apk update --no-cache && apk upgrade --no-cache && apk del apk-tools --no-cache && rm -rf /var/cache/apk
+
+# Remove user accounts
+echo "" > /etc/group
+echo "" > /etc/passwd
+echo "" > /etc/shadow
+
+# Remove crons
+rm -fr /var/spool/cron
+rm -fr /etc/crontabs
+rm -fr /etc/periodic
+
+# Remove init scripts
+rm -fr /etc/init.d
+rm -fr /etc/conf.d
+rm -f /etc/inittab
+
+# Remove media stuff
+rm -f /etc/fstab
+rm -fr /media

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -19,6 +19,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "helm.name" . }}
         app.kubernetes.io/instance: {{ .Chart.Name }}
+      {{- /* This will be set automatically by Kubernetes 1.19 when using the securityContext.seccompProfile  */ -}}
+      {{- if lt (.Capabilities.KubeVersion.Minor | int) 19 }}
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+      {{- end }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-serviceaccount
       containers:
@@ -56,6 +61,20 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 2000
+            runAsNonRoot: true
+            runAsUser: 1000
+            {{- if gt (.Capabilities.KubeVersion.Minor | int) 18 }}
+            seccompProfile:
+              type: RuntimeDefault
+            {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The Connaisseur image is based on an alpine image, which has now been slightly hardened. Furthermore the deployment to Kubernetes is now being controlled by a SecurityContext that is a lot stricter than the default configuration. Also Pods now use the runtime's default seccomp profile instead of none.

Fix: #12