### PR TITLE
 ci/docs: Release concept for Connaisseur image and release check on new tagged commit on master branch

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -7,10 +7,7 @@ on:
   pull_request:
     branches:
       - master
-
-env:
-  RELEASE_VERSION: v1.3.1
-  RELEASE_IMAGE: securesystemsengineering/connaisseur
+      - develop
 
 jobs:
   black:
@@ -149,10 +146,7 @@ jobs:
           sudo apt install bash -y
 
       - name: Build Connaisseur image
-        run: |
-          sed -i "s+TAG =.*+TAG = ${RELEASE_VERSION}+" Makefile
-          sed -i "s+IMAGE_NAME =.*+IMAGE_NAME = ${RELEASE_IMAGE}+" Makefile
-          make docker
+        run: make docker
 
       - name: Create KinD cluster
         run: |
@@ -160,14 +154,12 @@ jobs:
           kind create cluster --wait 120s
 
       - name: Check KinD cluster
-        run: |
-          kubectl get nodes
+        run: kubectl get nodes
 
       - name: Add images to KinD
         run: |
-          kind load docker-image ${RELEASE_IMAGE}:${RELEASE_VERSION}
-          kind load docker-image ${RELEASE_IMAGE}:helm-hook
+          kind load docker-image $(yq r helm/values.yaml 'deployment.image')
+          kind load docker-image $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
 
       - name: Run actual integration test
-        run: |
-          bash connaisseur/tests/integration/integration-test.sh
+        run: bash connaisseur/tests/integration/integration-test.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  push:
+    tags: "*"
+    branches: master
+
+jobs:
+  version-match:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Ensure version equality
+        run: |
+          if [[ "$(echo $GITHUB_REF | sed s+refs/tags/++)" == "" ]] \
+          || [[ "$(echo $GITHUB_REF | sed s+refs/tags/++)" != "$(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f2)" ]]
+            then exit 1
+          fi
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: [version-match]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+
+      - name: Pull Connaisseur images
+        run: |
+          DOCKER_CONTENT_TRUST=1 docker pull $(yq r helm/values.yaml 'deployment.image')
+          DOCKER_CONTENT_TRUST=1 docker pull $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
+
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+
+      - name: Check KinD cluster
+        run: kubectl get nodes
+
+      - name: Add images to KinD
+        run: |
+          kind load docker-image $(yq r helm/values.yaml 'deployment.image')
+          kind load docker-image $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
+
+      - name: Run actual integration test
+        run: bash connaisseur/tests/integration/integration-test.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 NAMESPACE = connaisseur
-IMAGE = $(IMAGE_NAME):$(TAG)
-IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v1.4.0
+IMAGE := $(shell yq r helm/values.yaml 'deployment.image')
+IMAGE_NAME := $(shell echo $(IMAGE) | cut -d ':' -f1)
 
 .PHONY: all docker certs install unistall upgrade annihilate
 

--- a/adr/ADR-2_release-management.md
+++ b/adr/ADR-2_release-management.md
@@ -1,0 +1,64 @@
+# ADR 2: Release Management
+
+## Status
+
+Proposed
+
+## Context
+
+During its initial development Connaisseur was more or less maintained by a single person and not released frequently. Hence, the easiest option was to just have the maintainer build and push at certain stages of development. With the influx of more team members, the number of contributions and hence the number of needed/reasonable releases went up. Also since publication, it is more important that the uploaded Connaisseur image corresponds to the most recent version referenced in the Helm chart.
+
+A single person having to build, sign and push the images whenever a new pull request is accepted is hence unpractical for both development and agility.
+
+## Considered options
+
+### Choice 1
+
+What branches to maintain
+
+#### Option 1
+
+Continue with PRs from personal feature branches to `master`.
+
+#### Option 2
+
+Have a development branch against which to create pull requests (during usual development, hotfixes may be different).
+
+Sub-options:
+- a `develop` (or similar) branch that will exist continuously
+- a `v.1.5.0_dev` (or similar) branch for each respective version
+
+### Choice 2
+
+Where to sign the images
+
+#### Option 1
+
+Have the pipeline build, sign and push the images.
+
+#### Option 2
+
+Have a maintainer build, sign and push the images.
+
+## Decision outcome
+
+For choice 1, we decided to go for two branches. On the one hand, `master` being the branch that contains the code of the latest release and will be tagged with release versions. On the other hand, there will be a `develop` branch that hosts the current state of development and will be merged to `master` whenever we want to create a new release.
+
+This way we get rid of the current pain of releasing with every pull request at the cost a some overhead during release.
+
+In the process of automating most of the release process, we will run an integration test with locally built images for pull requests to `master`. Regarding choice 2, whenever a pull request is merged, whoever merged the PR has to tag this commit on the `master` branch with the most recent version. Right after the merge, whoever merged the PR builds, signs and pushes the new Connaisseur release and creates a tag on the `master` branch referencing the new release version.
+
+After the image is pushed and the new commit tagged, the pipeline will run the integration test with the image pulled from Docker Hub to ensure that the released version is working.
+
+We decided for this option as it does not expose credentials to Github Actions, which we wanted to avoid especially in light of the [recent Github Actions injection attacks](https://bugs.chromium.org/p/project-zero/issues/detail?id=2070) and as it would also prevent us from opening up the repository to Pull Requests. To alleviate the work required for doing the steps outside the pipeline we use a shell script that will automate these steps given suitable environment, i.e. Docker context and DCT keys.
+
+### Positive Consequences
+
+- We can develop without having to ship changes immediatly.
+- Release process does not expose credentials to Github Actions.
+- Code gets git tags.
+
+### Negative Consequences
+
+- Process from code to release for a single change is more cumbersome than right now.
+- Release still requires human intervention.

--- a/connaisseur/tests/integration/integration-test.sh
+++ b/connaisseur/tests/integration/integration-test.sh
@@ -3,12 +3,8 @@ set -euo pipefail
 
 # This script is expected to be called from the root folder of Connaisseur
 
-if [[ -z "${RELEASE_IMAGE-}" ]] || [[ -z "${RELEASE_VERSION-}" ]]; then
-  echo "Missing environment variables."
-  exit 1
-fi
-
 echo 'Preparing Connaisseur config...'
+export RELEASE_IMAGE=$(yq r helm/values.yaml 'deployment.image')
 envsubst < connaisseur/tests/integration/update-config.yaml > update
 yq write --inplace --script update helm/values.yaml # Coincidentally, this also ensure all used env variables are set
 rm update

--- a/connaisseur/tests/integration/update-config.yaml
+++ b/connaisseur/tests/integration/update-config.yaml
@@ -4,7 +4,7 @@
       value: Never
     - command: update
       path: deployment.image
-      value: ${RELEASE_IMAGE}:${RELEASE_VERSION}
+      value: ${RELEASE_IMAGE}
     - command: update
       path: notary.host
       value: notary.docker.io

--- a/setup/README.md
+++ b/setup/README.md
@@ -38,6 +38,8 @@ git clone https://github.com/sse-secure-systems/connaisseur.git
 cd connaisseur
 ```
 
+> The default of what you will install when following this guide will always be the latest release of Connaisseur. If you want to run Connaisseur with the most recent changes that haven't yet made it into a release, you will have to [build an image yourself](../CONTRIBUTING.md#setup-the-environment) with `make docker`.
+
 ### 2. Set up Docker Content Trust
 
 If you already have a root key configured on your system, you can skip this step (you can check whether there is already a root key file with `grep -iRl "role: root$" ~/.docker/trust/`).


### PR DESCRIPTION
Previously we had no automatic releases. Now a delegation key is used to sign the images, which will subsequently be pushed to the repository with a technical user. Images will be released for each new tag on the master branch. It is ensured that the tag matches the versions defined in both the Makefile and the helm deployment.

TODO:
- [x] Add real integration test to release pipeline
- [ ] Agree on way forward
- [ ] Set delegation key
- [ ] Complete test

Discussion:
Idea is to have a PR to master that increments version number. After merge, one needs to `git tag` the new master commit and push the tag. Then the release pipeline would run
In my mind the PR would be dedicated and only increment the version and add to a Changelog.md

Are you fine with releasing this way? Do we want to do something different? Do you see potential problems / areas to improve?