### PR TITLE
fix: Add output during installation and increase sentinel timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,14 @@ certs:
 install: certs
 	kubectl create ns $(NAMESPACE) || true
 	kubectl config set-context --current --namespace $(NAMESPACE)
-	helm install connaisseur helm --wait
+	#
+	#=============================================
+	#
+	# The installation may last up to 5 minutes.
+	#
+	#=============================================
+	#
+	helm install connaisseur helm --atomic
 
 uninstall:
 	kubectl config set-context --current --namespace $(NAMESPACE)

--- a/adr/ADR-1_connaisseur-bootstrap-sentinel.md
+++ b/adr/ADR-1_connaisseur-bootstrap-sentinel.md
@@ -14,7 +14,7 @@ In [#3](https://github.com/sse-secure-systems/connaisseur/issues/3) it was noted
 
 ### Option 1
 
-At the start of the Helm deployment, one can create a Pod named `connaisseur-bootstrap-sentinel` that will run for 30 seconds (default). Connaisseur Pods will report `Ready` if they can 1) access notary AND ( 2) the MutatingWebhookConfiguration exists OR 3) the `connaisseur-bootstrap-sentinel` Pod is still running ).
+At the start of the Helm deployment, one can create a Pod named `connaisseur-bootstrap-sentinel` that will run for 5 minutes (which is also the installation timeout by helm). Connaisseur Pods will report `Ready` if they can 1) access notary AND 2) the MutatingWebhookConfiguration exists OR 3) the `connaisseur-bootstrap-sentinel` Pod is still running. If 1)  AND 2) both hold true, the sentinel is killed even if the 5 minutes have not passed yet.
 
 ### Option 2
 
@@ -34,4 +34,4 @@ If the Connaisseur Pods report `Ready` during the `connaisseur-bootstrap-sentine
 
 ### Negative Consequences
 
-On the other hand, if an adversary can deploy a Pod named `connaisseur-bootstrap-sentinel` to Connaisseur's Namespace, the Connaisseur Pods will always show `Ready` regardless of the MutatingWebhookConfiguration. However, if an adversary can deploy to Connaisseur's Namespace, chances are Connaisseur can be compromised anyways. More importantly, if not a single Connaisseur Pod is successfully deployed or if the notary healthcheck fails during the initial period of 30 seconds, then the deployment will fail regardless of possible recovery at a later time. Another issue would be the `connaisseur-bootstrap-sentinel` Pod being left behind, however since it has a very limited use-case we can also clean it up during the deployment, so apart from the minimal additional complexity of the deployment this is a non-issue.
+On the other hand, if an adversary can deploy a Pod named `connaisseur-bootstrap-sentinel` to Connaisseur's Namespace, the Connaisseur Pods will always show `Ready` regardless of the MutatingWebhookConfiguration. However, if an adversary can deploy to Connaisseur's Namespace, chances are Connaisseur can be compromised anyways. More importantly, if not a single Connaisseur Pod is successfully deployed or if the notary healthcheck fails during the sentinel's lifetime, then the deployment will fail regardless of possible recovery at a later time. Another issue would be the `connaisseur-bootstrap-sentinel` Pod being left behind, however since it has a very limited use-case we can also clean it up during the deployment, so apart from the minimal additional complexity of the deployment this is a non-issue.

--- a/helm/templates/bootstrap-sentinel.yaml
+++ b/helm/templates/bootstrap-sentinel.yaml
@@ -13,5 +13,5 @@ spec:
   - name: {{ .Chart.Name }}
     image: busybox
     imagePullPolicy: Always
-    command: ['sh', '-c', 'sleep {{ .Values.deployment.sentinelTimeout | int | default 60 }}s']
+    command: ['sh', '-c', 'sleep 300s']
   restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.3
+  image: securesystemsengineering/connaisseur:v1.4.4
   imagePullPolicy: Always
   resources: {}
   # limits:
@@ -13,9 +13,6 @@ deployment:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # bootstrap sentinel timeout in seconds
-  # deployment will fail if Connaisseur pods do not report ready within this timeframe
-  sentinelTimeout: 60
 
 # configure connaisseur service
 service:

--- a/setup/README.md
+++ b/setup/README.md
@@ -166,8 +166,6 @@ TEST SUITE: None
 
 Connaisseur was successfully deployed.
 
-> If `make install` fails and your Kubernetes cluster has low network bandwidth, it may be the case that the [Connaisseur Bootstrap Sentinel](../adr/ADR-1_connaisseur-bootstrap-sentinel.md) times out before Connaisseur's image has been pulled. You might want to consider increasing the `.deployment.sentinelTimeout` value in your `helm/values.yaml`.
-
 ## Test Connaisseur (optional)
 
 If you were just trusting everything someone told you, you wouldn't be here looking for a tool that ensures image integrity, so don't take our word for Connaisseur working. Go ahead and try it:


### PR DESCRIPTION
Currently, 'helm install' does not only not reveal much information about the progress but also does not  proceed anymore as soon as the sentinel has completed. Thus, in case the sentinel times out without connaisseur being ready, the last 4 minutes waiting for the helm timeout are wasted.