### PR TITLE
ci: Improve tag detection during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,7 @@ name: release
 
 on:
   push:
-    tags: "*"
-    branches: master
+    tags: "v*"
 
 jobs:
   version-match:
@@ -14,10 +13,14 @@ jobs:
         run: sudo snap install yq
       - name: Ensure version equality
         run: |
-          if [[ "$(echo $GITHUB_REF | sed s+refs/tags/++)" == "" ]] \
-          || [[ "$(echo $GITHUB_REF | sed s+refs/tags/++)" != "$(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f2)" ]]
-            then exit 1
-          fi
+          IMAGE_TAG=$(yq r helm/values.yaml 'deployment.image' | cut -d ':' -f2)
+          for COMMIT_TAG in $(git tag --points-at $(git rev-parse HEAD)); do
+            if [[ "$IMAGE_TAG" == "$COMMIT_TAG" ]]; then
+              exit 0
+            fi
+          done
+          echo "Tag '$IMAGE_TAG' is not within tags of commit: $(git tag --points-at $(git rev-parse HEAD))"
+          exit 1
 
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously we used the GITHUB_REF variable set during the execution of of Github Actions to get to the current tag, which failed if tagging was done on prior to the push/on a different branch. Now we use the information contained in the git repository that is checked out anyway. Additionally the release pipeline previously also ran for any new commit on master (without a new tag being present) and now runs only for tags in potentially any branch (which is fine, as the release pipeline does no privileged action).