### PR TITLE
fix: missing delegation files

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo snap install yq --channel=v3/stable
       - name: Build images
         run: make docker
       - name: Save images
@@ -169,7 +169,7 @@ jobs:
           docker load -i ${GITHUB_SHA}_hook.tar
       - name: Install yq and bash
         run: |
-          sudo snap install yq
+          sudo snap install yq --channel=v3/stable
           sudo apt update
           sudo apt install bash -y
       - name: Create KinD cluster

--- a/connaisseur/notary_api.py
+++ b/connaisseur/notary_api.py
@@ -97,6 +97,18 @@ def get_trust_data(host: str, image: Image, role: TUFRole, token: str = None):
     return TrustData(data, role.role)
 
 
+def get_delegation_trust_data(
+    host: str, image: Image, role: TUFRole, token: str = None
+):
+    if os.environ.get("LOG_LEVEL", "INFO") == "DEBUG":
+        return get_trust_data(host, image, role, token)
+
+    try:
+        return get_trust_data(host, image, role, token)
+    except Exception:
+        return None
+
+
 def parse_auth(auth_header: str):
     """
     Generates an URL from the 'Www-authenticate' header, where a token can be

--- a/connaisseur/validate.py
+++ b/connaisseur/validate.py
@@ -2,7 +2,7 @@ import base64
 from connaisseur.image import Image
 from connaisseur.key_store import KeyStore
 from connaisseur.util import normalize_delegation
-from connaisseur.notary_api import get_trust_data
+from connaisseur.notary_api import get_trust_data, get_delegation_trust_data
 from connaisseur.tuf_role import TUFRole
 from connaisseur.exceptions import (
     NotFoundException,
@@ -66,7 +66,9 @@ def get_trusted_digest(host: str, image: Image, policy_rule: dict):
     return digests.pop()
 
 
-def process_chain_of_trust(host: str, image: Image, req_delegations: list):
+def process_chain_of_trust(
+    host: str, image: Image, req_delegations: list
+):  # pylint: disable=too-many-branches
     """
     Processes the whole chain of trust, provided by the notary server (`host`)
     for any given `image`. The 'root', 'snapshot', 'timestamp', 'targets' and
@@ -92,7 +94,9 @@ def process_chain_of_trust(host: str, image: Image, req_delegations: list):
     # as well
     if trust_data["targets"].has_delegations():
         for delegation in trust_data["targets"].get_delegations():
-            trust_data[delegation] = get_trust_data(host, image, TUFRole(delegation))
+            trust_data[delegation] = get_delegation_trust_data(
+                host, image, TUFRole(delegation)
+            )
 
     # validate all trust data's signatures, expiry dates and hashes
     for role in trust_data:
@@ -124,14 +128,29 @@ def process_chain_of_trust(host: str, image: Image, req_delegations: list):
     # required delegation JSON's. otherwise take the targets field of the targets JSON, as
     # long as no delegations are defined in the targets JSON. should there be delegations
     # defined in the targets JSON the targets field of the releases JSON will be used.
+    # unfortunately there is a case, where delegations could have been added to a
+    # repository, but no signatures were created using the delegations. in this special
+    # case, the releases JSON doesn't exist yet and the targets JSON must be used instead
     if req_delegations:
+        if not all(trust_data[target_role] for target_role in req_delegations):
+            tuf_roles = [
+                target_role
+                for target_role in req_delegations
+                if not trust_data[target_role]
+            ]
+            msg = f"no trust data for delegation roles {tuf_roles} for image {image}"
+            raise NotFoundException(msg, {"tuf_roles": tuf_roles})
+
         image_targets = [
             trust_data[target_role].signed.get("targets", {})
             for target_role in req_delegations
         ]
     else:
         targets_key = (
-            "targets/releases" if trust_data["targets"].has_delegations() else "targets"
+            "targets/releases"
+            if trust_data["targets"].has_delegations()
+            and trust_data["targets/releases"]
+            else "targets"
         )
         image_targets = [trust_data[targets_key].signed.get("targets", {})]
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.4
+  image: securesystemsengineering/connaisseur:v1.4.5
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}


### PR DESCRIPTION
in the special case, that delegations haven been added to an imgae repository, but no signatures were created using said delegations, the delegations appear in the targets JSON, but the actual delegation JSON files don't exist yet. Previously connaisseur assumed them to be present if they are in the targets JSON. This was changed to use the targets in the targets JSON file, instead of the missing delegation JSON files.