### PR TITLE
ci: codecov fix

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -69,12 +69,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install packages
         run: pip3 install -r requirements_dev.txt && pip3 install .
+      - name: Install git and curl
+        run: apt update && apt install -y git curl
       - name: Test
         run: cd connaisseur && pytest --cov=connaisseur --cov-report=xml tests/
       - name: Upload code coverage
         uses: codecov/codecov-action@v1
         with:
           file: connaisseur/coverage.xml
+          fail_ci_if_error: true
 
   bandit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The code coverage silently fails, since the python:slim image doesn't contain git and curl for it to function. This is fixed.