### PR TITLE
feat: Allow configuration of bootstrap sentinel timeout and increase default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE = $(IMAGE_NAME):$(TAG)
 IMAGE_NAME = securesystemsengineering/connaisseur
-TAG = v1.3.1
+TAG = v1.4.0
 
 .PHONY: all docker certs install unistall upgrade annihilate
 

--- a/helm/templates/bootstrap-sentinel.yaml
+++ b/helm/templates/bootstrap-sentinel.yaml
@@ -13,5 +13,5 @@ spec:
   - name: {{ .Chart.Name }}
     image: busybox
     imagePullPolicy: Always
-    command: ['sh', '-c', 'sleep 30s']
+    command: ['sh', '-c', 'sleep {{ .Values.deployment.sentinelTimeout | int | default 60 }}s']
   restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.3.1
+  image: securesystemsengineering/connaisseur:v1.4.0
   imagePullPolicy: Always
   resources: {}
   # limits:
@@ -13,6 +13,9 @@ deployment:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # bootstrap sentinel timeout in seconds
+  # deployment will fail if Connaisseur pods do not report ready within this timeframe
+  sentinelTimeout: 60
 
 # configure connaisseur service
 service:

--- a/setup/README.md
+++ b/setup/README.md
@@ -168,6 +168,8 @@ TEST SUITE: None
 
 Connaisseur was successfully deployed.
 
+> If `make install` fails and your Kubernetes cluster has low network bandwidth, it may be the case that the [Connaisseur Bootstrap Sentinel](../adr/ADR-1_connaisseur-bootstrap-sentinel.md) times out before Connaisseur's image has been pulled. You might want to consider increasing the `.deployment.sentinelTimeout` value in your `helm/values.yaml`.
+
 ## Test Connaisseur (optional)
 
 If you were just trusting everything someone told you, you wouldn't be here looking for a tool that ensures image integrity, so don't take our word for Connaisseur working. Go ahead and try it:


### PR DESCRIPTION
Previously Connaisseur's bootstrap sentinel had a fixed timeout of 30s, which could cause problems on clusters with low bandwidth the first time they pull the Connaisseur image. This PR allows configuration of the timeout and increases its default value to 60s.

Fix #46