### PR TITLE
build: Added versioning to helm-hook-image

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           mkdir images
           docker save $(yq r helm/values.yaml 'deployment.image') -o images/${GITHUB_SHA}_image.tar
-          docker save $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook -o images/${GITHUB_SHA}_hook.tar
+          docker save $(yq r helm/values.yaml 'deployment.helmHookImage') -o images/${GITHUB_SHA}_hook.tar
       - uses: actions/upload-artifact@v2
         with:
           name: images
@@ -184,6 +184,7 @@ jobs:
       - name: Add images to KinD
         run: |
           kind load docker-image $(yq r helm/values.yaml 'deployment.image')
-          kind load docker-image $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
+          kind load docker-image $(yq r helm/values.yaml 'deployment.helmHookImage')
+
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/integration-test.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Pull Connaisseur images
         run: |
           DOCKER_CONTENT_TRUST=1 docker pull $(yq r helm/values.yaml 'deployment.image')
-          DOCKER_CONTENT_TRUST=1 docker pull $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
+          DOCKER_CONTENT_TRUST=1 docker pull $(yq r helm/values.yaml 'deployment.helmHookImage')
 
       - name: Create KinD cluster
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Add images to KinD
         run: |
           kind load docker-image $(yq r helm/values.yaml 'deployment.image')
-          kind load docker-image $(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f1):helm-hook
+          kind load docker-image $(yq r helm/values.yaml 'deployment.helmHookImage')
 
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/integration-test.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAMESPACE = connaisseur
 IMAGE := $(shell yq r helm/values.yaml 'deployment.image')
-IMAGE_NAME := $(shell echo $(IMAGE) | cut -d ':' -f1)
+HELM_HOOK_IMAGE := $(shell yq r helm/values.yaml 'deployment.helmHookImage')
 
 .PHONY: all docker certs install unistall upgrade annihilate
 
@@ -8,7 +8,7 @@ all: docker install
 
 docker:
 	docker build -f docker/Dockerfile -t $(IMAGE) .
-	docker build -f docker/Dockerfile.hook -t $(IMAGE_NAME):helm-hook .
+	docker build -f docker/Dockerfile.hook -t $(HELM_HOOK_IMAGE) .
 
 certs:
 	bash helm/certs/gen_certs.sh

--- a/connaisseur/tests/integration/update-config.yaml
+++ b/connaisseur/tests/integration/update-config.yaml
@@ -30,5 +30,5 @@
           verify: false
         - pattern: "docker.io/securesystemsengineering/connaisseur:*"
           verify: true
-        - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook"
+        - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook-*"
           verify: false

--- a/helm/templates/webhook/job.yaml
+++ b/helm/templates/webhook/job.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
         - name: {{ .Chart.Name }}-install-webhook
-          image: "securesystemsengineering/connaisseur:helm-hook"
+          image: {{ .Values.deployment.helmHookImage }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           command:
             - ash
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
         - name: {{ .Chart.Name }}-delete-webhook
-          image: "securesystemsengineering/connaisseur:helm-hook"
+          image: {{ .Values.deployment.helmHookImage }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           command:
             - ash
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
         - name: {{ .Chart.Name }}-upgrade-webhook
-          image: "securesystemsengineering/connaisseur:helm-hook"
+          image: {{ .Values.deployment.helmHookImage }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           command:
             - ash

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,7 @@
 deployment:
   replicasCount: 3
   image: securesystemsengineering/connaisseur:v1.4.4
+  helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}
   # limits:


### PR DESCRIPTION
Minor changes to the helm-hook-image could break prvious versions of connaisseur, which is why versioning is introduced to circumvent this.

fixes #67