### PR TITLE
Feat/multi root key

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo snap install yq --channel=v3/stable
       - name: Build images
         run: make docker
       - name: Save images
@@ -169,7 +169,7 @@ jobs:
           docker load -i ${GITHUB_SHA}_hook.tar
       - name: Install yq and bash
         run: |
-          sudo snap install yq
+          sudo snap install yq --channel=v3/stable
           sudo apt update
           sudo apt install bash -y
       - name: Create KinD cluster

--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -54,7 +54,9 @@ class Image:
         # strip trailing "/" or set to default "docker.io" registry
         self.registry = (self.registry or "docker.io").rstrip("/")
         # strip trailing "/"
-        self.repository = (self.repository or "/").rstrip("/")
+        self.repository = (
+            self.repository or ("library/" if self.registry == "docker.io" else "/")
+        ).rstrip("/")
 
         if not (self.tag or self.digest):
             self.tag = "latest"

--- a/connaisseur/key_store.py
+++ b/connaisseur/key_store.py
@@ -1,3 +1,4 @@
+import yaml
 from connaisseur.exceptions import NotFoundException
 
 
@@ -12,20 +13,21 @@ class KeyStore:
 
     def __init__(self):
         # will always be loaded there as k8s secret
-        root_path = "/etc/certs/root-pub.pem"
-        root_key = KeyStore.load_root_pub_key(root_path)
+        root_path = "/etc/keys/rootPubKeys.yaml"
 
-        self.keys = {"root": root_key}
+        self.keys = KeyStore.load_root_pub_keys(root_path)
         self.hashes = {}
 
     @staticmethod
-    def load_root_pub_key(path: str):
+    def load_root_pub_keys(path: str):
         """
         Loads the public root key from the containers file system.
         """
         with open(path, "r") as root_file:
-            root_key = "".join(root_file.read().splitlines()[1:-1])
-        return root_key
+            pub_keys = yaml.safe_load(root_file)
+            for key_id in pub_keys:
+                pub_keys[key_id] = "".join(pub_keys[key_id].split("\n")[1:-2])
+            return pub_keys
 
     def get_key(self, key_id: str):
         """

--- a/connaisseur/notary_api.py
+++ b/connaisseur/notary_api.py
@@ -97,6 +97,18 @@ def get_trust_data(host: str, image: Image, role: TUFRole, token: str = None):
     return TrustData(data, role.role)
 
 
+def get_delegation_trust_data(
+    host: str, image: Image, role: TUFRole, token: str = None
+):
+    if os.environ.get("LOG_LEVEL", "INFO") == "DEBUG":
+        return get_trust_data(host, image, role, token)
+
+    try:
+        return get_trust_data(host, image, role, token)
+    except Exception:
+        return None
+
+
 def parse_auth(auth_header: str):
     """
     Generates an URL from the 'Www-authenticate' header, where a token can be

--- a/connaisseur/tests/integration/update-config.yaml
+++ b/connaisseur/tests/integration/update-config.yaml
@@ -15,8 +15,9 @@
       path: notary.auth.enabled
       value: false
     - command: update
-      path: notary.rootPubKey
-      value: |
+      path: notary.rootPubKeys
+      value: 
+        6b35860633a0cf852670fd9b5c12ba068875f3804d6711feb16fcd74c723c816: |
           -----BEGIN PUBLIC KEY-----
           MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETBDLAICCabJQXB01DOy315nDm0aD
           BREZ4aWG+uphuFrZWw0uAVLW9B/AIcJkHa7xQ/NLtrDi3Ou5dENzDy+Lkg==

--- a/connaisseur/tests/test_image.py
+++ b/connaisseur/tests/test_image.py
@@ -48,7 +48,7 @@ def im():
             "path/to/repo",
             "reg.com:12345",
         ),
-        ("image:tag", "image", "tag", None, "", "docker.io"),
+        ("image:tag", "image", "tag", None, "library", "docker.io"),
         (
             "sub.registry.io/path/image:tag",
             "image",
@@ -118,12 +118,12 @@ def test_has_digest(im, image: str, digest: bool):
 @pytest.mark.parametrize(
     "image, str_image",
     [
-        ("image:tag", "docker.io/image:tag"),
+        ("image:tag", "docker.io/library/image:tag"),
         ("registry.io/image:tag", "registry.io/image:tag"),
         ("reg.io/path/image:tag", "reg.io/path/image:tag"),
-        ("image", "docker.io/image:latest"),
+        ("image", "docker.io/library/image:latest"),
         ("registry.io:42358/path/image:1", "registry.io:42358/path/image:1"),
-        ("registry:12", "docker.io/registry:12"),
+        ("registry:12", "docker.io/library/registry:12"),
         ("registry.io:8080/image", "registry.io:8080/image:latest"),
         (
             (
@@ -131,7 +131,7 @@ def test_has_digest(im, image: str, digest: bool):
                 "e8fc232cf126c9e598390ae61895eb96f52ae46d"
             ),
             (
-                "docker.io/image@sha256:859b5aada817b3eb53410"
+                "docker.io/library/image@sha256:859b5aada817b3eb53410"
                 "222e8fc232cf126c9e598390ae61895eb96f52ae46d"
             ),
         ),

--- a/connaisseur/tests/test_keystore.py
+++ b/connaisseur/tests/test_keystore.py
@@ -5,7 +5,7 @@ import connaisseur.key_store as ks
 from connaisseur.exceptions import BaseConnaisseurException
 
 root_pub_key = {
-    "root": (
+    "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798": (
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu"
         "7WMF8tCjVgeORAS2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDG"
         "l+W2k3elHkPbR+gNkK2PCA=="
@@ -13,20 +13,6 @@ root_pub_key = {
 }
 
 root_keys = {
-    "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798": (
-        "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJlekNDQVNLZ0F3SUJBZ0lSQ"
-        "UtDclUxM0pNUzdHTnJMWEk2SjVvRmd3Q2dZSUtvWkl6ajBFQXdJd0pERWkKTUNBR0"
-        "ExVUVBeE1aWkc5amEyVnlMbWx2TDNCb1ltVnNhWFI2TDNOaGJYQnNaVEFlRncweU1"
-        "EQXhNVE14TlRVMApORFphRncwek1EQXhNVEF4TlRVME5EWmFNQ1F4SWpBZ0JnTlZC"
-        "QU1UR1dSdlkydGxjaTVwYnk5d2FHSmxiR2wwCmVpOXpZVzF3YkdVd1dUQVRCZ2Nxa"
-        "GtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFTMUhtVENzTXJiWkxJSzd0WXcKWHkwS0"
-        "5XQjQ1RUJMWTlacHhGd0UzOVZCMVVyZzlXVFhEaWt4YVhQMEFkQzJFTWFYNWJhVGQ"
-        "2VWVROXRINkEyUQpyWThJb3pVd016QU9CZ05WSFE4QkFmOEVCQU1DQmFBd0V3WURW"
-        "UjBsQkF3d0NnWUlLd1lCQlFVSEF3TXdEQVlEClZSMFRBUUgvQkFJd0FEQUtCZ2dxa"
-        "GtqT1BRUURBZ05IQURCRUFpQnRLN25SMGZmc2oxRlZkNFJXeXRJM0orVG8KTkxMT0"
-        "lVMXJkczArQ2IxdjRnSWdiUGt5V21heGlxQW1OeFp5bnFBVHpuN3JLQ2FWRlZKWW9"
-        "XZjlqeFg1elRNPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
-    ),
     "7c62922e6be165f1ea08252f77410152b9e4ec0d7bf4e69c1cc43f0e6c73da20": (
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErIGdt5pelfWOSjmY7k+/TypV0IFF"
         "9XLA+K4swhclLJb79cLoeBBDqkkUrkfhN5gxRnA//wA3amL4WXkaGsb9zQ=="
@@ -73,13 +59,15 @@ def key_store():
 @pytest.fixture
 def mock_pub_key(monkeypatch):
     def pub_key(path: str):
-        return (
-            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu"
-            "7WMF8tCjVgeORAS2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDG"
-            "l+W2k3elHkPbR+gNkK2PCA=="
-        )
+        return {
+            "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu"
+                "7WMF8tCjVgeORAS2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDG"
+                "l+W2k3elHkPbR+gNkK2PCA=="
+            )
+        }
 
-    ks.KeyStore.load_root_pub_key = staticmethod(pub_key)
+    ks.KeyStore.load_root_pub_keys = staticmethod(pub_key)
 
 
 @pytest.fixture

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -293,7 +293,7 @@ def mock_request(monkeypatch):
 def mock_keystore(monkeypatch):
     def init(self):
         self.keys = {
-            "root": (
+            "a873ab3f157cfd51c9ccdc445caac92e8aef9f57881169d3bc3cc4868a20add2": (
                 "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
                 "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
             )

--- a/connaisseur/tests/test_trust_data.py
+++ b/connaisseur/tests/test_trust_data.py
@@ -232,7 +232,7 @@ def mock_schema_path(monkeypatch):
 def mock_keystore(monkeypatch):
     def init(self):
         self.keys = {
-            "root": (
+            "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798": (
                 "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
                 "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
             ),

--- a/connaisseur/tests/test_validate.py
+++ b/connaisseur/tests/test_validate.py
@@ -91,11 +91,6 @@ targets6 = [
     }
 ]
 
-alt_root_pub = (
-    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtkQuBJ/wL1MEDy/6kgfSBls04MT1"
-    "aUWM7eZ19L2WPJfjt105PPieCM1CZybSZ2h3O4+E4hPz1X5RfmojpXKePg=="
-)
-
 
 @pytest.fixture
 def mock_request(monkeypatch):
@@ -178,13 +173,22 @@ def mock_request(monkeypatch):
 def mock_keystore(monkeypatch, root_pub: str = None):
     def init(self):
         self.keys = {
-            "root": os.environ.get(
-                "ROOT_PUB",
-                (
-                    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
-                    "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
-                ),
-            )
+            "2cd463575a31cb3184320e889e82fb1f9e3bbebee2ae42b2f825b0c8a734e798": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
+                "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
+            ),
+            "a873ab3f157cfd51c9ccdc445caac92e8aef9f57881169d3bc3cc4868a20add2": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
+                "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
+            ),
+            "950430dd6ff06b4a3b4e6f29f7fc7e07f1386718fc936795b0ca27d85645cace": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu7WMF8tCjVgeORA"
+                "S2PWacRcBN/VQdVK4PVk1w4pMWlz9AHQthDGl+W2k3elHkPbR+gNkK2PCA=="
+            ),
+            "2b53d5708f0defb3e7023b59a32d85938139ee613b85f1aa862cd484f53edc2e": (
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtkQuBJ/wL1MEDy/6kgfSBls04MT1"
+                "aUWM7eZ19L2WPJfjt105PPieCM1CZybSZ2h3O4+E4hPz1X5RfmojpXKePg=="
+            ),
         }
         self.hashes = {}
 
@@ -257,7 +261,7 @@ def test_get_trusted_digest(
 
 
 @pytest.mark.parametrize(
-    "image, policy, error, root_pub",
+    "image, policy, error",
     [
         (
             "securesystemsengineering/charlie-image:test2",
@@ -266,13 +270,11 @@ def test_get_trusted_digest(
                 "not all required delegations have trust data for image "
                 '"docker.io/securesystemsengineering/charlie-image:test2".'
             ),
-            alt_root_pub,
         ),
         (
             "securesystmesengineering/dave-image:test",
             policy_rule4,
             "found multiple signed digests for the same image.",
-            alt_root_pub,
         ),
     ],
 )
@@ -284,49 +286,41 @@ def test_get_trusted_digest_error(
     image: str,
     policy: dict,
     error: str,
-    root_pub: str,
 ):
-    if root_pub:
-        monkeypatch.setenv("ROOT_PUB", root_pub)
     with pytest.raises(BaseConnaisseurException) as err:
         val.get_trusted_digest("host", Image(image), policy)
     assert error in str(err.value)
 
 
 @pytest.mark.parametrize(
-    "image, req_delegations, targets, root_pub",
+    "image, req_delegations, targets",
     [
-        ("securesystemsengineering/alice-image", req_delegations1, targets1, None),
-        ("securesystemsengineering/sample-image", req_delegations2, targets2, None),
+        ("securesystemsengineering/alice-image", req_delegations1, targets1),
+        ("securesystemsengineering/sample-image", req_delegations2, targets2),
         (
             "securesystemsengineering/bob-image",
             req_delegations2,
             targets3,
-            alt_root_pub,
         ),
         (
             "securesystemsengineering/charlie-image",
             req_delegations2,
             targets4,
-            alt_root_pub,
         ),
         (
             "securesystemsengineering/dave-image",
             req_delegations2,
             targets5,
-            alt_root_pub,
         ),
         (
             "securesystemsengineering/dave-image",
             req_delegations4,
             targets5,
-            alt_root_pub,
         ),
         (
             "securesystemsengineering/dave-image",
             req_delegations5,
             targets6,
-            alt_root_pub,
         ),
     ],
 )
@@ -338,10 +332,7 @@ def test_process_chain_of_trust(
     image: str,
     req_delegations: dict,
     targets: list,
-    root_pub: str,
 ):
-    if root_pub:
-        monkeypatch.setenv("ROOT_PUB", root_pub)
     assert val.process_chain_of_trust("host", Image(image), req_delegations) == targets
 
 

--- a/connaisseur/trust_data.py
+++ b/connaisseur/trust_data.py
@@ -97,9 +97,15 @@ class TrustData:
         """
         msg = json.dumps(self.signed, separators=(",", ":"))
         for signature in self.signatures:
-            key_id = "root" if self.kind == "root" else signature["keyid"]
+            key_id = signature["keyid"]
             pub_key = keystore.get_key(key_id)
             sig = signature["sig"]
+
+            if not pub_key:
+                raise NotFoundException(
+                    "couldn't find right public for trust data.",
+                    {"key_id": key_id, "trust_data_type": self.signed.get("_type")},
+                )
 
             try:
                 verify_signature(pub_key, sig, msg)

--- a/connaisseur/validate.py
+++ b/connaisseur/validate.py
@@ -2,7 +2,7 @@ import base64
 from connaisseur.image import Image
 from connaisseur.key_store import KeyStore
 from connaisseur.util import normalize_delegation
-from connaisseur.notary_api import get_trust_data
+from connaisseur.notary_api import get_trust_data, get_delegation_trust_data
 from connaisseur.tuf_role import TUFRole
 from connaisseur.exceptions import (
     NotFoundException,
@@ -66,7 +66,9 @@ def get_trusted_digest(host: str, image: Image, policy_rule: dict):
     return digests.pop()
 
 
-def process_chain_of_trust(host: str, image: Image, req_delegations: list):
+def process_chain_of_trust(
+    host: str, image: Image, req_delegations: list
+):  # pylint: disable=too-many-branches
     """
     Processes the whole chain of trust, provided by the notary server (`host`)
     for any given `image`. The 'root', 'snapshot', 'timestamp', 'targets' and
@@ -92,7 +94,9 @@ def process_chain_of_trust(host: str, image: Image, req_delegations: list):
     # as well
     if trust_data["targets"].has_delegations():
         for delegation in trust_data["targets"].get_delegations():
-            trust_data[delegation] = get_trust_data(host, image, TUFRole(delegation))
+            trust_data[delegation] = get_delegation_trust_data(
+                host, image, TUFRole(delegation)
+            )
 
     # validate all trust data's signatures, expiry dates and hashes
     for role in trust_data:
@@ -124,14 +128,29 @@ def process_chain_of_trust(host: str, image: Image, req_delegations: list):
     # required delegation JSON's. otherwise take the targets field of the targets JSON, as
     # long as no delegations are defined in the targets JSON. should there be delegations
     # defined in the targets JSON the targets field of the releases JSON will be used.
+    # unfortunately there is a case, where delegations could have been added to a
+    # repository, but no signatures were created using the delegations. in this special
+    # case, the releases JSON doesn't exist yet and the targets JSON must be used instead
     if req_delegations:
+        if not all(trust_data[target_role] for target_role in req_delegations):
+            tuf_roles = [
+                target_role
+                for target_role in req_delegations
+                if not trust_data[target_role]
+            ]
+            msg = f"no trust data for delegation roles {tuf_roles} for image {image}"
+            raise NotFoundException(msg, {"tuf_roles": tuf_roles})
+
         image_targets = [
             trust_data[target_role].signed.get("targets", {})
             for target_role in req_delegations
         ]
     else:
         targets_key = (
-            "targets/releases" if trust_data["targets"].has_delegations() else "targets"
+            "targets/releases"
+            if trust_data["targets"].has_delegations()
+            and trust_data["targets/releases"]
+            else "targets"
         )
         image_targets = [trust_data[targets_key].signed.get("targets", {})]
 

--- a/docker/Dockerfile.getRoot
+++ b/docker/Dockerfile.getRoot
@@ -1,0 +1,14 @@
+FROM python:alpine
+
+WORKDIR /app
+
+RUN ["apk", "add", "gcc", "musl-dev", "libffi-dev", "openssl-dev", "python3-dev"]
+
+COPY requirements.txt setup.py scripts/get_root_key.py /app/
+COPY connaisseur /app/connaisseur
+
+RUN ["pip3", "install", "-r", "/app/requirements.txt"]
+RUN ["pip3", "install", "/app"]
+RUN ["pip3", "install", "cryptography"]
+
+ENTRYPOINT [ "python3", "/app/get_root_key.py" ]

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - name: {{ .Chart.Name }}-certs
               mountPath: /etc/certs
               readOnly: true
+            - name: {{ .Chart.Name }}-root-pub-keys
+              mountPath: /etc/keys
+              readOnly: true
           envFrom:
             - configMapRef:
                 name: {{ .Chart.Name }}-env
@@ -91,3 +94,6 @@ spec:
         - name: {{ .Chart.Name }}-certs
           secret:
             secretName: {{ .Chart.Name }}-tls
+        - name: {{ .Chart.Name }}-root-pub-keys
+          configMap:
+            name: {{ .Chart.Name }}-root-pub-keys

--- a/helm/templates/root-keys.yaml
+++ b/helm/templates/root-keys.yaml
@@ -1,17 +1,15 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ .Chart.Name }}-tls
+  name: {{ .Chart.Name }}-root-pub-keys
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "helm.name" . }}
     helm.sh/chart: {{ include "helm.chart" . }}
     app.kubernetes.io/instance: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-type: Opaque
 data:
-  tls.crt: {{ .Files.Get "certs/tls.crt" | b64enc }}
-  tls.key: {{ .Files.Get "certs/tls.key" | b64enc }}
-  {{- if .Values.notary.selfsigned}}
-  notary.crt: {{ .Values.notary.selfsignedCert | b64enc }}
+  rootPubKeys.yaml: | 
+  {{- range $k,$v := .Values.notary.rootPubKeys }}
+    {{ $k }}: {{ toJson $v }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.5
+  image: securesystemsengineering/connaisseur:v1.5.0
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}
@@ -44,10 +44,23 @@ notary:
     # or use a predefined secret, which needs the fields 'NOTARY_USER'
     # and 'NOTARY_PASS'
     secretName: null
-  # the public part of the root key, for verifying notary's signatures
-  rootPubKey: |
-    -----BEGIN PUBLIC KEY-----
-    -----END PUBLIC KEY-----
+  # the public part of the root keys, for verifying notary's signatures
+  rootPubKeys:
+    # general schema
+    # <key-id>: |
+    #   -----BEGIN PUBLIC KEY-----
+    #   -----END PUBLIC KEY-----
+    # e.g.
+    # 6b35860633a0cf852670fd9b5c12ba068875f3804d6711feb16fcd74c723c816: |
+    #   -----BEGIN PUBLIC KEY-----
+    #   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETBDLAICCabJQXB01DOy315nDm0aD
+    #   BREZ4aWG+uphuFrZWw0uAVLW9B/AIcJkHa7xQ/NLtrDi3Ou5dENzDy+Lkg==
+    #   -----END PUBLIC KEY-----
+    # 5cc8d0bc980f600ec41c29974014626d69e3b1dad47540c9183965f0055e12cd: |
+    #   -----BEGIN PUBLIC KEY-----
+    #   MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
+    #   QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+    #   -----END PUBLIC KEY-----
   # if you use Azure Container Registry (ACR) for your notary
   # changes some behaviour, such as health probes and how to retrieve auth tokens
   # for compatibility with ACR set to `true`

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.4
+  image: securesystemsengineering/connaisseur:v1.4.5
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jsonschema~=3.2.0
 parsedatetime~=2.6
 pytz~=2020.1
 python-dateutil~=2.8.1
+PyYAML~=5.3.1

--- a/scripts/get_root_key.py
+++ b/scripts/get_root_key.py
@@ -1,0 +1,51 @@
+import base64
+import argparse
+import connaisseur.notary_api as api
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from connaisseur.image import Image
+from connaisseur.tuf_role import TUFRole
+
+
+def get_pub_root_key(host: str, image: Image):
+    root_td = api.get_trust_data(host, image, TUFRole("root"))
+
+    root_key_id = root_td.signatures[0].get("keyid")
+    root_cert_base64 = (
+        root_td.get_keys().get(root_key_id, {}).get("keyval", {}).get("public")
+    )
+
+    if not root_cert_base64:
+        raise Exception("Error getting the root public cert")
+
+    root_cert_pem = base64.b64decode(bytearray(root_cert_base64, "utf-8"))
+    root_cert = x509.load_pem_x509_certificate(root_cert_pem, default_backend())
+    root_public_bytes = root_cert.public_key().public_bytes(
+        Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+    )
+    root_public_key = root_public_bytes.decode("utf-8")
+
+    return root_key_id, root_public_key
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Gets the root public key and key ID "
+            "from a notary server for a specific image."
+        )
+    )
+    parser.add_argument(
+        "--server",
+        "-s",
+        help="address of the notary server",
+        type=str,
+        default="notary.docker.io",
+    )
+    parser.add_argument(
+        "--image", "-i", help="name of the image", type=str, required=True
+    )
+    args = parser.parse_args()
+    root_key_id, root_key = get_pub_root_key(args.server, Image(args.image))
+    print(f"KeyID: {root_key_id}\nKey: {root_key}")

--- a/setup/local/README.md
+++ b/setup/local/README.md
@@ -277,21 +277,24 @@ notary:
     enabled: true
     user: test
     password: Securesystems8
-  rootPubKey: |
-    -----BEGIN PUBLIC KEY-----
-    -----END PUBLIC KEY-----
+  rootPubKeys:
+    # <key-id>: |
+    #   -----BEGIN PUBLIC KEY-----
+    #   -----END PUBLIC KEY-----
 ```
 
-For the `notary.rootPubKey` field, you need the public part of the Notary's `root` key. Its private component resides in your `~/.docker/trust/private` directory. With `openssl` you can get the public part form it, but you'll need to provide the passphrase you set, when generating the key:
+For the `notary.rootPubKeys` field, you need the public part of the Notary's `root` key and it's key ID. Its private component resides in your `~/.docker/trust/private` directory. With `openssl` you can get the public part form it, but you'll need to provide the passphrase you set, when generating the key:
 
 ```bash
 cd ~/.docker/trust/private
-sed '/^role:\sroot$/d' $(grep -iRl "role: root" .) > root-priv.key
+KEY_PATH=$(grep -iRl "role: root$" .)
+KEY_ID=$(basename -s .key $KEY_PATH)
+sed '/^role:\sroot$/d' $KEY_PATH > root-priv.key
 openssl ec -in root-priv.key -pubout -out root-pub.pem
 cd -
 ```
 
- Copy the contents of the public key into the `notary.rootPubKey` field of the `helm/values.yaml`.
+ Copy the key ID and the contents of the public key into the `notary.rootPubKeys` field of the `helm/values.yaml`.
 
 And with that, everything is ready to install Connaisseur. Use the repository's `Makefile`:
 


### PR DESCRIPTION
In order to verify signatures that were created by yourself and signatures from others, multiple public root keys must be provisioned. 

Previous behavior: A single root key was provisioned and added to the internal `key_store` as `root`. When verifying any trust data file of type root, this `root` key was used, regardless of the key ID declared in the trust data.

New behavior: One or more root keys are provisioned, each given with a key ID and stored in the internal `key_store` under their key ID. When verifying any trust data file of type root, the declared key ID used for signing the file is looked up in the `key_store`. If there is no key found an error will be raised, otherwise validation will go forth.