### PR TITLE
docs: Move IMAGE_PATH variable to test section

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -27,11 +27,9 @@ We assume you have a running Kubernetes cluster already. Since this tutorial wor
 
 ### 1. Set up environment
 
-First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate (ideally use lowercase letters for compatibility with Docker):
+First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate:
 
 ```bash
-IMAGE_PATH=docker.io/testingconny/testimage
-
 NOTARY_URL=notary.docker.io
 NOTARY_USER=<YOUR-NOTARY-USERNAME/DOCKER-HUB-ID>
 NOTARY_PASSWORD=<YOUR-NOTARY-PASSWORD>
@@ -126,9 +124,11 @@ If you were just trusting everything someone told you, you wouldn't be here look
 
 ### 1. Deploy (un)signed images
 
-To test Connaisseur's capabilities go ahead and build both an unsigned and a signed image:
+To test Connaisseur's capabilities go ahead and build both an unsigned and a signed image. Below, substitute the `IMAGE_PATH` variable as appropriate:
 
 ```bash
+IMAGE_PATH=<YOUR-REGISTRY-USUALLY-docker.io>/<REPOSITORY-NAME-USUALLY-YOUR-DOCKER-HUB-ID>/testimage
+
 cd setup
 DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile.unsigned -t ${IMAGE_PATH}:unsigned .
 DOCKER_CONTENT_TRUST=0 docker push ${IMAGE_PATH}:unsigned

--- a/setup/acr/README.md
+++ b/setup/acr/README.md
@@ -19,16 +19,13 @@ For the most part, this tutorial will be the same as [for a regular Kubernetes c
 
 ### 1. Get Connaisseur
 
-First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate (ideally use lowercase letters for compatibility with Docker):
+First off, we'll export the variables used in this tutorial to allow you to immediately use your own names/URLs instead of relying on our default names. Below, substitute your own values as appropriate:
 
 ```bash
 # You can/have to change these values to match your environment
 REGISTRY_NAME=connyregistry
-REPOSITORY_NAME=test
-IMAGE_NAME=testimage
 
 REGISTRY_URL=$(echo "${REGISTRY_NAME}.azurecr.io")
-IMAGE_PATH=$(echo "${REGISTRY_URL}/${REPOSITORY_NAME}/${IMAGE_NAME}")
 NOTARY_URL=$(echo "${REGISTRY_NAME}.azurecr.io")
 
 git clone https://github.com/sse-secure-systems/connaisseur.git


### PR DESCRIPTION
Previously the IMAGE_PATH variable was defined inside the Connaisseur setup section although it was no longer used there. Its definition is now moved to the section dealing with testing Connaisseur.