### PR TITLE
docs: use small caps for repo and image names

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -27,7 +27,7 @@ We assume you have a running Kubernetes cluster already. Since this tutorial wor
 
 ### 1. Set up environment
 
-First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate:
+First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate (ideally use lowercase letters for compatibility with Docker):
 
 ```bash
 IMAGE_PATH=docker.io/testingconny/testimage

--- a/setup/acr/README.md
+++ b/setup/acr/README.md
@@ -19,7 +19,7 @@ For the most part, this tutorial will be the same as [for a regular Kubernetes c
 
 ### 1. Get Connaisseur
 
-First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate:
+First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate (ideally use lowercase letters for compatibility with Docker):
 
 ```bash
 # You can/have to change these values to match your environment


### PR DESCRIPTION
Docker does not allow usage of capital letters in image names and repos. This seems to also cause problems with DCT.