### PR TITLE
ci: add build step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# ignore Markdown files
+*.md
+# ignore tests
+connaisseur/tests/
+# ignore img
+img/

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           name: images
           path: images
+          retention-days: 1
 
   black:
     runs-on: ubuntu-latest
@@ -56,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
-        run: pip3 install -r requirements.txt
+        run: pip3 install -r requirements_dev.txt
       - name: Lint
         run: cd connaisseur && pylint --ignore-patterns=tests,coverage *.*
 
@@ -68,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
-        run: pip3 install -r requirements.txt && pip3 install .
+        run: pip3 install -r requirements_dev.txt && pip3 install .
       - name: Test
         run: cd connaisseur && pytest --cov=connaisseur --cov-report=xml tests/
       - name: Upload code coverage
@@ -104,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
-        run: pip3 install -r requirements.txt
+        run: pip3 install -r requirements_dev.txt
       - name: Freeze packages
         run: pip3 freeze > actual_package_versions.txt
       - name: Install safety

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -10,6 +10,24 @@ on:
       - develop
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install yq
+        run: sudo snap install yq
+      - name: Build images
+        run: make docker
+      - name: Save images
+        run: |
+          mkdir images
+          docker save $(yq r helm/values.yaml 'deployment.image') -o images/${GITHUB_SHA}_image.tar
+          docker save $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook -o images/${GITHUB_SHA}_hook.tar
+      - uses: actions/upload-artifact@v2
+        with:
+          name: images
+          path: images
+
   black:
     runs-on: ubuntu-latest
     steps:
@@ -53,10 +71,6 @@ jobs:
         run: pip3 install -r requirements.txt && pip3 install .
       - name: Test
         run: cd connaisseur && pytest --cov=connaisseur --cov-report=xml tests/
-      - name: Install curl
-        run: |
-          apt update
-          apt install -y curl
       - name: Upload code coverage
         uses: codecov/codecov-action@v1
         with:
@@ -110,56 +124,65 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker:stable
-    needs: [pytest]
+    needs: [build]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
       - name: Install trivy
         run: |
           apk update
           apk add curl
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
-      - name: Build image
-        run: docker build -t $GITHUB_SHA -f docker/Dockerfile .
-      - name: Save image
-        run: docker save $GITHUB_SHA -o $GITHUB_SHA.tar
-      - name: Scan
-        run: trivy image --input $GITHUB_SHA.tar -o trivy-report.txt --exit-code 1 --severity="UNKNOWN,MEDIUM,HIGH,CRITICAL"
-      - name: Print report
+          mkdir trivy-reports
+      - name: Scan Image
+        run: trivy image --input ${GITHUB_SHA}_image.tar
+                -o trivy-reports/image.txt
+                --exit-code 1
+                --severity="UNKNOWN,MEDIUM,HIGH,CRITICAL"
+      - name: Scan Hook
+        run: trivy image --input ${GITHUB_SHA}_hook.tar 
+                -o trivy-reports/hook.txt
+                --exit-code 1
+                --severity="UNKNOWN,MEDIUM,HIGH,CRITICAL"
+      - name: Print reports
         if: ${{ success() || failure() }}
-        run: cat trivy-report.txt
+        run: |
+          cat trivy-reports/image.txt
+          cat trivy-reports/hook.txt
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-           name: trivy-report
-           path: trivy-report.txt
+           name: trivy-reports
+           path: trivy-reports
 
   integration-test:
     runs-on: ubuntu-latest
-    needs: [bandit, safety, trivy]
+    needs: [build]
     steps:
       - uses: actions/checkout@v2
-
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
+      - name: Load Docker images
+        run: |
+          docker load -i ${GITHUB_SHA}_image.tar
+          docker load -i ${GITHUB_SHA}_hook.tar
       - name: Install yq and bash
         run: |
           sudo snap install yq
           sudo apt update
           sudo apt install bash -y
-
-      - name: Build Connaisseur image
-        run: make docker
-
       - name: Create KinD cluster
         run: |
           GO111MODULE="on" go get sigs.k8s.io/kind
           kind create cluster --wait 120s
-
       - name: Check KinD cluster
         run: kubectl get nodes
-
       - name: Add images to KinD
         run: |
           kind load docker-image $(yq r helm/values.yaml 'deployment.image')
           kind load docker-image $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
-
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/integration-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ testing-env/aks/k8s/deployment.yaml
 samples/*
 demo/
 tls-*.conf
+.venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Changes can also be tested locally. We recommend the following approach for runn
 ```
 docker run -it --rm -v <path-to-repository>:/data --entrypoint=ash python:alpine
 cd data
-pip3 install -r requirements.txt
+pip3 install -r requirements_dev.txt
 pip3 install .
 cd connaisseur
 pytest --cov=connaisseur --cov-report=xml tests/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,15 @@
-FROM python:alpine
+FROM python:alpine as base
+
+# build dependencies
+FROM base as builder
+
+RUN mkdir /install
+WORKDIR /install
+COPY requirements.txt /requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r /requirements.txt
+
+# build connaisseur image
+FROM base
 
 WORKDIR /app
 
@@ -7,8 +18,7 @@ COPY docker/harden.sh /
 RUN sh /harden.sh && rm /harden.sh
 
 # Copy source code and install packages
-COPY requirements.txt /app/
-RUN pip install --no-cache-dir -r requirements.txt
+COPY --from=builder /install /usr/local
 COPY connaisseur /app/connaisseur
 
 USER 1000:2000

--- a/docker/Dockerfile.hook
+++ b/docker/Dockerfile.hook
@@ -3,7 +3,12 @@ FROM alpine:3
 RUN apk add --no-cache curl && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin/kubectl
+    mv ./kubectl /usr/local/bin/kubectl && \
+    apk del curl
+
+# Harden image
+COPY docker/harden.sh /
+RUN sh /harden.sh && rm /harden.sh
 
 COPY scripts/helm_hook.sh /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 Flask~=1.1.2
 requests~=2.24.0
 rfc3339-validator~=0.1.2
-pytest-cov~=2.10.0
 ecdsa~=0.15
 jsonschema~=3.2.0
-pytz~=2020.1
 parsedatetime~=2.6
+pytz~=2020.1
 python-dateutil~=2.8.1
-pylint~=2.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest-cov~=2.10.0
+parsedatetime~=2.6
+pylint~=2.5.3


### PR DESCRIPTION
Originally, the Connaisseur docker image is built in multiple later steps of the pipeline. This causes code duplication, maintenance increase, unintuitive failing and unnecessary ci run time.

Fixes #54