### PR TITLE
ci/test: Test Connaisseur verification with target namespace

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -196,3 +196,34 @@ jobs:
           docker network connect kind ${SERVICE_CONTAINER_ID}
           export ALERTING_ENDPOINT_IP=$(docker network inspect kind | jq -r --arg container_id ${SERVICE_CONTAINER_ID}  '.[].Containers[$container_id].IPv4Address' | sed s+/.*++g)
           bash connaisseur/tests/integration/integration-test.sh
+
+  namespaced-integration-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
+      - name: Load Docker images
+        run: |
+          docker load -i ${GITHUB_SHA}_image.tar
+          docker load -i ${GITHUB_SHA}_hook.tar
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+      - name: Check KinD cluster
+        run: kubectl get nodes
+      - name: Add images to KinD
+        run: |
+          kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
+          kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
+
+      - name: Run actual integration test
+        run: bash connaisseur/tests/integration/namespaced-integration-test.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,3 +54,34 @@ jobs:
 
       - name: Run actual integration test
         run: bash connaisseur/tests/integration/integration-test.sh
+
+  namespaced-integration-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: images
+      - name: Load Docker images
+        run: |
+          docker load -i ${GITHUB_SHA}_image.tar
+          docker load -i ${GITHUB_SHA}_hook.tar
+      - name: Install yq and bash
+        run: |
+          sudo snap install yq
+          sudo apt update
+          sudo apt install bash -y
+      - name: Create KinD cluster
+        run: |
+          GO111MODULE="on" go get sigs.k8s.io/kind
+          kind create cluster --wait 120s
+      - name: Check KinD cluster
+        run: kubectl get nodes
+      - name: Add images to KinD
+        run: |
+          kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
+          kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
+
+      - name: Run actual integration test
+        run: bash connaisseur/tests/integration/namespaced-integration-test.sh

--- a/connaisseur/tests/integration/namespaced-integration-test.sh
+++ b/connaisseur/tests/integration/namespaced-integration-test.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+set -euo pipefail
+
+# This script is expected to be called from the root folder of Connaisseur
+
+echo 'Preparing Connaisseur config...'
+yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' helm/values.yaml connaisseur/tests/integration/namespaced-update.yaml
+echo 'Config set'
+
+echo 'Installing Connaisseur...'
+make install || { echo 'Failed to install Connaisseur'; exit 1; }
+echo 'Successfully installed Connaisseur'
+
+echo 'Testing unsigned image in protected namespace...'
+kubectl run pod --namespace verifyns --image=securesystemsengineering/testimage:unsigned >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/securesystemsengineering/testimage:unsigned" in trust data.' ]]; then
+  echo 'Failed to deny unsigned image or failed with unexpected error. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully denied usage of unsigned image'
+fi
+
+echo 'Testing signed image in protected namespace...'
+kubectl run pod --namespace verifyns --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
+  echo 'Failed to allow signed image. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully allowed usage of signed image'
+fi
+
+echo 'Testing unsigned image in unprotected namespace...'
+kubectl run pod --image=securesystemsengineering/testimage:unsigned >output.log 2>&1 || true
+
+if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
+  echo 'Failed to allow unsigned image in unprotected namespace. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully allowed usage of unsigned image in unprotected namespace'
+fi
+
+echo 'Uninstalling Connaisseur...'
+make uninstall || { echo 'Failed to uninstall Connaisseur'; exit 1; }
+echo 'Successfully uninstalled Connaisseur'
+
+rm output.log
+echo 'Passed integration test'

--- a/connaisseur/tests/integration/namespaced-update.yaml
+++ b/connaisseur/tests/integration/namespaced-update.yaml
@@ -1,0 +1,23 @@
+deployment:
+  imagePullPolicy: Never
+notary:
+  host: notary.docker.io
+  selfsigned: false
+  auth:
+    enabled: false
+  rootPubKey: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+    d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
+    -----END PUBLIC KEY-----
+policy:
+  - pattern: "*:*"
+    verify: true
+  - pattern: "k8s.gcr.io/*:*"
+    verify: false
+  - pattern: "docker.io/securesystemsengineering/connaisseur:*"
+    verify: true
+  - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook-*"
+    verify: false
+
+targetNamespaces: ["verifyns"]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,7 +69,7 @@ policy:
 # interrupting operation.
 detection_mode: false
 
-# A list of namespaces that will be subsequent to Connaisseur verification.
+# A list of namespaces that will be subject to Connaisseur verification.
 # If the list contains '*' - all namespaces will be monitored.
 targetNamespaces: ['*']
 


### PR DESCRIPTION
This commit adds an integration test for the namespaced verification behaviour of Connaisseur.

Fix #103