### PR TITLE
feat: sigstore/cosign support

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -224,6 +224,35 @@ jobs:
         run: |
           kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
           kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
-
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/namespaced-integration-test.sh
+
+  cosign-integration-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
+      - name: Load Docker images
+        run: |
+          docker load -i ${GITHUB_SHA}_image.tar
+          docker load -i ${GITHUB_SHA}_hook.tar
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+      - name: Check KinD cluster
+        run: kubectl get nodes
+      - name: Add images to KinD
+        run: |
+          kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
+          kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
+      - name: Run actual integration test
+        run: bash connaisseur/tests/integration/cosign-integration-test.sh

--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -17,5 +17,11 @@ jobs:
         run: DOCKER_CONTENT_TRUST=1 docker pull docker.io/securesystemsengineering/testimage:signed
       - name: Check unsigned test image
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:unsigned
+      - name: Check cosign signed test image
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:co-signed
+      - name: Check cosign unsigned test image
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:co-unsigned
+      - name: Check cosign test image signed with alternative key
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:co-signed-alt
       - name: Check alerting endpoint image
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/alerting-endpoint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,35 @@ jobs:
         run: |
           kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
           kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
-
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/namespaced-integration-test.sh
+
+  cosign-integration-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
+      - name: Load Docker images
+        run: |
+          docker load -i ${GITHUB_SHA}_image.tar
+          docker load -i ${GITHUB_SHA}_hook.tar
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+      - name: Check KinD cluster
+        run: kubectl get nodes
+      - name: Add images to KinD
+        run: |
+          kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
+          kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
+      - name: Run actual integration test
+        run: bash connaisseur/tests/integration/cosign-integration-test.sh

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@ NAMESPACE = connaisseur
 IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
 HELM_HOOK_IMAGE := $(shell yq e '.deployment.helmHookImage' helm/values.yaml)
 CLUSTER := $(shell CONTEXT=`kubectl config current-context` && kubectl config view -ojson | jq --arg CONTEXT $$CONTEXT '.contexts[] | select(.name==$$CONTEXT) | .context.cluster')
+COSIGN_VERSION = 0.2.0
 
 .PHONY: all docker certs install unistall upgrade annihilate
 
 all: docker install
 
 docker:
-	docker build -f docker/Dockerfile -t $(IMAGE) .
+	docker build --build-arg COSIGN_VERSION=$(COSIGN_VERSION) -f docker/Dockerfile -t $(IMAGE) .
 	docker build -f docker/Dockerfile.hook -t $(HELM_HOOK_IMAGE) .
 
 certs:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 <!-- # Connaisseur -->
 
-Connaisseur is an admission controller for Kubernetes that integrates Image Signature Verification into a cluster, as a means to ensure that only valid images are being deployed.
+Connaisseur is an admission controller for Kubernetes that integrates Image Signature Verification and Trust Pinning into a cluster, as a means to ensure that only valid images are being deployed.
+
+🚨 🚨 We have added experimental support for [Cosign](https://github.com/sigstore/cosign) from the [Sigstore Project](https://sigstore.dev/). You can find instructions [here](setup/COSIGN.md). 🚨 🚨
 
 Have feedback? Feel free to [reach out to us](https://github.com/sse-secure-systems/connaisseur/discussions)!
 

--- a/connaisseur/crypto.py
+++ b/connaisseur/crypto.py
@@ -2,6 +2,8 @@ import hashlib
 import base64
 import ecdsa
 
+from connaisseur.exceptions import InvalidPublicKey
+
 
 def verify_signature(public_base64: str, signature_base64: str, message: str):
     """
@@ -10,11 +12,24 @@ def verify_signature(public_base64: str, signature_base64: str, message: str):
 
     Raises ValidationError if unsuccessful.
     """
-    public = base64.b64decode(public_base64)
-    pub_key = ecdsa.VerifyingKey.from_der(public)
+    pub_key = decode_and_verify_ecdsa_key(public_base64)
 
     signature = base64.b64decode(signature_base64)
 
     msg_bytes = bytearray(message, "utf-8")
 
     return pub_key.verify(signature, msg_bytes, hashfunc=hashlib.sha256)
+
+
+def decode_and_verify_ecdsa_key(public_base64: str):
+    """
+    Verifies that the provided public key in base64 encoding qualifies as a
+    proper ecdsa key and throws if not.
+    """
+    try:
+        public = base64.b64decode(public_base64)
+        return ecdsa.VerifyingKey.from_der(public)
+    except Exception as err:
+        raise InvalidPublicKey(
+            f"The public key provided is not a base64-encoded ECDSA key: {err}."
+        ) from err

--- a/connaisseur/exceptions.py
+++ b/connaisseur/exceptions.py
@@ -29,6 +29,10 @@ class BaseConnaisseurException(Exception):
         return msg
 
 
+class InvalidPublicKey(BaseConnaisseurException):
+    pass
+
+
 class InvalidFormatException(BaseConnaisseurException):
     pass
 
@@ -54,6 +58,18 @@ class UnknownVersionError(Exception):
 
 
 class AmbiguousDigestError(BaseConnaisseurException):
+    pass
+
+
+class CosignError(BaseConnaisseurException):
+    pass
+
+
+class CosignTimeout(BaseConnaisseurException):
+    pass
+
+
+class UnexpectedCosignData(BaseConnaisseurException):
     pass
 
 

--- a/connaisseur/mutate.py
+++ b/connaisseur/mutate.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 from connaisseur.image import Image
 from connaisseur.validate import get_trusted_digest
 from connaisseur.admission_review import get_admission_review

--- a/connaisseur/sigstore_validator.py
+++ b/connaisseur/sigstore_validator.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import re
+import subprocess  # nosec
+
+from connaisseur.crypto import decode_and_verify_ecdsa_key
+from connaisseur.exceptions import (
+    CosignError,
+    CosignTimeout,
+    NotFoundException,
+    ValidationError,
+    UnexpectedCosignData,
+)
+
+
+def get_cosign_validated_digests(image: str, pubkey: str):
+    """
+    Gets and processes cosign validation output for a given `image` and `pubkey`
+    and either returns a list of valid digests or raises a suitable exception
+    in case no valid signature is found or cosign fails.
+    """
+    returncode, stdout, stderr = invoke_cosign(image, pubkey)
+    logging.info(
+        "COSIGN output for image: %s; RETURNCODE: %s; STDOUT: %s; STDERR: %s",
+        image,
+        returncode,
+        stdout,
+        stderr,
+    )
+    digests = []
+    if returncode == 0:
+        for sig in stdout.splitlines():
+            try:
+                sig_data = json.loads(sig)
+                try:
+                    digest = sig_data["Critical"]["Image"].get(
+                        "Docker-manifest-digest", ""
+                    )
+                    if re.match(r"sha256:[0-9A-Fa-f]{64}", digest) is None:
+                        raise Exception(
+                            f"digest '{digest}' does not match expected digest pattern."
+                        )
+                except Exception as err:
+                    raise UnexpectedCosignData(
+                        "could not retrieve valid and unambiguous digest "
+                        f"from data received by cosign: {type(err).__name__}: {err}"
+                    ) from err
+                # remove prefix 'sha256'
+                digests.append(digest[7:])
+            except json.JSONDecodeError:
+                logging.info("non-json signature data from cosign: %s", sig)
+                pass
+    elif "error: no matching signatures:\nunable to verify signature\n" in stderr:
+        raise ValidationError(
+            "failed to verify signature of trust data.",
+            {"trust_data_type": "dev.cosignproject.cosign/signature", "stderr": stderr},
+        )
+    elif re.match(r"^error: GET https://[^ ]+ MANIFEST_UNKNOWN:.*", stderr):
+        raise NotFoundException(
+            f'no trust data for image "{image}".',
+            {"trust_data_type": "dev.cosignproject.cosign/signature", "stderr": stderr},
+        )
+    else:
+        raise CosignError(
+            f'unexpected cosign exception for image "{image}": {stderr}.',
+            {"trust_data_type": "dev.cosignproject.cosign/signature"},
+        )
+    if not digests:
+        raise UnexpectedCosignData(
+            "could not extract any digest from data received by cosign "
+            "despite successful image verification."
+        )
+    return digests
+
+
+def invoke_cosign(image, pubkey):
+    """
+    Invokes a cosign binary in a subprocess for a specific `image` given a `pubkey` and
+    returns the returncode, stdout and stderr. Will raise an exception if cosign times out.
+    """
+
+    decode_and_verify_ecdsa_key(pubkey)  # raises if invalid; return value not used
+    cmd = ["/app/cosign/cosign", "verify", "-key", "/dev/stdin", image]
+    stdinput = f"-----BEGIN PUBLIC KEY-----\n{pubkey}\n-----END PUBLIC KEY-----"
+
+    with subprocess.Popen(  # nosec
+        cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as process:
+        try:
+            stdout, stderr = process.communicate(bytes(stdinput, "utf-8"), timeout=60)
+        except subprocess.TimeoutExpired as err:
+            process.kill()
+            raise CosignTimeout(
+                "cosign timed out.",
+                {"trust_data_type": "dev.cosignproject.cosign/signature"},
+            ) from err
+
+    return process.returncode, stdout.decode("utf-8"), stderr.decode("utf-8")

--- a/connaisseur/tests/data/cosign_error_no_data.txt
+++ b/connaisseur/tests/data/cosign_error_no_data.txt
@@ -1,0 +1,1 @@
+error: GET https://index.docker.io/v2/securesystemsengineering/connaisseur/manifests/sha256-495079f059a9398471a2b3eb3c27c97b160282a7bf73bd8e7b5056aa5cbb2277.cosign: MANIFEST_UNKNOWN: manifest unknown; map[Tag:sha256-495079f059a9398471a2b3eb3c27c97b160282a7bf73bd8e7b5056aa5cbb2277.cosign]

--- a/connaisseur/tests/data/cosign_error_wrong_key.txt
+++ b/connaisseur/tests/data/cosign_error_wrong_key.txt
@@ -1,0 +1,3 @@
+error: no matching signatures:
+unable to verify signature
+ unable to verify signature

--- a/connaisseur/tests/integration/cosign-integration-test.sh
+++ b/connaisseur/tests/integration/cosign-integration-test.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+set -euo pipefail
+
+# This script is expected to be called from the root folder of Connaisseur
+
+echo 'Preparing Connaisseur config...'
+yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' helm/values.yaml connaisseur/tests/integration/cosign-update.yaml
+echo 'Config set'
+
+echo 'Installing Connaisseur...'
+make install || { echo 'Failed to install Connaisseur'; exit 1; }
+echo 'Successfully installed Connaisseur'
+
+echo 'Testing unsigned image...'
+kubectl run pod --image=securesystemsengineering/testimage:co-unsigned >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: no trust data for image "docker.io/securesystemsengineering/testimage:co-unsigned".' ]]; then
+  echo 'Failed to deny unsigned image or failed with unexpected error. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied usage of unsigned image'
+fi
+
+echo 'Testing image signed under different key...'
+kubectl run pod --image=securesystemsengineering/testimage:co-signed-alt >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: failed to verify signature of trust data.' ]]; then
+  echo 'Failed to deny image signed with different key or failed with unexpected error. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied usage of image signed under different key'
+fi
+
+echo 'Testing signed image...'
+kubectl run pod --image=securesystemsengineering/testimage:co-signed >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
+  echo 'Failed to allow signed image. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully allowed usage of signed image'
+fi
+
+echo 'Uninstalling Connaisseur...'
+make uninstall || { echo 'Failed to uninstall Connaisseur'; exit 1; }
+echo 'Successfully uninstalled Connaisseur'
+
+rm output.log
+echo 'Passed integration test'

--- a/connaisseur/tests/integration/cosign-update.yaml
+++ b/connaisseur/tests/integration/cosign-update.yaml
@@ -1,0 +1,22 @@
+deployment:
+  imagePullPolicy: Never
+notary:
+  host: notary.docker.io
+  selfsigned: false
+  auth:
+    enabled: false
+  rootPubKey: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvtc/qpHtx7iUUj+rRHR99a8mnGni
+    qiGkmUb9YpWWTS4YwlvwdmMDiGzcsHiDOYz6f88u2hCRF5GUCvyiZAKrsA==
+    -----END PUBLIC KEY-----
+  isCosign: true
+policy:
+  - pattern: "*:*"
+    verify: true
+  - pattern: "k8s.gcr.io/*:*"
+    verify: false
+  - pattern: "docker.io/securesystemsengineering/connaisseur:*"
+    verify: true
+  - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook-*"
+    verify: false

--- a/connaisseur/tests/test_crypto.py
+++ b/connaisseur/tests/test_crypto.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import connaisseur.crypto
+from connaisseur.exceptions import InvalidPublicKey
 
 root_pub = (
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtR5kwrDK22SyCu"
@@ -43,3 +44,30 @@ def get_message(path: str):
 )
 def test_verify_signature(crypto, public: str, signature: str, message: str):
     assert crypto.verify_signature(public, signature, message)
+
+
+@pytest.mark.parametrize(
+    "base64encoded_key",
+    [
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6uuXbZhEfTYb4Mnb/LdrtXKTIIbzNBp8mw"
+        "riocbaxXxzquvbZpv4QtOTPoIw+0192MW9dWlSVaQPJd7IaiZIIQ==",
+        targets_pub,
+    ],
+)
+def test_decode_and_verify_ecdsa_key(base64encoded_key):
+    connaisseur.crypto.decode_and_verify_ecdsa_key(base64encoded_key)
+
+
+@pytest.mark.parametrize(
+    "base64encoded_key",
+    [
+        "somekey==",
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6uuXbZhEfTYb4Mnb/LdrtXKTIIbzNBp8mw"
+        "riocbaxXxzquvbZpv4QtOTPoIw+0192MW9dWlSVaQPJd7IaiZIIQ=",
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6uuXbZhEfTnb/LdrtXKTIIbzNBp8mw"
+        "riocbaxXxzquvbZpv4QtOTPoIw+0192MW9dWlSVaQPJd7IaiZIIQ==",
+    ],
+)
+def test_decode_and_verify_ecdsa_key_invalid_key_error(base64encoded_key):
+    with pytest.raises(InvalidPublicKey):
+        connaisseur.crypto.decode_and_verify_ecdsa_key(base64encoded_key)

--- a/connaisseur/tests/test_exceptions.py
+++ b/connaisseur/tests/test_exceptions.py
@@ -29,7 +29,7 @@ def test_exception_str(excep):
         ("Hello", "1", "Hello (not denied due to DETECTION_MODE)"),
     ],
 )
-def test_exception_user_msg(excep, msg, dm, out):
-    os.environ["DETECTION_MODE"] = dm
+def test_exception_user_msg(monkeypatch, excep, msg, dm, out):
+    monkeypatch.setenv("DETECTION_MODE", dm)
     ex = excep.BaseConnaisseurException(msg, {"you": "there"})
     assert ex.user_msg == out

--- a/connaisseur/tests/test_sigstore_validator.py
+++ b/connaisseur/tests/test_sigstore_validator.py
@@ -1,0 +1,261 @@
+import pytest
+import pytest_subprocess
+import subprocess
+
+import connaisseur.sigstore_validator as sigstore_validator
+from connaisseur.exceptions import (
+    NotFoundException,
+    ValidationError,
+    CosignError,
+    CosignTimeout,
+    UnexpectedCosignData,
+)
+
+cosign_payload = '{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7"},"Type":"cosign container signature"},"Optional":null}'
+cosign_multiline_payload = """
+{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:2f6d89c49ad745bfd5d997f9b2d253329323da4c500c7fe343e068c0382b8df4"},"Type":"cosign container signature"},"Optional":null}
+{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:2f6d89c49ad745bfd5d997f9b2d253329323da4c500c7fe343e068c0382b8df4"},"Type":"cosign container signature"},"Optional":{"foo":"bar"}}
+"""
+cosign_payload_unexpected_json_format = '{"Important":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7"},"Type":"cosign container signature"},"Optional":null}'
+cosign_payload_unexpected_digest_pattern = '{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha512:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7"},"Type":"cosign container signature"},"Optional":null}'
+
+cosign_nonjson_payload = "This is not json."
+cosign_combined_payload = "{}\n{}".format(cosign_payload, cosign_nonjson_payload)
+
+example_pubkey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6uuXbZhEfTYb4Mnb/LdrtXKTIIbzNBp8mwriocbaxXxzquvbZpv4QtOTPoIw+0192MW9dWlSVaQPJd7IaiZIIQ=="
+
+with open("tests/data/cosign_error_wrong_key.txt", "r") as readfile:
+    cosign_error_message_wrong_pubkey = readfile.read()
+
+with open("tests/data/cosign_error_no_data.txt", "r") as readfile:
+    cosign_error_message_no_cosign_signature = readfile.read()
+
+cosign_stderr_at_success = """
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - The signatures were verified against the specified public key
+  - Any certificates were verified against the Fulcio roots.
+"""
+
+
+@pytest.fixture()
+def mock_add_kill_fake_process(monkeypatch):
+    def mock_kill(self):
+        return
+
+    pytest_subprocess.core.FakePopen.kill = mock_kill
+
+
+@pytest.fixture()
+def mock_invoke_cosign(mocker, status_code, stdout, stderr):
+    mocker.patch(
+        "connaisseur.sigstore_validator.invoke_cosign",
+        return_value=(status_code, stdout, stderr),
+    )
+
+
+@pytest.mark.parametrize(
+    "status_code, stdout, stderr, image, output",
+    [
+        (
+            0,
+            cosign_payload,
+            cosign_stderr_at_success,
+            "testimage:v1",
+            ["c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7"],
+        ),
+        (
+            0,
+            cosign_combined_payload,
+            cosign_stderr_at_success,
+            "testimage:v1",
+            ["c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7"],
+        ),
+        (
+            0,
+            cosign_multiline_payload,
+            cosign_stderr_at_success,
+            "",
+            [
+                "2f6d89c49ad745bfd5d997f9b2d253329323da4c500c7fe343e068c0382b8df4",
+                "2f6d89c49ad745bfd5d997f9b2d253329323da4c500c7fe343e068c0382b8df4",
+            ],
+        ),
+    ],
+)
+def test_get_cosign_validated_digests(
+    mock_invoke_cosign, mocker, status_code, stdout, stderr, image, output
+):
+    mock_info_log = mocker.patch("logging.info")
+    digests = sigstore_validator.get_cosign_validated_digests(image, "sth")
+    mock_info_log.assert_has_calls(
+        [
+            mocker.call(
+                "COSIGN output for image: %s; RETURNCODE: %s; STDOUT: %s; STDERR: %s",
+                image,
+                status_code,
+                stdout,
+                stderr,
+            )
+        ]
+    )
+    if stdout == (cosign_nonjson_payload or cosign_combined_payload):
+        mock_info_log.assert_has_calls(
+            [
+                mocker.call(
+                    "non-json signature data from cosign: %s", cosign_nonjson_payload
+                )
+            ]
+        )
+    assert digests == output
+
+
+@pytest.mark.parametrize(
+    "status_code, stdout, stderr, image",
+    [
+        (1, "", cosign_error_message_wrong_pubkey, "testimage:v1"),
+    ],
+)
+def test_get_cosign_validated_digests_validation_error(
+    mock_invoke_cosign, status_code, stdout, stderr, image
+):
+    with pytest.raises(ValidationError) as err:
+        sigstore_validator.get_cosign_validated_digests(image, "sth")
+    assert "failed to verify signature of trust data." in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "status_code, stdout, stderr, image, error_message",
+    [
+        (
+            0,
+            cosign_payload_unexpected_json_format,
+            cosign_stderr_at_success,
+            "testimage:v1",
+            "could not retrieve valid and unambiguous digest from data received by cosign: KeyError: 'Critical'",
+        ),
+        (
+            0,
+            cosign_payload_unexpected_digest_pattern,
+            cosign_stderr_at_success,
+            "testimage:v1",
+            "could not retrieve valid and unambiguous digest from data received by cosign: "
+            "Exception: digest 'sha512:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7' "
+            "does not match expected digest pattern.",
+        ),
+        (
+            0,
+            cosign_nonjson_payload,
+            cosign_stderr_at_success,
+            "testimage:v1",
+            "could not extract any digest from data received by cosign "
+            "despite successful image verification.",
+        ),
+    ],
+)
+def test_get_cosign_validated_digests_unexpected_cosign_data_error(
+    mock_invoke_cosign, mocker, status_code, stdout, stderr, image, error_message
+):
+    with pytest.raises(UnexpectedCosignData) as err:
+        sigstore_validator.get_cosign_validated_digests(image, "sth")
+    assert error_message in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "status_code, stdout, stderr, image",
+    [
+        (1, "", cosign_error_message_no_cosign_signature, "testimage:v1"),
+    ],
+)
+def test_get_cosign_validated_digests_not_found_exception(
+    mock_invoke_cosign, status_code, stdout, stderr, image
+):
+    with pytest.raises(NotFoundException) as err:
+        sigstore_validator.get_cosign_validated_digests(image, "sth")
+    assert 'no trust data for image "testimage:v1"' in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "status_code, stdout, stderr, image",
+    [
+        (1, "", "Hm. Something weird happened.", "testimage:v1"),
+    ],
+)
+def test_get_cosign_validated_digests_cosign_error(
+    mock_invoke_cosign, status_code, stdout, stderr, image
+):
+    with pytest.raises(CosignError) as err:
+        sigstore_validator.get_cosign_validated_digests(image, "sth")
+    assert (
+        'unexpected cosign exception for image "testimage:v1": Hm. Something weird happened.'
+        in str(err.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "image, process_input",
+    [
+        (
+            "testimage:v1",
+            "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6uuXbZhEfTYb4Mnb/LdrtXKTIIbzNBp8mwriocbaxXxzquvbZpv4QtOTPoIw+0192MW9dWlSVaQPJd7IaiZIIQ==\n-----END PUBLIC KEY-----",
+        )
+    ],
+)
+def test_invoke_cosign(fake_process, image, process_input):
+    def stdin_function(input):
+        return {"stderr": input.decode(), "stdout": input}
+
+    # as we are mocking the subprocess the output doesn't change with the input. To check that the
+    # <process>.communicate() method is invoked with the correct input, we append it to stderr as explained in the docs
+    # https://pytest-subprocess.readthedocs.io/en/latest/usage.html#passing-input
+    # It seems there is a bug that, when appending the input to a data stream (e.g. stderr),
+    # eats the other data stream (stdout in that case). Thus, simply appending to both.
+    fake_process.register_subprocess(
+        ["/app/cosign/cosign", "verify", "-key", "/dev/stdin", image],
+        stderr=cosign_stderr_at_success,
+        stdout=bytes(cosign_payload, "utf-8"),
+        stdin_callable=stdin_function,
+    )
+    returncode, stdout, stderr = sigstore_validator.invoke_cosign(
+        "testimage:v1", example_pubkey
+    )
+    assert [
+        "/app/cosign/cosign",
+        "verify",
+        "-key",
+        "/dev/stdin",
+        image,
+    ] in fake_process.calls
+    assert (returncode, stdout, stderr) == (
+        0,
+        "{}{}".format(cosign_payload, process_input),
+        "{}{}".format(cosign_stderr_at_success, process_input),
+    )
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        "testimage:v1",
+    ],
+)
+def test_invoke_cosign_timeout_expired(
+    mocker, mock_add_kill_fake_process, fake_process, image
+):
+    def callback_function(input):
+        fake_process.register_subprocess(["test"], wait=0.5)
+        fake_process_raising_timeout = subprocess.Popen(["test"])
+        fake_process_raising_timeout.wait(timeout=0.1)
+
+    fake_process.register_subprocess(
+        ["/app/cosign/cosign", "verify", "-key", "/dev/stdin", image],
+        stdin_callable=callback_function,
+    )
+
+    mock_kill = mocker.patch("pytest_subprocess.core.FakePopen.kill")
+
+    with pytest.raises(CosignTimeout) as err:
+        sigstore_validator.invoke_cosign(image, example_pubkey)
+
+    mock_kill.assert_has_calls([mocker.call()])
+    assert "cosign timed out." in str(err.value)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,14 @@ WORKDIR /install
 COPY requirements.txt /requirements.txt
 RUN pip install --no-cache-dir --prefix=/install -r /requirements.txt
 
+# build cosign
+FROM golang:buster as go_builder
+
+ARG COSIGN_VERSION
+RUN git clone -b "v${COSIGN_VERSION}" --single-branch --depth 1 https://github.com/sigstore/cosign.git
+WORKDIR /go/cosign
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/cosign/main.go
+
 # build connaisseur image
 FROM base
 
@@ -19,6 +27,7 @@ RUN sh /harden.sh && rm /harden.sh
 
 # Copy source code and install packages
 COPY --from=builder /install /usr/local
+COPY --from=go_builder /go/cosign/main /app/cosign/cosign
 COPY connaisseur /app/connaisseur
 
 USER 1000:2000

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -34,6 +34,9 @@ data:
   {{- if .Values.notary.isAcr }}
   IS_ACR: "1"
   {{- end}}
+  {{- if .Values.notary.isCosign }}
+  IS_COSIGN: "1"
+  {{- end}}
   ALERT_CONFIG_DIR: "/app/config"
   {{- if .Values.alerting.cluster}}
   CLUSTER_NAME: {{ .Values.alerting.cluster }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,6 +52,10 @@ notary:
   # changes some behaviour, such as health probes and how to retrieve auth tokens
   # for compatibility with ACR set to `true`
   isAcr: false
+  # set to `true` if you want to use Cosign (https://github.com/sigstore/cosign)
+  # based image signature verification.
+  # NOTE: Cosign support is currently in an experimental state, as is cosign.
+  isCosign: false
 
 # the image policy, which defines all repositories that need to be
 # verified. more detail in the git repo README.md

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ parsedatetime~=2.6
 pylint~=2.7.2
 requests-mock~=1.8.0
 pytest-mock~=3.3.1
+pytest-subprocess~=1.0.1

--- a/setup/COSIGN.md
+++ b/setup/COSIGN.md
@@ -1,0 +1,111 @@
+# Using Connaisseur with Cosign signatures
+
+[Sigstore](https://sigstore.dev/) is a [Linux Foundation](https://linuxfoundation.org/) project that aims to provide public software signing and transparency to improve open source supply chain security. As part of the Sigstore project, [Cosign](https://github.com/sigstore/cosign) allows seamless container signing, verification and storage. You can read more about it [here](https://blog.sigstore.dev/cosign-signed-container-images-c1016862618).
+
+Connaisseur currently supports the elementary function of verifying Cosign-generated signatures against the locally created corresponding public keys. We plan to expose further features of Cosign and Sigstore in upcoming releases, so stay tuned!
+
+> :warning: Sigstore and Cosign are currently in *pre-release* state and under heavy development and so is our support for them. We therefore consider this an *experimental feature* that might unstable over time. As such, it is not part of our semantic versioning guarantees and we take the liberty to adjust or remove it with any version at any time without incrementing MAJOR or MINOR.
+
+## Demo
+![](../img/connaisseur_cosign.gif)
+
+## Signing Container Images with Cosign
+
+> **NOTE**: You can also do a minimal test without installing Cosign locally. In that case, skip this step and use our provided public key and `testimage`s below.
+
+Getting started with Cosign is very well described in the [docs](https://github.com/sigstore/cosign). Please check there for detailed instructions. The currently supported version can be found in our [Makefile](https://github.com/sse-secure-systems/connaisseur/blob/master/Makefile/#L5). In short: After installation, a keypair is generated via:
+
+```bash
+cosign generate-key-pair
+```
+
+You will be prompted to set a password, after which a private (`cosign.key`) and public (`cosign.pub`) key are created. You can then use Cosign to sign a container image using:
+
+```bash
+# Here, $IMAGE is REPOSITORY/IMAGE_NAME:TAG
+cosign sign -key cosign.key $IMAGE
+```
+
+The created signature can be verfied via:
+
+```bash
+cosign verify -key cosign.pub $IMAGE
+```
+
+
+
+## Configuring Connaisseur for Cosign Signatures
+
+Setting up Connaisseur for Cosign signatures only requires minor changes. In case of questions, please refer to the [default guide](README.md). In essence, you can just clone this repository:
+
+```bash
+git clone https://github.com/sse-secure-systems/connaisseur.git
+cd connaisseur
+```
+
+Next, configure Connaisseur to use Cosign and the previously created public key for validation via the `helm/values.yaml`.  To do so, copy your `cosign.pub` key into `notary.rootPubkey`. Here, at the example of our public key for our `testimage`s (you can also use this key and test with our images):
+
+```yaml
+# Replace the actual key part with your own key
+  rootPubKey: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvtc/qpHtx7iUUj+rRHR99a8mnGni
+    qiGkmUb9YpWWTS4YwlvwdmMDiGzcsHiDOYz6f88u2hCRF5GUCvyiZAKrsA==
+    -----END PUBLIC KEY-----
+```
+
+Next, set `notary.isCosign` to `true`:
+
+```yaml
+  isCosign: true
+```
+
+And finally, install Connaisseur via:
+
+```bash
+make install
+```
+
+
+
+## Test Signature Verification
+
+You can now test signature verification by deploying the signed image from above:
+
+```bash
+kubectl run signed --image=$IMAGE
+```
+
+Or attempt to deploy any another unsigned image which will fail.
+
+For the lazy ones, you can configure our public key provided in the previous section and test with our signed `testimage`:
+
+```bash
+kubectl run signed --image=docker.io/securesystemsengineering/testimage:co-signed
+```
+
+and compare to the unsigned `testimage`:
+
+```bash
+kubectl run unsigned --image=docker.io/securesystemsengineering/testimage:co-unsigned
+```
+
+or a `testimage` signed with a different key:
+
+```bash
+kubectl run unsigned --image=docker.io/securesystemsengineering/testimage:co-signed-alt
+```
+
+Once finished, you can clean up your cluster via:
+
+```bash
+make uninstall
+```
+
+
+
+## End
+
+Hope you enjoy the new feature and let us [know what you think](https://github.com/sse-secure-systems/connaisseur/discussions/137)!
+
+We are working on improving support for Cosign and Sigstore features. So stay tuned!


### PR DESCRIPTION
[sigstore](https://github.com/sigstore) project for software supply chain transparency and [sigstore/cosign](https://github.com/sigstore/cosign) for container signing and verification offer an alternative to Notary v1 and Notary v2. This is an initial tentative integration into Connaisseur.

Currently a rough first hack to get `cosign` on board and allow playing around with it as an experimental feature. Important next steps:

- [x] improve design and architectural approach
   - move signed digest identification into module
   - only use cosign when configured
   - fix parsing of stdout return
- [x] consider building signature verification ourselves to avoid having to inject cosign
   - [x] :arrow_right: create issue 
- [x] if injecting cosign: pull by version
   - [x] :arrow_right: create issue to verify signature
- [x] use `subprocess` module securely or avoid completely
   - rewrite the popen echo part properly
- [x] allow configuration via `values.yaml`
   - [x] :arrow_right: create separate issue/PR to handle additional/experimental features
- [x] how to handle same image with multiple signatures / different images with same tag but different signed digests
- [x] refactor and improve code quality
- [x] add error handling
- [x] tests, tests and more tests
   - [x] unit tests
   - [x] integration tests
   - [x] add `testimage:cosigned` to docker
- [x] README.md for cosign
- [x] comments

In case you want to test it, you will have to build the Conny image locally. To generate a key pair and sign your test image:
```
cosign generate-key-pair
cosign sign -key cosign.key <reponame>/<imagename>:signed
```
More details on cosign can be found in the docs: https://github.com/sigstore/cosign
The `cosign generate-key-pair` will yield a public key that has to be copied into `helm/values.yaml` as a trust root just like for Nv1.