### PR TITLE
fix: validate images of initContainers

### DIFF
--- a/connaisseur/mutate.py
+++ b/connaisseur/mutate.py
@@ -26,11 +26,15 @@ def get_container_specs(request_object: dict):
     """
     object_kind = request_object["kind"]
     if object_kind == "Pod":
-        return request_object["spec"]["containers"]
+        relevant_spec = request_object["spec"]
+        init_containers = relevant_spec.get("initContainers", [])
+        return relevant_spec["containers"] + init_containers
     elif object_kind == "CronJob":
-        return request_object["spec"]["jobTemplate"]["spec"]["template"]["spec"][
-            "containers"
+        relevant_spec = request_object["spec"]["jobTemplate"]["spec"]["template"][
+            "spec"
         ]
+        init_containers = relevant_spec.get("initContainers", [])
+        return relevant_spec["containers"] + init_containers
     elif object_kind in (
         "Deployment",
         "ReplicationController",
@@ -39,7 +43,9 @@ def get_container_specs(request_object: dict):
         "StatefulSet",
         "Job",
     ):
-        return request_object["spec"]["template"]["spec"]["containers"]
+        relevant_spec = request_object["spec"]["template"]["spec"]
+        init_containers = relevant_spec.get("initContainers", [])
+        return relevant_spec["containers"] + init_containers
 
 
 def get_json_patch(object_kind: str, index: int, image_name: str):

--- a/connaisseur/tests/integration/integration-test.sh
+++ b/connaisseur/tests/integration/integration-test.sh
@@ -51,6 +51,17 @@ else
   echo 'Successfully allowed usage of signed image'
 fi
 
+echo 'Testing deployment of unsigned init container along with a valid container...'
+kubectl apply -f connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: error when creating "connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml": admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/connytest/testimage:unsigned" in trust data.' ]]; then
+  echo 'Allowed an unsigned image via init container or failed due to an unexpected error handling init containers. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied unsigned image in init container'
+fi
+
 echo 'Uninstalling Connaisseur...'
 make uninstall || { echo 'Failed to uninstall Connaisseur'; exit 1; }
 echo 'Successfully uninstalled Connaisseur'

--- a/connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml
+++ b/connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: connaisseur-integration-test-pod
+  namespace: default
+spec:
+  containers:
+  - name: valid_container
+    image: connytest/testimage:signed
+    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+  initContainers:
+  - name: unsigned_init_container
+    image: connytest/testimage:unsigned
+    command: ['sh', '-c', 'sleep 5']

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -18,6 +18,22 @@ request_obj_pod = {
         ]
     },
 }
+request_obj_pod_with_init_container = {
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {},
+    "spec": {
+        "containers": [
+            {"name": "test-connaisseur", "image": "phbelitz/charlie-image:test"}
+        ],
+        "initContainers": [
+            {
+                "name": "init-container",
+                "image": "docker.io/abreust/testing_conny:unsigned",
+            }
+        ],
+    },
+}
 request_obj_cronjob = {
     "apiVersion": "batch/v1beta1",
     "kind": "CronJob",
@@ -40,6 +56,35 @@ request_obj_cronjob = {
         },
     },
 }
+request_obj_cronjob_with_init_container = {
+    "apiVersion": "batch/v1beta1",
+    "kind": "CronJob",
+    "metadata": {},
+    "spec": {
+        "schedule": "*/1 * * * *",
+        "jobTemplate": {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "test-connaisseur",
+                                "image": "phbelitz/charlie-image:test",
+                            }
+                        ],
+                        "initContainers": [
+                            {
+                                "name": "init-container",
+                                "image": "docker.io/abreust/testing_conny:unsigned",
+                            }
+                        ],
+                    }
+                }
+            }
+        },
+    },
+}
+
 request_obj_deployment = {
     "kind": "Deployment",
     "apiVersion": "apps/v1",
@@ -58,8 +103,45 @@ request_obj_deployment = {
         }
     },
 }
+request_obj_deployment_with_two_init_containers = {
+    "kind": "Deployment",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "phbelitz/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/abreust/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/abreust/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
 request_obj_output = [
     {"name": "test-connaisseur", "image": "phbelitz/charlie-image:test"}
+]
+request_obj_output_with_init_container = [
+    {"name": "test-connaisseur", "image": "phbelitz/charlie-image:test"},
+    {"name": "init-container", "image": "docker.io/abreust/testing_conny:unsigned"},
+]
+request_obj_output_with_two_init_containers = [
+    {"name": "test-connaisseur", "image": "phbelitz/charlie-image:test"},
+    {"name": "init-container", "image": "docker.io/abreust/testing_conny:unsigned"},
+    {"name": "init-container2", "image": "docker.io/abreust/testing_conny:signed"},
 ]
 patch_pod = {
     "op": "replace",
@@ -236,6 +318,15 @@ def get_ad_request(path: str):
         (request_obj_pod, request_obj_output),
         (request_obj_cronjob, request_obj_output),
         (request_obj_deployment, request_obj_output),
+        (request_obj_pod_with_init_container, request_obj_output_with_init_container),
+        (
+            request_obj_cronjob_with_init_container,
+            request_obj_output_with_init_container,
+        ),
+        (
+            request_obj_deployment_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
     ],
 )
 def test_get_container_specs(mutate, request_obj: dict, output: dict):

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,4 +1,4 @@
-# configure connaisser deployment
+# configure connaisseur deployment
 deployment:
   replicasCount: 3
   image: securesystemsengineering/connaisseur:v1.3.0


### PR DESCRIPTION
Currently, Connaisseur only validates the images referenced 'containers'. This adds validation for images referenced in 'initContainers'.