### PR TITLE
docs/fix: adjust public keys in READMEs to DockerHub Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Make sure `docker`, `git`, `helm`, `kubectl`, `make` and `yq` (>= v4) are instal
   # the public part of the root key, for verifying notary's signatures
   rootPubKey: |
     -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETBDLAICCabJQXB01DOy315nDm0aD
-    BREZ4aWG+uphuFrZWw0uAVLW9B/AIcJkHa7xQ/NLtrDi3Ou5dENzDy+Lkg==
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+    d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
     -----END PUBLIC KEY-----
 ```
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -97,8 +97,8 @@ Lastly, we need to configure the `notary.rootPubKey` that serves as a trust anch
   # the public part of the root key, for verifying notary's signatures
   rootPubKey: |
     -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETBDLAICCabJQXB01DOy315nDm0aD
-    BREZ4aWG+uphuFrZWw0uAVLW9B/AIcJkHa7xQ/NLtrDi3Ou5dENzDy+Lkg==
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+    d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
     -----END PUBLIC KEY-----
 ```
 


### PR DESCRIPTION
the issue was introduced in #79 when all testimages were moved to `docker.io/securesystemsengineering/testimage` but only the public key for integration tests was changed. Consequently, demo and other setup guides would not work anymore