### PR TITLE
ci: Add check for formatting

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -13,6 +13,27 @@ env:
   RELEASE_IMAGE: securesystemsengineering/connaisseur
 
 jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install black
+        run: |
+          pip3 install setuptools wheel
+          pip3 install black
+      - name: Verify formatting
+        run: |
+          python3 -m black . 2>&1 | grep -q "reformatted" && { echo 'Not properly formatted.'; exit 1; } || true
+
+  hadolint:
+    runs-on: ubuntu-latest
+    container:
+      image: hadolint/hadolint:latest-debian
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint
+        run: hadolint docker/Dockerfile
+
   pylint:
     runs-on: ubuntu-latest
     container:
@@ -24,20 +45,11 @@ jobs:
       - name: Lint
         run: cd connaisseur && pylint --ignore-patterns=tests,coverage *.*
 
-  hadolint:
-    runs-on: ubuntu-latest
-    container:
-      image: hadolint/hadolint:latest-debian
-    steps:
-      - uses: actions/checkout@v2
-      - name: Lint
-        run: hadolint docker/Dockerfile
-
   pytest:
     runs-on: ubuntu-latest
     container:
       image: python:slim
-    needs: [pylint, hadolint]
+    needs: [black,hadolint,pylint]
     steps:
       - uses: actions/checkout@v2
       - name: Install packages

--- a/connaisseur/tests/test_notary_api.py
+++ b/connaisseur/tests/test_notary_api.py
@@ -381,11 +381,12 @@ def test_parse_auth_error(napi, header: str, error: str):
         napi.parse_auth(header)
     assert error in str(err.value)
 
+
 @pytest.mark.parametrize(
     "user, password, out",
     [
         (None, None, "no.BA.no"),
-        (None, 'password123', "no.BA.no"),
+        (None, "password123", "no.BA.no"),
         ("myname", "password456", "BA.myname.password456a"),
         ("myname", None, "BA.myname.a"),
     ],


### PR DESCRIPTION
Previously, we claimed to want to format code with black prior to pushing. However, we regularly introduced code that was not formatted properly. This introduces a CI check to ensure pipeline failure if autoformatting would change the code.