### PR TITLE
Enable Per-Namespace verification

### DIFF
--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,11 @@
+{{- if not (has "*" .Values.targetNamespaces) }}
+{{- range .Values.targetNamespaces }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ . | quote }}
+  labels:
+    {{- include  "connaisseur.namespaceLabels" $ | indent 4 }}
+---
+{{- end }}        
+{{- end }}        

--- a/helm/templates/webhook/_webhook.tpl
+++ b/helm/templates/webhook/_webhook.tpl
@@ -1,0 +1,5 @@
+{{- define "connaisseur.namespaceLabels" }}
+de.securesystems.connaisseur/enabled: "true"
+de.securesystems.connaisseur/release: "{{ .Release.Name }}"
+de.securesystems.connaisseur/rootPubKeyHash: "{{ trim .Values.notary.rootPubKey | sha1sum }}"
+{{ end -}}

--- a/helm/templates/webhook/webhook.yaml
+++ b/helm/templates/webhook/webhook.yaml
@@ -22,4 +22,9 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+  {{- if not (has "*" .Values.targetNamespaces) }}
+    namespaceSelector:
+      matchLabels:
+       {{- include  "connaisseur.namespaceLabels" . | indent 8 }}
+  {{- end }} 
 {{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,4 +68,8 @@ policy:
 # interrupting operation.
 detection_mode: false
 
+# A list of namespaces that will be subsequent to Connaisseur verification.
+# If the list contains '*' - all namespaces will be monitored.
+targetNamespaces: ['*']
+
 # debug: true


### PR DESCRIPTION
This commit aims to add the feature to enable the Connaiseur
Webhook validation in *some* K8s namespaces and not the whole
cluster.

This is done by adding a variable in the `values.yaml` file
called `targetNamespaces`, that contains a list of namespace names.
The webhook will then be used by container creations ONLY in these
namespaces.

In case the names in the list are not available as namespaces,
they are auto-created.

Finally, the default value of `['*']`, deploys the default behavior -
validating all the cluster containers.