### PR TITLE
ci/test: Add integration test

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -132,4 +132,39 @@ jobs:
         with:
            name: trivy-report
            path: trivy-report.json
-  
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: [bandit, safety, trivy]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+
+      - name: Build Connaisseur image
+        run: |
+          sed -i "s+TAG =.*+TAG = ${RELEASE_VERSION}+" Makefile
+          sed -i "s+IMAGE_NAME =.*+IMAGE_NAME = ${RELEASE_IMAGE}+" Makefile
+          make docker
+
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+
+      - name: Check KinD cluster
+        run: |
+          kubectl get nodes
+
+      - name: Add images to KinD
+        run: |
+          kind load docker-image ${RELEASE_IMAGE}:${RELEASE_VERSION}
+          kind load docker-image ${RELEASE_IMAGE}:helm-hook
+
+      - name: Run actual integration test
+        run: |
+          bash connaisseur/tests/integration/integration-test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,13 +68,14 @@ This helps identify bugs in changes before pushing.
 
 > :information_source: **INFO** We believe that testing should not only ensure functionality, but also aim to test for expected security issues like injections and appreciate if security tests are added with new functionalities.
 
-Besides the unit testing and before any PR can be merged, an integration test should be carried out whereby:
+Besides the unit testing and before any PR can be merged, an integration test is carried out whereby:
 - Connaisseur is successfully installed in a test cluster
 - a non-signed image is deployed to the cluster and denied
+- an image signed with an unrelated key is denied
 - a signed image is deployed to the cluster and passed
 - Connaisseur is successfully uninstalled
 
-We hope to automate these tests in the future and also provide a test script for local testing with minikube.
+You can also run this integration test on a local cluster after setting the necessary environment variables.
 
 ### Signed Commits and Pull Requests
 All changes to the `master` branch must be signed which is enforced via [branch protection](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-required-commit-signing). This can be achieved by only fast-forwarding signed commits or signing of merge commits by a contributor. Consequently, while we appreciate signed commits in PRs, we do not require it.

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ all: docker install
 
 docker:
 	docker build -f docker/Dockerfile -t $(IMAGE) .
+	docker build -f docker/Dockerfile.hook -t $(IMAGE_NAME):helm-hook .
 
 certs:
 	bash helm/certs/gen_certs.sh
@@ -21,11 +22,11 @@ install: certs
 uninstall:
 	kubectl config set-context --current --namespace $(NAMESPACE)
 	helm uninstall connaisseur
-	kubectl delete ns $(NAMESPACE)
+	kubectl delete ns $(NAMESPACE) --timeout=120s
 
 upgrade:
 	kubectl config set-context --current --namespace $(NAMESPACE)
 	helm upgrade connaisseur helm --wait
 
 annihilate:
-	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,imagepolicies -lapp.kubernetes.io/instance=connaisseur
+	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,configmaps,imagepolicies -lapp.kubernetes.io/instance=connaisseur

--- a/connaisseur/tests/integration/integration-test.sh
+++ b/connaisseur/tests/integration/integration-test.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+set -euo pipefail
+
+# This script is expected to be called from the root folder of Connaisseur
+
+if [[ -z "${RELEASE_IMAGE-}" ]] || [[ -z "${RELEASE_VERSION-}" ]]; then
+  echo "Missing environment variables."
+  exit 1
+fi
+
+echo 'Preparing Connaisseur config...'
+envsubst < connaisseur/tests/integration/update-config.yaml > update
+yq write --inplace --script update helm/values.yaml # Coincidentally, this also ensure all used env variables are set
+rm update
+echo 'Config set'
+
+echo 'Installing Connaisseur...'
+make install || { echo 'Failed to install Connaisseur'; exit 1; }
+echo 'Successfully installed Connaisseur'
+
+echo 'Testing unsigned image...'
+kubectl run pod --image=connytest/testimage:unsigned >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/connytest/testimage:unsigned" in trust data.' ]]; then
+  echo 'Failed to deny unsigned image or failed with unexpected error. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied usage of unsigned image'
+fi
+
+echo 'Testing image signed under different key...'
+kubectl run pod --image=securesystemsengineering/connaisseur:signed >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: failed to verify signature of trust data.' ]]; then
+  echo 'Failed to deny image signed different key or failed with unexpected error. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied usage of image signed under different key'
+fi
+
+echo 'Testing signed image...'
+kubectl run pod --image=connytest/testimage:signed >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
+  echo 'Failed to allow signed image. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully allowed usage of signed image'
+fi
+
+echo 'Uninstalling Connaisseur...'
+make uninstall || { echo 'Failed to uninstall Connaisseur'; exit 1; }
+echo 'Successfully uninstalled Connaisseur'
+
+rm output.log
+echo 'Passed integration test'

--- a/connaisseur/tests/integration/update-config.yaml
+++ b/connaisseur/tests/integration/update-config.yaml
@@ -1,0 +1,34 @@
+---
+    - command: update
+      path: deployment.imagePullPolicy
+      value: Never
+    - command: update
+      path: deployment.image
+      value: ${RELEASE_IMAGE}:${RELEASE_VERSION}
+    - command: update
+      path: notary.host
+      value: notary.docker.io
+    - command: update
+      path: notary.selfsigned
+      value: false
+    - command: update
+      path: notary.auth.enabled
+      value: false
+    - command: update
+      path: notary.rootPubKey
+      value: |
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETBDLAICCabJQXB01DOy315nDm0aD
+          BREZ4aWG+uphuFrZWw0uAVLW9B/AIcJkHa7xQ/NLtrDi3Ou5dENzDy+Lkg==
+          -----END PUBLIC KEY-----
+    - command: update
+      path: policy
+      value:
+        - pattern: "*:*"
+          verify: true
+        - pattern: "k8s.gcr.io/*:*"
+          verify: false
+        - pattern: "docker.io/securesystemsengineering/connaisseur:*"
+          verify: true
+        - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook"
+          verify: false


### PR DESCRIPTION
Add integration test with KinD cluster in Github Actions. Tests building of docker images, installing Connaisseur, rejecting unsigned image, rejecting image signed under different key, accepting signed image and uninstallation.

Fix #25