### PR TITLE
Fix/refactor: Refactor validate method to not use non-validated data

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-At the current stage of the project, we are not working with actual releases. Please make sure to frequently pull the latest project state, version and build of the Connaisseur image to ensure up-to-date security.
+The last known significant security vulnerability was in version 1.3.0 (Connaisseur not validating initContainers). However, since both Python packages and OS packages in the Connaisseur image may become known to be vulnerable over time, we suggest either frequently rebuilding the Connaisseur image from source yourself or updating to the latest Connaisseur image. We strictly stick to semantic versioning, so unless the major version changes, updating Conaisseur should never brake your installation.
 
 ## Reporting a Vulnerability
 

--- a/connaisseur/tests/test_keystore.py
+++ b/connaisseur/tests/test_keystore.py
@@ -84,7 +84,7 @@ def mock_pub_key(monkeypatch):
 
 @pytest.fixture
 def mock_trust_data(monkeypatch):
-    def _validate_expiry(self):
+    def validate_expiry(self):
         pass
 
     def trust_init(self, data: dict, role: str):
@@ -94,7 +94,7 @@ def mock_trust_data(monkeypatch):
         self.signed = data["signed"]
         self.signatures = data["signatures"]
 
-    monkeypatch.setattr(TrustData, "_validate_expiry", _validate_expiry)
+    monkeypatch.setattr(TrustData, "validate_expiry", validate_expiry)
     monkeypatch.setattr(TargetsData, "__init__", trust_init)
     TrustData.schema_path = "res/{}_schema.json"
 

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -561,7 +561,7 @@ def mock_policy(monkeypatch):
 
 @pytest.fixture
 def mock_trust_data(monkeypatch):
-    def _validate_expiry(self):
+    def validate_expiry(self):
         pass
 
     def trust_init(self, data: dict, role: str):
@@ -572,7 +572,7 @@ def mock_trust_data(monkeypatch):
         self.signatures = data["signatures"]
 
     monkeypatch.setattr(
-        connaisseur.trust_data.TrustData, "_validate_expiry", _validate_expiry
+        connaisseur.trust_data.TrustData, "validate_expiry", validate_expiry
     )
     monkeypatch.setattr(connaisseur.trust_data.TargetsData, "__init__", trust_init)
     connaisseur.trust_data.TrustData.schema_path = "res/{}_schema.json"

--- a/connaisseur/tests/test_notary_api.py
+++ b/connaisseur/tests/test_notary_api.py
@@ -105,7 +105,7 @@ def mock_request(monkeypatch):
 
 @pytest.fixture
 def mock_trust_data(monkeypatch):
-    def _validate_expiry(self):
+    def validate_expiry(self):
         pass
 
     def trust_init(self, data: dict, role: str):
@@ -116,7 +116,7 @@ def mock_trust_data(monkeypatch):
         self.signatures = data["signatures"]
 
     monkeypatch.setattr(
-        connaisseur.trust_data.TrustData, "_validate_expiry", _validate_expiry
+        connaisseur.trust_data.TrustData, "validate_expiry", validate_expiry
     )
     monkeypatch.setattr(connaisseur.trust_data.TargetsData, "__init__", trust_init)
     connaisseur.trust_data.TrustData.schema_path = "res/{}_schema.json"

--- a/connaisseur/tests/test_trust_data.py
+++ b/connaisseur/tests/test_trust_data.py
@@ -353,7 +353,7 @@ def test_validate_schema(td, mock_schema_path, trustdata: dict, role: str):
 def test_validate_signature(td, mock_schema_path, mock_keystore, data: dict, role: str):
     ks = KeyStore()
     trust_data_ = td.TrustData(data, role)
-    assert trust_data_._validate_signature(ks) is None
+    assert trust_data_.validate_signature(ks) is None
 
 
 def test_validate_signature_error(td, mock_schema_path, mock_keystore):
@@ -363,7 +363,7 @@ def test_validate_signature_error(td, mock_schema_path, mock_keystore):
     ks = KeyStore()
 
     with pytest.raises(ValidationError) as err:
-        trust_data_._validate_signature(ks)
+        trust_data_.validate_signature(ks)
     assert "failed to verify signature of trust data." in str(err.value)
 
 
@@ -380,7 +380,7 @@ def test_validate_signature_error(td, mock_schema_path, mock_keystore):
 def test_validate_hash(td, mock_schema_path, mock_keystore, data: dict, role: str):
     ks = KeyStore()
     trust_data_ = td.TrustData(data, role)
-    assert trust_data_._validate_hash(ks) is None
+    assert trust_data_.validate_hash(ks) is None
 
 
 def test_validate_hash_error(td, mock_schema_path, mock_keystore):
@@ -390,7 +390,7 @@ def test_validate_hash_error(td, mock_schema_path, mock_keystore):
     ks = KeyStore()
 
     with pytest.raises(ValidationError) as err:
-        trust_data_._validate_hash(ks)
+        trust_data_.validate_hash(ks)
     assert "failed validating trust data hash." in str(err.value)
 
 
@@ -408,7 +408,7 @@ def test_validate_trust_data_expiry(td, mock_schema_path, data: dict, role: str)
     time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
     trust_data_.signed["expires"] = time.strftime(time_format)
 
-    assert trust_data_._validate_expiry() is None
+    assert trust_data_.validate_expiry() is None
 
 
 @pytest.mark.parametrize(
@@ -422,7 +422,7 @@ def test_validate_trust_data_expiry_error(td, mock_schema_path, data: dict, role
     trust_data_.signed["expires"] = time.strftime(time_format)
 
     with pytest.raises(ValidationError) as err:
-        trust_data_._validate_expiry()
+        trust_data_.validate_expiry()
     assert "trust data expired." in str(err.value)
 
 

--- a/connaisseur/tests/test_validate.py
+++ b/connaisseur/tests/test_validate.py
@@ -194,7 +194,7 @@ def mock_keystore(monkeypatch, root_pub: str = None):
 
 @pytest.fixture
 def mock_trust_data(monkeypatch):
-    def _validate_expiry(self):
+    def validate_expiry(self):
         pass
 
     def trust_init(self, data: dict, role: str):
@@ -205,7 +205,7 @@ def mock_trust_data(monkeypatch):
         self.signatures = data["signatures"]
 
     monkeypatch.setattr(
-        connaisseur.trust_data.TrustData, "_validate_expiry", _validate_expiry
+        connaisseur.trust_data.TrustData, "validate_expiry", validate_expiry
     )
     monkeypatch.setattr(connaisseur.trust_data.TargetsData, "__init__", trust_init)
     connaisseur.trust_data.TrustData.schema_path = "res/{}_schema.json"

--- a/connaisseur/trust_data.py
+++ b/connaisseur/trust_data.py
@@ -71,11 +71,11 @@ class TrustData:
         Validates the trust data's signature, expiry date and hash value, given
         a `keystore` containing keys and hashes.
         """
-        self._validate_signature(keystore)
-        self._validate_expiry()
-        self._validate_hash(keystore)
+        self.validate_signature(keystore)
+        self.validate_expiry()
+        self.validate_hash(keystore)
 
-    def _validate_expiry(self):
+    def validate_expiry(self):
         """
         Validates the expiry date of the trust data.
 
@@ -90,7 +90,7 @@ class TrustData:
                 {"expire": str(expire), "trust_data_type": self.signed.get("_type")},
             )
 
-    def _validate_signature(self, keystore: KeyStore):
+    def validate_signature(self, keystore: KeyStore):
         """
         Validates the signature of the trust data, using keys from a
         `keystore`.
@@ -111,7 +111,7 @@ class TrustData:
                     {"key_id": key_id, "trust_data_type": self.signed.get("_type")},
                 ) from err
 
-    def _validate_hash(self, keystore: KeyStore):
+    def validate_hash(self, keystore: KeyStore):
         """
         Validates the given hash from a `keystore` corresponds to the trust
         data's calculated hash.
@@ -168,7 +168,7 @@ class SnapshotData(TrustData):  # pylint: disable=abstract-method
 
 
 class TimestampData(TrustData):  # pylint: disable=abstract-method
-    def _validate_hash(self, keystore: KeyStore):
+    def validate_hash(self, keystore: KeyStore):
         pass
 
     def get_hashes(self):

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.5
+  image: securesystemsengineering/connaisseur:v1.4.6
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}


### PR DESCRIPTION
Previously, Connaisseur accepted all trust data files at first and then validated them. This was not an immediate security issue, since the root key could not be overwritten and since the KeyStore is write-once, so keys will only be used after they have been validated. However, Connaisseur would have pulled all delegations in a malicious targets.json without prior validation, which would have allowed an attacker to specify many non-existant delegations, potentially causing a denial of service. This PR fixes the issue by first validating and then processing the trust data files. In addition, the way Connaisseur previously validated trust data files would have allowed an attacker that compromised the long-term snapshot key to mount freeze attacks (i.e. ignoring the validation via timestamp key) by mounting a targeted collision attack instead of a 2nd-preimage attack against the DCT hash function.