### PR TITLE
docs/test: Documentation for image validation, improve validation test coverage

### DIFF
--- a/connaisseur/crypto.py
+++ b/connaisseur/crypto.py
@@ -8,7 +8,7 @@ def verify_signature(public_base64: str, signature_base64: str, message: str):
     Verifies the given bas64-encoded signature with the base64-encoded public
     key and serialized message. The message should not contain any whitespaces.
 
-    Raises ValidationError if unsuccessfull.
+    Raises ValidationError if unsuccessful.
     """
     public = base64.b64decode(public_base64)
     pub_key = ecdsa.VerifyingKey.from_der(public)

--- a/connaisseur/notary_api.py
+++ b/connaisseur/notary_api.py
@@ -53,7 +53,7 @@ def is_notary_selfsigned():
 
 def get_trust_data(host: str, image: Image, role: TUFRole, token: str = None):
     """
-    Request the specific trust data, denoted by the `role` and `image` form
+    Request the specific trust data, denoted by the `role` and `image` from
     the notary server (`host`). Uses a token, should authentication be
     required.
     """

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -90,7 +90,6 @@ request_obj_cronjob_with_init_container = {
         },
     },
 }
-
 request_obj_deployment = {
     "kind": "Deployment",
     "apiVersion": "apps/v1",
@@ -111,6 +110,254 @@ request_obj_deployment = {
 }
 request_obj_deployment_with_two_init_containers = {
     "kind": "Deployment",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/securesystemsengineering/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/securesystemsengineering/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
+request_obj_replicationscontroller = {
+    "kind": "ReplicationController",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_replicationcontroller_with_two_init_containers = {
+    "kind": "ReplicationController",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/securesystemsengineering/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/securesystemsengineering/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
+request_obj_replicatset = {
+    "kind": "ReplicaSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_replicaset_with_two_init_containers = {
+    "kind": "ReplicaSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/securesystemsengineering/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/securesystemsengineering/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
+request_obj_daemonset = {
+    "kind": "DaemonSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_daemonset_with_two_init_containers = {
+    "kind": "DaemonSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/securesystemsengineering/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/securesystemsengineering/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
+request_obj_statefulset = {
+    "kind": "StatefulSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_tuftuf = {
+    "kind": "TufTuf",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_statefulset_with_two_init_containers = {
+    "kind": "StatefulSet",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ],
+                "initContainers": [
+                    {
+                        "name": "init-container",
+                        "image": "docker.io/securesystemsengineering/testing_conny:unsigned",
+                    },
+                    {
+                        "name": "init-container2",
+                        "image": "docker.io/securesystemsengineering/testing_conny:signed",
+                    },
+                ],
+            },
+        }
+    },
+}
+request_obj_job = {
+    "kind": "Job",
+    "apiVersion": "apps/v1",
+    "metadata": {},
+    "spec": {
+        "template": {
+            "metadata": {},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image:test",
+                    }
+                ]
+            },
+        }
+    },
+}
+request_obj_job_with_two_init_containers = {
+    "kind": "Job",
     "apiVersion": "apps/v1",
     "metadata": {},
     "spec": {
@@ -342,6 +589,12 @@ def get_ad_request(path: str):
         (request_obj_pod, request_obj_output),
         (request_obj_cronjob, request_obj_output),
         (request_obj_deployment, request_obj_output),
+        (request_obj_replicationscontroller, request_obj_output),
+        (request_obj_replicatset, request_obj_output),
+        (request_obj_daemonset, request_obj_output),
+        (request_obj_statefulset, request_obj_output),
+        (request_obj_job, request_obj_output),
+        (request_obj_tuftuf, None),
         (request_obj_pod_with_init_container, request_obj_output_with_init_container),
         (
             request_obj_cronjob_with_init_container,
@@ -349,6 +602,26 @@ def get_ad_request(path: str):
         ),
         (
             request_obj_deployment_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
+        (
+            request_obj_replicationcontroller_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
+        (
+            request_obj_replicaset_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
+        (
+            request_obj_daemonset_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
+        (
+            request_obj_statefulset_with_two_init_containers,
+            request_obj_output_with_two_init_containers,
+        ),
+        (
+            request_obj_job_with_two_init_containers,
             request_obj_output_with_two_init_containers,
         ),
     ],

--- a/connaisseur/tests/test_trust_data.py
+++ b/connaisseur/tests/test_trust_data.py
@@ -313,6 +313,8 @@ def test_trust_data_error(td):
     "trustdata, role",
     [
         (trust_data("tests/data/sample6_root.json"), "root"),
+        ([], "root"),
+        ({}, "targets"),
         (trust_data("tests/data/sample3_timestamp.json"), "timestamp"),
     ],
 )

--- a/connaisseur/tests/test_validate.py
+++ b/connaisseur/tests/test_validate.py
@@ -31,6 +31,7 @@ req_delegations2 = []
 req_delegations3 = ["targets/someuserthatdidnotsign"]
 req_delegations4 = ["targets/del1"]
 req_delegations5 = ["targets/del2"]
+req_delegations6 = ["targets/phbelitz", "targets/someuserthatdidnotsign"]
 
 targets1 = [
     {
@@ -349,13 +350,21 @@ def test_process_chain_of_trust(
     "image, req_delegations, error",
     [
         (
+            # no delegations
             "docker.io/securesystemsengineering/sample-image",
             req_delegations1,
             "could not find any delegations in trust data.",
         ),
         (
+            # single invalid delegation
             "securesystemsengineering/alice-image",
             req_delegations3,
+            "could not find delegation roles ['targets/someuserthatdidnotsign'] in trust data.",
+        ),
+        (
+            # invalid and valid delegations
+            "securesystemsengineering/alice-image",
+            req_delegations6,
             "could not find delegation roles ['targets/someuserthatdidnotsign'] in trust data.",
         ),
     ],

--- a/connaisseur/trust_data.py
+++ b/connaisseur/trust_data.py
@@ -67,7 +67,7 @@ class TrustData:
     def validate(self, keystore: KeyStore):
         """
         Validates the trust data's signature, expiry date and hash value, given
-        the keys and hashes from a `keystore`.
+        a `keystore` containing keys and hashes.
         """
         self._validate_signature(keystore)
         self._validate_expiry()

--- a/connaisseur/validate.py
+++ b/connaisseur/validate.py
@@ -16,9 +16,9 @@ def get_trusted_digest(host: str, image: Image, policy_rule: dict):
     given `image`, by using the notary API. Also checks whether the given
     `policy_rule` complies.
 
-    Returns the signed digest, belonging to the `image`.
+    Returns the signed digest, belonging to the `image` or throws if validation fails.
     """
-    # concat `targets/` to the  required delegation roles, if not already present
+    # prepend `targets/` to the required delegation roles, if not already present
     req_delegations = list(
         map(normalize_delegation, policy_rule.get("delegations", []))
     )

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,28 @@
+# Validation
+
+This document describes the image validation process as employed by Connaisseur.
+
+Since Connaisseur is a Kubernetes AdmissionController it operates on requests and has these requests, the Kubernetes API, the registry and the notary to work with. First off, Connaisseur does some light checks on the semantics of the request it receives, e.g. whether it is capable of using the API version of the admission request.
+
+Then it parses images to deploy from the request. Connaisseur does this for Pods, Jobs, CronJobs, Deployments, DaemonSets, StatefulSets, ReplicaSets and ReplicationControllers. These images are then validated as follows:
+
+1. If the image is deployed as part of an already deployed object (i.e. a Pod gets deployed as a child of a Deployment and the Deployment was already validated), it will be admitted. This is done as the parent (and thus the child) might have been mutated, which could lead to duplicate validation or rule mismatch. For example, given a Deployment which contains Pods with `image:tag` that gets mutated to contain Pods with `image@sha256:digest`. Then a) the Pod would not need another validation as the image was validated during the admittance of the Deployment and b) if there exists a specific rule for `image:tag` and another for `image:*`, then after mutating the Deployment, the Pod would be falsely validated against `image:*` instead of `image:tag`. To ensure the child resource is legit in this case, the parent resource is requested via the Kubernetes API and only those images it lists are accepted.
+2. The best matching rule from the image policy is looked up and if `verify: false`, the image is admitted.
+3. Trust data of the image is consulted as described in the next section.
+
+## Validation of trust data
+
+Validation of trust data on a high level boils down to two steps:
+
+1. Get all trusted (i.e. signed) image digests related to the tag or digest of the image.
+2. If there is exactly one, admit the image.
+
+Regarding the latter step, rejection upon no matching trusted digests is obvious. However, Connaisseur also needs to reject the image if there is more than one trusted digest, since at this point in time Connaisseur doesn't have the ability to distinguish between the right and wrong trusted digest. This only occurs in some edge cases, but nonetheless has to be addressed.
+
+Let's now focus on the integral part of Connaisseur that is how to get all trusted digests for an `image:tag` or `image:digest` combination:
+
+Connaisseur looks up trust data of the image in the `root`, `snapshot`, `timestamp` and `targets` files by querying the API of the notary server. Trust data syntax is validated against [their known schemas](https://github.com/sse-secure-systems/connaisseur/tree/master/connaisseur/res) (for an introduction to the trust data formats see the [presentation of our colleague Philipp Belitz](https://berlin-crypto.github.io/assets/Berlin%20Crypto%20Connaisseur.pdf)). Then, the files' signatures are validated against the pinned root key for the `root` file and against the respective keys validated in previous steps for later files. Connaisseur further gathers trust data of potential delegations linked in the `targets` file.
+
+At this point, Connaisseur is left with a set of potentially disjoint or overlapping sets of trust data. Connaisseur filters the trust data for digests that actually relate to the image under validation.
+
+If the image policy rule that governs the image to be validated does contain a `delegations` field, Connaisseur makes sure that all delegations' sets of trust data do contain an entry for the image. If that is not the case, the request is rejected. Subsequently, Connaisseur builds a set over the union of the digests and proceeds with step 2., i.e. accepeting if the size of the resulting set equals 1.


### PR DESCRIPTION
This PR documents the existing validation procedure employed by Connaisseur. In addition, it adds some test cases for all supported and one unsupported Kubernetes resource, tests more invalid trust data and checks the combination of valid and invalid delegations alongside each other. Also typos