### PR TITLE
fix: fix error during build stage

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -69,12 +69,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install packages
         run: pip3 install -r requirements_dev.txt && pip3 install .
+      - name: Install git and curl
+        run: apt update && apt install -y git curl
       - name: Test
         run: cd connaisseur && pytest --cov=connaisseur --cov-report=xml tests/
       - name: Upload code coverage
         uses: codecov/codecov-action@v1
         with:
           file: connaisseur/coverage.xml
+          fail_ci_if_error: true
 
   bandit:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -161,6 +161,11 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: [build]
+    services:
+      alerting-endpoint:
+        image: securesystemsengineering/alerting-endpoint
+        ports:
+          - 56243:56243
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -185,6 +190,9 @@ jobs:
         run: |
           kind load docker-image $(yq e '.deployment.image' helm/values.yaml)
           kind load docker-image $(yq e '.deployment.helmHookImage' helm/values.yaml)
-
       - name: Run actual integration test
-        run: bash connaisseur/tests/integration/integration-test.sh
+        run: |
+          SERVICE_CONTAINER_ID=$(docker container ls --no-trunc --format "{{json . }}" | jq ' . | select(.Image|match("alerting-endpoint"))' | jq -r .ID)
+          docker network connect kind ${SERVICE_CONTAINER_ID}
+          export ALERTING_ENDPOINT_IP=$(docker network inspect kind | jq -r --arg container_id ${SERVICE_CONTAINER_ID}  '.[].Containers[$container_id].IPv4Address' | sed s+/.*++g)
+          bash connaisseur/tests/integration/integration-test.sh

--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -17,3 +17,5 @@ jobs:
         run: DOCKER_CONTENT_TRUST=1 docker pull docker.io/securesystemsengineering/testimage:signed
       - name: Check unsigned test image
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:unsigned
+      - name: Check alerting endpoint image
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/alerting-endpoint

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ samples/*
 demo/
 tls-*.conf
 .venv/
+venv/
+.idea/

--- a/.pylintrc
+++ b/.pylintrc
@@ -150,7 +150,6 @@ disable=print-statement,
         W0703,
         W0511,
 
-
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
 HELM_HOOK_IMAGE := $(shell yq e '.deployment.helmHookImage' helm/values.yaml)
-CLUSTER := $(shell CONTEXT=`kubectl config current-context` && kubectl config view -ojson | jq --arg CONTEXT $$CONTEXT '.contexts[] | select(.name==$$CONTEXT) | .context.cluster')
+CLUSTER := $(shell CONTEXT=`kubectl config current-context || true` && if [[ -z ${CONTEXT} ]];then echo "cluster not discoverable";else kubectl config view -ojson | jq --arg CONTEXT $$CONTEXT '.contexts[] | select(.name==$$CONTEXT) | .context.cluster';fi)
 
 .PHONY: all docker certs install unistall upgrade annihilate
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Connaisseur is an admission controller for Kubernetes that integrates Image Sign
   * [Makefile and Helm](#makefile-and-helm)
   * [Image Policy](#image-policy)
   * [Detection Mode](#detection-mode)
+  * [Alerting](#alerting)
 - [Threat Model](#threat-model)
   * [(1) Developer/User](#-1--developer-user)
   * [(2) Connaisseur Service](#-2--connaisseur-service)
@@ -139,6 +140,38 @@ In addition to the pattern, rules can also contain a `verify` flag which specifi
 A detection mode is available in order to avoid interruptions of a running cluster, to support initial rollout or for testing purposes. In detection mode, Connaisseur will admit all images to the cluster, but logs an error message for images that do not comply with the policy or in case of other unexpected failures.
 
 To activate the detection mode, set the `detection_mode` flag to `true` in `helm/values.yaml`.
+
+### Alerting
+
+You can receive notification on the admission decisions made by Connaisseur on basically every REST endpoint that accepts JSON payload. For Slack, Opsgenie and Keybase we have preconfigured payloads that are ready to use, but you can also use the existing payload templates as an example how to create your own custom one. It is also possible to configure multiple different interfaces you want to receive alerts at for each event category (admit/deny) in the `helm/values.yaml`.
+
+If you for example would like to receive notifications in Keybase whenever Connaisseur admits a request to your cluster, your alerting configuration would look similar to to following snippet:
+
+
+```
+alerting:
+  admit_request:
+    templates:
+      - template: keybase
+        receiver_url: https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>
+```
+
+For each element in `templates`, both `template` as well as `receiver_url` are required. The value for `template` needs to match an existing file of the pattern `helm/alert_payload_templates/<template>.json`; so if you want to use a predefined one it needs to be one of `slack`, `keybase` or `opsgenie`. For some REST endpoints like e.g. Opsgenie you need to configure a additional headers which you can pass to `custom_headers` as a list of plain string like e.g. `["Authorization: GenieKey <Your-Genie-Key>"]`. Setting `fail_if_alert_sending_fails` to `True` will make Connaisseur deny images if the corresponding alert cannot be successfully sent. This, obviously, makes sense only for requests that Connaisseur would have admitted as other requests would have been denied in the first place. The setting can come handy if you want to run Connaisseur in detection mode but still make sure that you get notified about what is going on in your cluster. *However, this setting will block everyone from contributing if the alert sending fails permanently. It could occur that your developers are blocked if the third party interface is down because somebody accidentally deleted your Slack Webhook App or your configuration has expired because your GenieKey expired!*
+
+| key                                                |  accepted values                                      | required               |
+| -------------------------------------------------- | ----------------------------------------------------  | ---------------------  |
+| `alerting.<category>.template`                     | `opsgenie`, `slack`, `keybase` or custom <sup>*</sup> | yes                    |
+| `alerting.<category>.receiver_url`                 | string                                                | yes                    |
+| `alerting.<category>.priority`                     | int                                                   | no (default: `3`)      |
+| `alerting.<category>.custom_headers`               | list[string]                                          | no                     |
+| `alerting.<category>.payload_fields`               | subyaml                                               | no                     |
+| `alerting.<category>.fail_if_alert_sending_fails`  | bool                                                  | no (default: `False`)  |
+
+<sup>* the basename of a custom template file in `helm/alerting_payload_templates` without file extension </sup>
+
+Along the lines of the templates that are already there you can easily define your custom template for your own endpoint. The following variables can be rendered during runtime into your payload: `alert_message`, `priority`, `connaisseur_pod_id`, `cluster`, `timestamp`, `request_id` and `images`. Rendering is done by Jinja2; so if you want to have a timestamp in your payload later on you can use `{{ timestamp }}` in your template. You can update your payload dynamically by adding payload fields in `yaml` presentation in the `payload_fields` key which will be translated to JSON by helm as is. If your REST endpoint requires particular headers, your can specify them as described above in `custom_headers`.
+
+Feel free to open a PR if you add new neat templates for other third parties!
 
 ## Threat Model
 

--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import os
+from datetime import datetime
+
+import requests
+from jinja2 import Template, StrictUndefined
+from jsonschema import validate as json_validate
+
+from connaisseur.util import safe_path_func
+from connaisseur.exceptions import AlertSendingError, ConfigurationError
+from connaisseur.image import Image
+from connaisseur.mutate import get_container_specs
+
+
+class Alert:
+    """
+    Class to store image information about an alert as attributes and a sending functionality as method.
+    Alert Sending can, depending on the configuration, throw an AlertSendingError causing Connaisseur
+    responding with status code 500 to the request that was sent for admission control,
+    causing a Kubernetes Error event.
+    """
+
+    template: str
+    receiver_url: str
+    payload: dict
+    headers: dict
+
+    context: dict
+    admission_request: dict
+    throw_if_alert_sending_fails: bool
+
+    def __init__(self, alert_message, receiver_config, admission_request):
+        self.context = {
+            "alert_message": alert_message,
+            "priority": str(receiver_config.get("priority", 3)),
+            "connaisseur_pod_id": os.getenv("POD_NAME"),
+            "cluster": os.getenv("CLUSTER_NAME"),
+            "timestamp": datetime.now(),
+            "request_id": admission_request.get("request", {}).get(
+                "uid", "No given UID"
+            ),
+            "images": (str(get_images(admission_request)) or "No given images"),
+        }
+        self.admission_request = admission_request
+        self.receiver_url = receiver_config["receiver_url"]
+        self.template = receiver_config["template"]
+        self.throw_if_alert_sending_fails = receiver_config.get(
+            "fail_if_alert_sending_fails", False
+        )
+        self.payload = self._construct_payload(receiver_config)
+        self.headers = self._get_headers(receiver_config)
+
+    def _construct_payload(self, receiver_config):
+        try:
+            alert_templates_dir = f'{os.getenv("ALERT_CONFIG_DIR")}/templates'
+            with safe_path_func(
+                open,
+                alert_templates_dir,
+                f"{alert_templates_dir}/{self.template}.json",
+                "r",
+            ) as templatefile:
+                template = json.load(templatefile)
+        except Exception as err:
+            raise ConfigurationError(
+                "Template file for alerting payload is either missing or invalid JSON: {}".format(
+                    str(err)
+                )
+            ) from err
+        payload = self._render_template(template)
+        if receiver_config.get("payload_fields") is not None:
+            payload.update(receiver_config.get("payload_fields"))
+        return json.dumps(payload)
+
+    def _render_template(self, template):
+        if isinstance(template, dict):
+            for key in template.keys():
+                template[key] = self._render_template(template[key])
+        elif isinstance(template, list):
+            template[:] = [self._render_template(entry) for entry in template]
+        elif isinstance(template, str):
+            template = Template(template).render(
+                self.context, undefined=StrictUndefined
+            )
+        return template
+
+    def send_alert(self):
+        try:
+            response = requests.post(
+                self.receiver_url, data=self.payload, headers=self.headers
+            )
+            response.raise_for_status()
+            logging.info("sent alert to %s", self.template)
+        except Exception as err:
+            if self.throw_if_alert_sending_fails:
+                raise AlertSendingError(str(err)) from err
+            logging.error(err)
+        return response
+
+    @staticmethod
+    def _get_headers(receiver_config):
+        headers = {"Content-Type": "application/json"}
+        additional_headers = receiver_config.get("custom_headers")
+        if additional_headers is not None:
+            for header in additional_headers:
+                key, value = header.split(":", 1)
+                headers.update({key.strip(): value.strip()})
+        return headers
+
+
+def load_config():
+    try:
+        alert_config_dir = f'{os.getenv("ALERT_CONFIG_DIR")}'
+        with safe_path_func(
+            open, alert_config_dir, f"{alert_config_dir}/alertconfig.json", "r"
+        ) as configfile:
+            alertconfig = json.load(configfile)
+        schema = get_alert_config_validation_schema()
+        json_validate(instance=alertconfig, schema=schema)
+    except Exception as err:
+        raise ConfigurationError(
+            "Alerting configuration file either not present or not valid."
+            "Check in the 'helm/values.yml' whether everything is correctly configured. {}".format(
+                str(err)
+            )
+        ) from err
+    return alertconfig
+
+
+def get_images(admission_request):
+    relevant_spec = get_container_specs(
+        admission_request.get("request", {}).get("object", {})
+    )
+    return list(map(lambda x: x.get("image"), relevant_spec))
+
+
+def send_alerts(admission_request, *, admitted, reason=None):
+    alert_config = load_config()
+    event_category = "admit_request" if admitted else "reject_request"
+    if alert_config.get(event_category) is not None:
+        for receiver in alert_config[event_category]["templates"]:
+            message = (
+                "CONNAISSEUR admitted a request."
+                if admitted
+                else "CONNAISSEUR rejected a request: {}".format(reason)
+            )
+            alert = Alert(message, receiver, admission_request)
+            alert.send_alert()
+
+
+def call_alerting_on_request(admission_request, *, admitted):
+    normalized_hook_image = Image(os.getenv("HELM_HOOK_IMAGE"))
+    hook_image = "{}/{}/{}:{}".format(
+        normalized_hook_image.registry,
+        normalized_hook_image.repository,
+        normalized_hook_image.name,
+        normalized_hook_image.tag,
+    )
+    images = []
+    for image in get_images(admission_request):
+        normalized_image = Image(image)
+        images.append(
+            "{}/{}/{}:{}".format(
+                normalized_image.registry,
+                normalized_image.repository,
+                normalized_image.name,
+                normalized_image.tag,
+            )
+        )
+    if images == [hook_image]:
+        return False
+    return not no_alerting_configured_for_event(admitted)
+
+
+def no_alerting_configured_for_event(admitted):
+    config = load_config()
+    templates = (
+        config.get("admit_request") if admitted else config.get("reject_request")
+    )
+    return templates is None
+
+
+def get_alert_config_validation_schema():
+    with open("connaisseur/res/alertconfig_schema.json") as schemafile:
+        return json.load(schemafile)

--- a/connaisseur/exceptions.py
+++ b/connaisseur/exceptions.py
@@ -55,3 +55,23 @@ class UnknownVersionError(Exception):
 
 class AmbiguousDigestError(BaseConnaisseurException):
     pass
+
+
+class AlertingException(Exception):
+
+    message: str
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__()
+
+    def __str__(self):
+        return str(self.__dict__)
+
+
+class ConfigurationError(AlertingException):
+    pass
+
+
+class AlertSendingError(AlertingException):
+    pass

--- a/connaisseur/mutate.py
+++ b/connaisseur/mutate.py
@@ -24,7 +24,7 @@ def get_container_specs(request_object: dict):
     Returns the container specifications of the `request_object`, based on its
     type.
     """
-    object_kind = request_object["kind"]
+    object_kind = request_object.get("kind")
     if object_kind == "Pod":
         relevant_spec = request_object["spec"]
         init_containers = relevant_spec.get("initContainers", [])
@@ -46,6 +46,7 @@ def get_container_specs(request_object: dict):
         relevant_spec = request_object["spec"]["template"]["spec"]
         init_containers = relevant_spec.get("initContainers", [])
         return relevant_spec["containers"] + init_containers
+    return []
 
 
 def get_json_patch(object_kind: str, index: int, image_name: str):

--- a/connaisseur/res/alertconfig_schema.json
+++ b/connaisseur/res/alertconfig_schema.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "properties": {
+    "admit_request": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string"
+              },
+              "receiver_url": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "custom_headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "payload_fields": {
+                "type": "object"
+              },
+              "fail_if_alert_sending_fails": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "template",
+              "receiver_url"
+            ]
+          }
+        }
+      },
+      "required": [
+        "templates"
+      ]
+    },
+    "reject_request": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string"
+              },
+              "receiver_url": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "custom_headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "payload_fields": {
+                "type": "object"
+              },
+              "fail_if_alert_sending_fails": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "template",
+              "receiver_url"
+            ]
+          }
+        }
+      },
+      "required": [
+        "templates"
+      ]
+    }
+  }
+}

--- a/connaisseur/tests/data/ad_request_allowlisted.json
+++ b/connaisseur/tests/data/ad_request_allowlisted.json
@@ -1,0 +1,161 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "request": {
+        "uid": "309781a9-a170-480e-a44e-c107e13783fa",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "resource": {
+            "group": "",
+            "version": "v1",
+            "resource": "pods"
+        },
+        "requestKind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "requestResource": {
+            "group": "",
+            "version": "v1",
+            "resource": "pods"
+        },
+        "name": "connaisseur-integration-test-pod",
+        "namespace": "default",
+        "operation": "CREATE",
+        "userInfo": {
+            "username": "minikube-user",
+            "groups": [
+                "system:masters",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "connaisseur-integration-test-pod",
+                "namespace": "default",
+                "creationTimestamp": null,
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"connaisseur-integration-test-pod\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"sh\",\"-c\",\"echo The app is running! \\u0026\\u0026 sleep 3600\"],\"image\":\"docker.io/securesystemsengineering/connaisseur:helm-hook\",\"name\":\"valid_container\"}]}}\n"
+                },
+                "managedFields": [
+                    {
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "apiVersion": "v1",
+                        "time": "2020-12-02T08:25:13Z",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:metadata": {
+                                "f:annotations": {
+                                    ".": {},
+                                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:containers": {
+                                    "k:{\"name\":\"valid_container\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {},
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {}
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:enableServiceLinks": {},
+                                "f:initContainers": {
+                                    ".": {},
+                                    "k:{\"name\":\"unsigned_init_container\"}": {
+                                        ".": {},
+                                        "f:command": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {},
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {}
+                                    }
+                                },
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:terminationGracePeriodSeconds": {}
+                            }
+                        }
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-t54kr",
+                        "secret": {
+                            "secretName": "default-token-t54kr"
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "valid_container",
+                        "image": "docker.io/securesystemsengineering/connaisseur:helm-hook",
+                        "command": [
+                            "sh",
+                            "-c",
+                            "echo The app is running! && sleep 3600"
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-t54kr",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true
+            },
+            "status": {}
+        },
+        "oldObject": null,
+        "dryRun": false,
+        "options": {
+            "kind": "CreateOptions",
+            "apiVersion": "meta.k8s.io/v1"
+        }
+    }
+}

--- a/connaisseur/tests/data/alerting/alertconfig.json
+++ b/connaisseur/tests/data/alerting/alertconfig.json
@@ -1,0 +1,76 @@
+{
+    "admit_request": {
+        "templates": [
+            {
+                "custom_headers": [
+                    "Authorization: GenieKey <Your-Genie-Key>"
+                ],
+                "fail_if_alert_sending_fails": true,
+                "payload_fields": {
+                    "responders": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ],
+                    "tags": [
+                        "image_deployed"
+                    ],
+                    "visibleTo": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ]
+                },
+                "priority": 4,
+                "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+                "template": "opsgenie"
+            },
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack"
+            }
+        ]
+    },
+    "reject_request": {
+        "templates": [
+            {
+                "custom_headers": [
+                    "Content-Language: de-DE"
+                ],
+                "fail_if_alert_sending_fails": true,
+                "priority": 3,
+                "receiver_url": "https://bots.keybase.io/webhookbot/123",
+                "template": "keybase"
+            },
+            {
+                "custom_headers": [
+                    "Authorization: GenieKey <Your-Genie-Key>"
+                ],
+                "fail_if_alert_sending_fails": false,
+                "payload_fields": {
+                    "responders": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ],
+                    "tags": [
+                        "image_rejected"
+                    ],
+                    "visibleTo": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ]
+                },
+                "priority": 4,
+                "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+                "template": "opsgenie"
+            }
+        ]
+    }
+}

--- a/connaisseur/tests/data/alerting/alertconfig_schema.json
+++ b/connaisseur/tests/data/alerting/alertconfig_schema.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "properties": {
+    "admit_request": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string"
+              },
+              "receiver_url": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "custom_headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "payload_fields": {
+                "type": "object"
+              },
+              "fail_if_alert_sending_fails": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "template",
+              "receiver_url"
+            ]
+          }
+        }
+      },
+      "required": [
+        "templates"
+      ]
+    },
+    "reject_request": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "template": {
+                "type": "string"
+              },
+              "receiver_url": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "custom_headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              },
+              "payload_fields": {
+                "type": "object"
+              },
+              "fail_if_alert_sending_fails": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "template",
+              "receiver_url"
+            ]
+          }
+        }
+      },
+      "required": [
+        "templates"
+      ]
+    }
+  }
+}

--- a/connaisseur/tests/data/alerting/config_only_send_on_admit/alertconfig.json
+++ b/connaisseur/tests/data/alerting/config_only_send_on_admit/alertconfig.json
@@ -1,0 +1,38 @@
+{
+    "admit_request": {
+        "templates": [
+            {
+                "custom_headers": [
+                    "Authorization: GenieKey <Your-Genie-Key>"
+                ],
+                "fail_if_alert_sending_fails": true,
+                "payload_fields": {
+                    "responders": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ],
+                    "tags": [
+                        "deployed_an_image"
+                    ],
+                    "visibleTo": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ]
+                },
+                "priority": 4,
+                "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+                "template": "opsgenie"
+            },
+            {
+                "fail_if_alert_sending_fails": false,
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/<Your-Slack-Hook-Path>",
+                "template": "slack"
+            }
+        ]
+    }
+}

--- a/connaisseur/tests/data/alerting/config_only_send_on_reject/alertconfig.json
+++ b/connaisseur/tests/data/alerting/config_only_send_on_reject/alertconfig.json
@@ -1,0 +1,41 @@
+{
+    "reject_request": {
+        "templates": [
+            {
+                "custom_headers": [
+                    "Content-Language: de-DE"
+                ],
+                "fail_if_alert_sending_fails": false,
+                "priority": 3,
+                "receiver_url": "https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>",
+                "template": "keybase"
+            },
+            {
+                "custom_headers": [
+                    "Authorization: GenieKey <Your-Genie-Key>"
+                ],
+                "fail_if_alert_sending_fails": false,
+                "payload_fields": {
+                    "responders": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ],
+                    "tags": [
+                        "image_rejected"
+                    ],
+                    "visibleTo": [
+                        {
+                            "type": "user",
+                            "username": "testuser@testcompany.de"
+                        }
+                    ]
+                },
+                "priority": 4,
+                "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+                "template": "opsgenie"
+            }
+        ]
+    }
+}

--- a/connaisseur/tests/data/alerting/invalid_config/alertconfig.json
+++ b/connaisseur/tests/data/alerting/invalid_config/alertconfig.json
@@ -1,0 +1,12 @@
+{
+    "reject_request": {
+        "templates": [
+            {
+                "receiver_url": "https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>",
+                "fail_if_alert_sending_fails": "i should not be a string",
+                "priority": 3,
+                "template": "keybase"
+            }
+        ]
+    }
+}

--- a/connaisseur/tests/data/alerting/misconfigured_config/alertconfig.json
+++ b/connaisseur/tests/data/alerting/misconfigured_config/alertconfig.json
@@ -1,0 +1,12 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "fail_if_alert_sending_fails": false,
+                "priority": 3,
+                "template": "keybase"
+            }
+        ]
+    }
+}

--- a/connaisseur/tests/data/alerting/templates/custom.json
+++ b/connaisseur/tests/data/alerting/templates/custom.json
@@ -1,0 +1,14 @@
+[
+  {
+    "test": [
+      "{{ connaisseur_pod_id }}",
+      "{{ priority }}"
+    ]
+  },
+  {
+    "test1": [
+      "{{ alert_message }}",
+      "{{ cluster }}"
+    ]
+  }
+]

--- a/connaisseur/tests/data/alerting/templates/keybase.json
+++ b/connaisseur/tests/data/alerting/templates/keybase.json
@@ -1,0 +1,3 @@
+{
+    "msg": "@here\n\n\n*{{ alert_message }}* \n\n_*Cluster*_:                             {{ cluster }}\n_*Request ID*_:                      {{ request_id }}\n_*Images*_:                             {{ images }}\n_*Connaisseur Pod ID*_:       {{ connaisseur_pod_id }}\n_*Created*_:                           {{ timestamp }}\n_*Severity*_:                           {{ priority }}\n\nCheck the logs of `{{ connaisseur_pod_id }}` for more details!"
+}

--- a/connaisseur/tests/data/alerting/templates/opsgenie.json
+++ b/connaisseur/tests/data/alerting/templates/opsgenie.json
@@ -1,0 +1,16 @@
+{
+    "message": "{{ alert_message }}",
+    "alias": "{{ alert_message }} to deploy the images {{ images }}.",
+    "description":"{{ alert_message }} to deploy the following images:\n {{ images }} \n\n Please check the logs of the `{{ connaisseur_pod_id }}` for more details.",
+    "responders": [
+    ],
+    "visibleTo": [
+    ],
+    "actions": [
+    ],
+    "tags": [
+    ],
+    "details":{"pod":"{{ connaisseur_pod_id }}","cluster":"{{ cluster }}", "alert_created": "{{ timestamp }}", "request_id": "{{ request_id }}"},
+    "entity":"Connaisseur",
+    "priority":"P{{ priority }}"
+}

--- a/connaisseur/tests/data/alerting/templates/slack.json
+++ b/connaisseur/tests/data/alerting/templates/slack.json
@@ -1,0 +1,15 @@
+{
+     "text": "Connaisseur Slack Alert Message",
+     "blocks": [
+         {
+             "type": "divider"
+         },
+         {
+             "type": "section",
+             "text": {
+                 "type": "mrkdwn",
+                 "text": "*{{ alert_message }}* \n\n_*Cluster*_:                           {{ cluster }}\n_*Request ID*_:                     {{ request_id }}\n_*Images*_:                           {{ images }}\n_*Connaisseur Pod ID*_:       {{ connaisseur_pod_id }}\n_*Created*_:                          {{ timestamp }}\n_*Severity*_:                          {{ priority }}\n\nCheck the logs of `{{ connaisseur_pod_id }}` for more details!"
+             }
+         }
+     ]
+}

--- a/connaisseur/tests/integration/alerting/Dockerfile
+++ b/connaisseur/tests/integration/alerting/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+COPY ./app ./app
+WORKDIR app
+
+RUN apt-get update -y
+RUN pip3 install flask~=1.1.2
+
+EXPOSE 56243
+
+CMD ["python", "./alert_checker.py"]

--- a/connaisseur/tests/integration/alerting/app/alert_checker.py
+++ b/connaisseur/tests/integration/alerting/app/alert_checker.py
@@ -1,0 +1,72 @@
+from flask import Flask, request
+import json
+
+APP = Flask(__name__)
+
+endpoint_hits = {}
+opsgenie_endpoint_hits = 0
+slack_endpoint_hits = 0
+keybase_endpoint_hits = 0
+
+
+@APP.route("/")
+def show_endpoint_hits():
+    return endpoint_hits
+
+
+@APP.route("/opsgenie", methods=["POST"])
+def opsgenie_payload_verification():
+    with open("/app/opsgenie_payload.json", "r") as readfile:
+        opsgenie_test_payload = json.load(readfile)
+    if request.is_json is False:
+        return ("", 500)
+    payload = request.json
+    if (
+        payload.keys() != opsgenie_test_payload.keys()
+        or payload.get("details").keys() != opsgenie_test_payload.get("details").keys()
+    ):
+        APP.logger.error("Received payload differs from expected payload.")
+        return ("", 500)
+    global opsgenie_endpoint_hits
+    opsgenie_endpoint_hits += 1
+    endpoint_hits.update(
+        {"successful_requests_to_opsgenie_endpoint": opsgenie_endpoint_hits}
+    )
+    return ("", 200)
+
+
+@APP.route("/slack", methods=["POST"])
+def slack_payload_verification():
+    with open("/app/slack_payload.json", "r") as readfile:
+        slack_test_payload = json.load(readfile)
+    payload = request.json
+    if (
+        payload.keys() != slack_test_payload.keys()
+        or payload["blocks"][1].keys() != slack_test_payload["blocks"][1].keys()
+    ):
+        APP.logger.error("Received payload differs from expected payload.")
+        return ("", 500)
+    global slack_endpoint_hits
+    slack_endpoint_hits += 1
+    endpoint_hits.update({"successful_requests_to_slack_endpoint": slack_endpoint_hits})
+    return ("", 200)
+
+
+@APP.route("/keybase", methods=["POST"])
+def keybase_payload_verification():
+    with open("/app/keybase_payload.json", "r") as readfile:
+        keybase_test_payload = json.load(readfile)
+    payload = request.json
+    if payload.keys() != keybase_test_payload.keys():
+        APP.logger.error("Received payload differs from expected payload.")
+        return ("", 500)
+    global keybase_endpoint_hits
+    keybase_endpoint_hits += 1
+    endpoint_hits.update(
+        {"successful_requests_to_keybase_endpoint": keybase_endpoint_hits}
+    )
+    return ("", 200)
+
+
+if __name__ == "__main__":
+    APP.run(debug=True, host="0.0.0.0", port=56243)

--- a/connaisseur/tests/integration/alerting/app/keybase_payload.json
+++ b/connaisseur/tests/integration/alerting/app/keybase_payload.json
@@ -1,0 +1,3 @@
+{
+  "msg": "@here\n\n\n*CONNAISSEUR admitted a request* \n\n_*Cluster*_:                             minikube\n_*Request ID*_:                      3a3a7b38-5512-4a85-94bb-3562269e0a6a\n_*Images*_:                             ['securesystemsengineering/alice-image:test']\n_*Connaisseur Pod ID*_:       connaisseur-pod-123\n_*Created*_:                          now\n_*Severity*_:                           4\n\nCheck the logs of `connaisseur-pod-123` for more details!"
+}

--- a/connaisseur/tests/integration/alerting/app/opsgenie_payload.json
+++ b/connaisseur/tests/integration/alerting/app/opsgenie_payload.json
@@ -1,0 +1,17 @@
+{
+    "message": "CONNAISSEUR admitted a request",
+    "alias": "CONNAISSEUR admitted a request to deploy the images ['securesystemsengineering/alice-image:test'].",
+    "description": "CONNAISSEUR admitted a request to deploy the following images:\n ['securesystemsengineering/alice-image:test'] \n\n Please check the logs of the `connaisseur-pod-123` for more details.",
+    "responders": [{"type": "user", "username": "testuser@testcompany.de"}],
+    "visibleTo": [{"type": "user", "username": "testuser@testcompany.de"}],
+    "actions": [],
+    "tags": ["image_deployed"],
+    "details": {
+        "pod": "connaisseur-pod-123",
+        "cluster": "minikube",
+        "request_id": "3a3a7b38-5512-4a85-94bb-3562269e0a6a",
+        "alert_created": "now"
+    },
+    "entity": "Connaisseur",
+    "priority": "P4"
+}

--- a/connaisseur/tests/integration/alerting/app/slack_payload.json
+++ b/connaisseur/tests/integration/alerting/app/slack_payload.json
@@ -1,0 +1,13 @@
+{
+    "text": "Connaisseur Slack Alert Message",
+    "blocks": [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*CONNAISSEUR admitted a request* \n\n_*Cluster*_:                           minikube\n_*Request ID*_:                     3a3a7b38-5512-4a85-94bb-3562269e0a6a\n_*Images*_:                           ['securesystemsengineering/alice-image:test']\n_*Connaisseur Pod ID*_:       connaisseur-pod-123\n_*Created*_:                           now\n_*Severity*_:                          4\n\nCheck the logs of `connaisseur-pod-123` for more details!"
+            }
+        }
+    ]
+}

--- a/connaisseur/tests/integration/integration-test.sh
+++ b/connaisseur/tests/integration/integration-test.sh
@@ -2,9 +2,13 @@
 set -euo pipefail
 
 # This script is expected to be called from the root folder of Connaisseur
+declare -i NUMBER_OF_VALID_DEPLOYMENTS=0
+declare -i NUMBER_OF_INVALID_DEPLOYMENTS=0
 
 echo 'Preparing Connaisseur config...'
-yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' helm/values.yaml connaisseur/tests/integration/update.yaml
+envsubst < connaisseur/tests/integration/update.yaml > update
+yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' helm/values.yaml update
+rm update
 echo 'Config set'
 
 echo 'Installing Connaisseur...'
@@ -13,6 +17,7 @@ echo 'Successfully installed Connaisseur'
 
 echo 'Testing unsigned image...'
 kubectl run pod --image=securesystemsengineering/testimage:unsigned >output.log 2>&1 || true
+NUMBER_OF_INVALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/securesystemsengineering/testimage:unsigned" in trust data.' ]]; then
   echo 'Failed to deny unsigned image or failed with unexpected error. Output:'
@@ -24,6 +29,7 @@ fi
 
 echo 'Testing image signed under different key...'
 kubectl run pod --image=library/redis >output.log 2>&1 || true
+NUMBER_OF_INVALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: failed to verify signature of trust data.' ]]; then
   echo 'Failed to deny image signed with different key or failed with unexpected error. Output:'
@@ -35,6 +41,7 @@ fi
 
 echo 'Testing signed image...'
 kubectl run pod --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+NUMBER_OF_VALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow signed image. Output:'
@@ -46,6 +53,7 @@ fi
 
 echo 'Testing deployment of unsigned init container along with a valid container...'
 kubectl apply -f connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml >output.log 2>&1 || true
+NUMBER_OF_INVALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'Error from server: error when creating "connaisseur/tests/integration/valid_container_with_unsigned_init_container_image.yml": admission webhook "connaisseur-svc.connaisseur.svc" denied the request: could not find signed digest for image "docker.io/securesystemsengineering/testimage:unsigned" in trust data.' ]]; then
   echo 'Allowed an unsigned image via init container or failed due to an unexpected error handling init containers. Output:'
@@ -53,6 +61,27 @@ if [[ "$(cat output.log)" != 'Error from server: error when creating "connaisseu
   exit 1
 else
   echo 'Successfully denied unsigned image in init container'
+fi
+
+echo 'Checking whether alert endpoints have been called successfully'
+ENDPOINT_HITS=$(curl 127.0.0.1:56243 --header "Content-Type: application/json")
+let NUMBER_OF_DEPLOYMENTS=${NUMBER_OF_INVALID_DEPLOYMENTS}+${NUMBER_OF_VALID_DEPLOYMENTS}
+EXPECTED_ENDPOINT_HITS=$(jq -n \
+--argjson REQUESTS_TO_SLACK_ENDPOINT ${NUMBER_OF_DEPLOYMENTS} \
+--argjson REQUESTS_TO_OPSGENIE_ENDPOINT  ${NUMBER_OF_VALID_DEPLOYMENTS} \
+--argjson REQUESTS_TO_KEYBASE_ENDPOINT ${NUMBER_OF_INVALID_DEPLOYMENTS} \
+'{
+"successful_requests_to_slack_endpoint":$REQUESTS_TO_SLACK_ENDPOINT,
+"successful_requests_to_opsgenie_endpoint": $REQUESTS_TO_OPSGENIE_ENDPOINT,
+"successful_requests_to_keybase_endpoint": $REQUESTS_TO_KEYBASE_ENDPOINT
+}')
+echo "Hit the alerting endpoints ${ENDPOINT_HITS} times; expected was ${EXPECTED_ENDPOINT_HITS}."
+diff <(echo $ENDPOINT_HITS | jq -S .) <(echo $EXPECTED_ENDPOINT_HITS | jq -S .) >output.log 2>&1
+if [[ -s output.log ]]; then
+  cat output.log
+  exit 1
+else
+  echo 'Successfully called mocked alert endpoints'
 fi
 
 echo 'Uninstalling Connaisseur...'

--- a/connaisseur/tests/integration/update.yaml
+++ b/connaisseur/tests/integration/update.yaml
@@ -19,3 +19,38 @@ policy:
     verify: true
   - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook-*"
     verify: false
+alerting:
+  config_dir_path: "/app/config"
+  cluster_name: "minikube"
+  admit_request:
+    message: "CONNAISSEUR admitted a request"
+    templates:
+      - template: opsgenie
+        receiver_url: http://${ALERTING_ENDPOINT_IP}:56243/opsgenie
+        priority: 4
+        custom_headers: ["Authorization: GenieKey <Your-Genie-Key>"]
+        payload_fields:
+          responders:
+            - username: "testuser@testcompany.de"
+              type: user
+          visibleTo:
+            - username: "testuser@testcompany.de"
+              type: user
+          tags:
+            - "deployed_an_image"
+        fail_if_alert_sending_fails: True
+      - template: slack
+        receiver_url: http://${ALERTING_ENDPOINT_IP}:56243/slack
+        priority: 3
+        fail_if_alert_sending_fails: False
+  reject_request:
+    message: "CONNAISSEUR rejected a request"
+    templates:
+      - template: keybase
+        receiver_url: http://${ALERTING_ENDPOINT_IP}:56243/keybase
+        priority: 3
+        fail_if_alert_sending_fails: True
+      - template: slack
+        receiver_url: http://${ALERTING_ENDPOINT_IP}:56243/slack
+        priority: 3
+        fail_if_alert_sending_fails: False

--- a/connaisseur/tests/test_alert.py
+++ b/connaisseur/tests/test_alert.py
@@ -1,0 +1,495 @@
+import pytest
+from datetime import datetime, timedelta
+import json
+
+from connaisseur.alert import (
+    Alert,
+    send_alerts,
+    call_alerting_on_request,
+    get_alert_config_validation_schema,
+    load_config,
+)
+from connaisseur.exceptions import AlertSendingError, ConfigurationError
+
+with open("tests/data/ad_request_deployments.json", "r") as readfile:
+    admission_request_deployment = json.load(readfile)
+
+with open("tests/data/ad_request_allowlisted.json", "r") as readfile:
+    admission_request_allowlisted = json.load(readfile)
+
+with open("tests/data/alerting/alertconfig_schema.json", "r") as readfile:
+    alertconfig_schema = json.load(readfile)
+
+opsgenie_receiver_config_throw = {
+    "custom_headers": ["Authorization: GenieKey <Your-Genie-Key>"],
+    "fail_if_alert_sending_fails": True,
+    "payload_fields": {
+        "responders": [{"type": "user", "username": "testuser@testcompany.de"}],
+        "tags": ["image_deployed"],
+        "visibleTo": [{"type": "user", "username": "testuser@testcompany.de"}],
+    },
+    "priority": 4,
+    "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+    "template": "opsgenie",
+}
+
+opsgenie_receiver_config = {
+    "custom_headers": ["Authorization: GenieKey <Your-Genie-Key>"],
+    "fail_if_alert_sending_fails": False,
+    "payload_fields": {
+        "responders": [{"type": "user", "username": "testuser@testcompany.de"}],
+        "tags": ["image_rejected"],
+        "visibleTo": [{"type": "user", "username": "testuser@testcompany.de"}],
+    },
+    "priority": 4,
+    "receiver_url": "https://api.eu.opsgenie.com/v2/alerts",
+    "template": "opsgenie",
+}
+
+slack_receiver_config = {
+    "priority": 3,
+    "receiver_url": "https://hooks.slack.com/services/123",
+    "template": "slack",
+}
+
+custom_receiver_config = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "template": "custom",
+}
+
+keybase_receiver_config = {
+    "custom_headers": ["Content-Language: de-DE"],
+    "fail_if_alert_sending_fails": True,
+    "priority": 3,
+    "receiver_url": "https://bots.keybase.io/webhookbot/123",
+    "template": "keybase",
+}
+
+missing_template_receiver_config = {
+    "fail_if_alert_sending_fails": True,
+    "receiver_url": "www.my.custom.rest.endpoint.receiving.connaisseurs.post.requests.io",
+    "template": "my_own_custom_endpoint_for_which_I_forgot_to_create_a_payload_template",
+}
+
+alert_headers_opsgenie = {
+    "Content-Type": "application/json",
+    "Authorization": "GenieKey <Your-Genie-Key>",
+}
+
+alert_headers_slack = {"Content-Type": "application/json"}
+
+alert_payload_opsgenie_deployment = {
+    "message": "CONNAISSEUR admitted a request",
+    "alias": "CONNAISSEUR admitted a request to deploy the images ['securesystemsengineering/alice-image:test'].",
+    "description": "CONNAISSEUR admitted a request to deploy the following images:\n ['securesystemsengineering/alice-image:test'] \n\n Please check the logs of the `connaisseur-pod-123` for more details.",
+    "responders": [{"type": "user", "username": "testuser@testcompany.de"}],
+    "visibleTo": [{"type": "user", "username": "testuser@testcompany.de"}],
+    "actions": [],
+    "tags": ["image_deployed"],
+    "details": {
+        "pod": "connaisseur-pod-123",
+        "cluster": "minikube",
+        "alert_created": datetime.now(),
+        "request_id": "3a3a7b38-5512-4a85-94bb-3562269e0a6a",
+    },
+    "entity": "Connaisseur",
+    "priority": "P4",
+}
+
+alert_payload_slack_deployment = {
+    "text": "Connaisseur Slack Alert Message",
+    "blocks": [
+        {"type": "divider"},
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*CONNAISSEUR admitted a request* \n\n_*Cluster*_:                           minikube\n_*Request ID*_:                     3a3a7b38-5512-4a85-94bb-3562269e0a6a\n_*Images*_:                           ['securesystemsengineering/alice-image:test']\n_*Connaisseur Pod ID*_:       connaisseur-pod-123\n_*Created*_:                          ${datetime.now()}\n_*Severity*_:                          4\n\nCheck the logs of `connaisseur-pod-123` for more details!",
+            },
+        },
+    ],
+}
+
+injection_string = '"]}, "test": "Can I inject into json?", "cluster":'
+
+
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch):
+    monkeypatch.setenv("ALERT_CONFIG_DIR", "tests/data/alerting")
+    monkeypatch.setenv("POD_NAME", "connaisseur-pod-123")
+    monkeypatch.setenv("CLUSTER_NAME", "minikube")
+    monkeypatch.setenv(
+        "HELM_HOOK_IMAGE", "securesystemsengineering/connaisseur:helm-hook"
+    )
+
+
+@pytest.fixture()
+def mock_alertconfig_validation_schema(mocker):
+    mocker.patch(
+        "connaisseur.alert.get_alert_config_validation_schema",
+        return_value=alertconfig_schema,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_safe_path_func_load_config(mocker):
+    side_effect = lambda callback, base_dir, path, *args, **kwargs: callback(
+        path, *args, **kwargs
+    )
+    mocker.patch("connaisseur.alert.safe_path_func", side_effect)
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request, alert_payload, alert_headers",
+    [
+        (
+            "CONNAISSEUR admitted a request",
+            opsgenie_receiver_config_throw,
+            admission_request_deployment,
+            alert_payload_opsgenie_deployment,
+            alert_headers_opsgenie,
+        ),
+        (
+            "CONNAISSEUR admitted a request",
+            slack_receiver_config,
+            admission_request_deployment,
+            alert_payload_slack_deployment,
+            alert_headers_slack,
+        ),
+        (
+            "CONNAISSEUR does great",
+            custom_receiver_config,
+            admission_request_deployment,
+            [
+                {"test": ["connaisseur-pod-123", "3"]},
+                {"test1": ["CONNAISSEUR does great", "minikube"]},
+            ],
+            {"Content-Type": "application/json"},
+        ),
+        (
+            injection_string,
+            custom_receiver_config,
+            admission_request_deployment,
+            [
+                {"test": ["connaisseur-pod-123", "3"]},
+                {"test1": [injection_string, "minikube"]},
+            ],
+            {"Content-Type": "application/json"},
+        ),
+    ],
+)
+def test_alert(
+    mock_alertconfig_validation_schema,
+    message: str,
+    receiver_config: dict,
+    admission_request: dict,
+    alert_payload: dict,
+    alert_headers: dict,
+):
+    alert = Alert(message, receiver_config, admission_request)
+    assert alert.throw_if_alert_sending_fails == receiver_config.get(
+        "fail_if_alert_sending_fails", False
+    )
+    assert alert.receiver_url == receiver_config["receiver_url"]
+    assert alert.headers == alert_headers
+    payload = json.loads(alert.payload)
+    if receiver_config["template"] == "opsgenie":
+        assert payload["details"]["alert_created"] is not None
+        assert datetime.strptime(
+            payload["details"]["alert_created"], "%Y-%m-%d %H:%M:%S.%f"
+        ) > datetime.now() - timedelta(seconds=30)
+        payload["details"].pop("alert_created")
+        alert_payload["details"].pop("alert_created")
+        assert payload == alert_payload
+    if receiver_config["template"] == "slack":
+        assert (
+            alert_payload_slack_deployment["blocks"][1]["text"]["text"].split(
+                "Created"
+            )[0]
+            in json.loads(alert.payload)["blocks"][1]["text"]["text"]
+        )
+    if receiver_config["template"] == "custom":
+        assert alert_payload == json.loads(alert.payload)
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request",
+            missing_template_receiver_config,
+            admission_request_deployment,
+        ),
+    ],
+)
+def test_configuration_error_missing_template(
+    mock_alertconfig_validation_schema, message, receiver_config, admission_request
+):
+    with pytest.raises(ConfigurationError) as err:
+        Alert(message, receiver_config, admission_request)
+    assert (
+        "Template file for alerting payload is either missing or invalid JSON"
+        in str(err.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request",
+            slack_receiver_config,
+            admission_request_deployment,
+        ),
+    ],
+)
+def test_configuration_error_missing_or_invalid_config(
+    mock_alertconfig_validation_schema,
+    monkeypatch,
+    message,
+    receiver_config,
+    admission_request,
+):
+    alert_config_dirs = [
+        "tests/data/alerting/misconfigured_config",
+        "tests/data/alerting/invalid_config",
+    ]
+    for alert_config_dir in alert_config_dirs:
+        monkeypatch.setenv("ALERT_CONFIG_DIR", alert_config_dir)
+        with pytest.raises(ConfigurationError) as err:
+            load_config()
+        assert (
+            "Alerting configuration file either not present or not valid."
+            "Check in the 'helm/values.yml' whether everything is correctly configured"
+            in str(err.value)
+        )
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request",
+            opsgenie_receiver_config_throw,
+            admission_request_deployment,
+        ),
+    ],
+)
+def test_alert_sending_error(
+    requests_mock,
+    mock_alertconfig_validation_schema,
+    message: str,
+    receiver_config: dict,
+    admission_request: dict,
+):
+    requests_mock.post(
+        "https://api.eu.opsgenie.com/v2/alerts",
+        status_code=401,
+    )
+    with pytest.raises(AlertSendingError) as err:
+        alert = Alert(message, receiver_config, admission_request)
+        alert.send_alert()
+    assert (
+        "401 Client Error: None for url: https://api.eu.opsgenie.com/v2/alerts"
+        in str(err.value)
+    )
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request",
+            slack_receiver_config,
+            admission_request_deployment,
+        ),
+    ],
+)
+def test_log_alert_sending_error(
+    requests_mock,
+    mocker,
+    mock_alertconfig_validation_schema,
+    message: str,
+    receiver_config: dict,
+    admission_request: dict,
+):
+    mock_error_log = mocker.patch("logging.error")
+    requests_mock.post(
+        "https://hooks.slack.com/services/123",
+        status_code=401,
+    )
+    alert = Alert(message, receiver_config, admission_request)
+    alert.send_alert()
+    assert mock_error_log.called is True
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request.",
+            opsgenie_receiver_config,
+            admission_request_deployment,
+        )
+    ],
+)
+def test_alert_sending(
+    requests_mock,
+    mocker,
+    mock_alertconfig_validation_schema,
+    message: str,
+    receiver_config: dict,
+    admission_request: dict,
+):
+    mock_info_log = mocker.patch("logging.info")
+    requests_mock.post(
+        "https://api.eu.opsgenie.com/v2/alerts",
+        json={
+            "result": "Request will be processed",
+            "took": 0.302,
+            "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120",
+        },
+        status_code=200,
+    )
+    alert = Alert(message, receiver_config, admission_request)
+    response = alert.send_alert()
+    mock_info_log.assert_has_calls([mocker.call("sent alert to %s", "opsgenie")])
+    assert response.status_code == 200
+    assert response.json()["result"] == "Request will be processed"
+
+
+@pytest.mark.parametrize(
+    "message, receiver_config, admission_request",
+    [
+        (
+            "CONNAISSEUR admitted a request.",
+            opsgenie_receiver_config_throw,
+            admission_request_allowlisted,
+        ),
+    ],
+)
+def test_alert_sending_bypass_for_only_allowlisted_images(
+    mock_alertconfig_validation_schema,
+    message: str,
+    receiver_config: dict,
+    admission_request: dict,
+):
+    Alert(message, receiver_config, admission_request)
+
+
+@pytest.mark.parametrize(
+    "admission_request, admission_decision",
+    [
+        (admission_request_deployment, {"admitted": True}),
+        (admission_request_deployment, {"admitted": False}),
+    ],
+)
+def test_send_alerts(
+    mocker,
+    mock_alertconfig_validation_schema,
+    admission_decision: bool,
+    admission_request: dict,
+):
+    mock_alert = mocker.patch("connaisseur.alert.Alert")
+    send_alerts(admission_request, admitted=True)
+    admit_calls = [
+        mocker.call(
+            "CONNAISSEUR admitted a request.",
+            opsgenie_receiver_config_throw,
+            admission_request_deployment,
+        ),
+        mocker.call(
+            "CONNAISSEUR admitted a request.",
+            slack_receiver_config,
+            admission_request_deployment,
+        ),
+    ]
+    mock_alert.assert_has_calls(admit_calls, any_order=True)
+    mocker.resetall()
+    mocker.patch(
+        "connaisseur.alert.get_alert_config_validation_schema",
+        return_value=alertconfig_schema,
+    )
+    mock_alert = mocker.patch("connaisseur.alert.Alert")
+    send_alerts(admission_request, admitted=False, reason="Couldn't find trust data.")
+    reject_calls = [
+        mocker.call(
+            "CONNAISSEUR rejected a request: Couldn't find trust data.",
+            opsgenie_receiver_config,
+            admission_request_deployment,
+        ),
+        mocker.call(
+            "CONNAISSEUR rejected a request: Couldn't find trust data.",
+            keybase_receiver_config,
+            admission_request_deployment,
+        ),
+    ]
+    mock_alert.assert_has_calls(reject_calls, any_order=True)
+    mocker.resetall()
+
+    mock_alert_sending = mocker.patch(
+        "connaisseur.alert.Alert.send_alert", return_value=True
+    )
+    send_alerts(admission_request, **admission_decision)
+    assert mock_alert_sending.has_calls([mocker.call(), mocker.call()])
+
+
+@pytest.mark.parametrize(
+    "admission_request, admission_decision, alert_config_dir, alert_call_decision",
+    [
+        (
+            admission_request_deployment,
+            {"admitted": True},
+            "tests/data/alerting/config_only_send_on_reject",
+            False,
+        ),
+        (
+            admission_request_deployment,
+            {"admitted": True},
+            "tests/data/alerting/config_only_send_on_admit",
+            True,
+        ),
+        (
+            admission_request_deployment,
+            {"admitted": False},
+            "tests/data/alerting/config_only_send_on_admit",
+            False,
+        ),
+        (
+            admission_request_deployment,
+            {"admitted": False},
+            "tests/data/alerting",
+            True,
+        ),
+        (
+            admission_request_allowlisted,
+            {"admitted": False},
+            "tests/data/alerting",
+            False,
+        ),
+        (
+            admission_request_allowlisted,
+            {"admitted": True},
+            "tests/data/alerting",
+            False,
+        ),
+    ],
+)
+def test_call_alerting_on_request(
+    mock_alertconfig_validation_schema,
+    monkeypatch,
+    admission_request,
+    admission_decision,
+    alert_config_dir,
+    alert_call_decision,
+):
+    monkeypatch.setenv("ALERT_CONFIG_DIR", alert_config_dir)
+    decision = call_alerting_on_request(admission_request, **admission_decision)
+    assert decision == alert_call_decision
+
+
+def test_get_alert_config_validation_schema(mocker, mock_env_vars):
+    with open("tests/data/alerting/alertconfig_schema.json") as f:
+        content = f.read()
+    mocker.patch("builtins.open", mocker.mock_open(read_data=content))
+    assert get_alert_config_validation_schema() == alertconfig_schema

--- a/connaisseur/tests/test_mutate.py
+++ b/connaisseur/tests/test_mutate.py
@@ -594,7 +594,7 @@ def get_ad_request(path: str):
         (request_obj_daemonset, request_obj_output),
         (request_obj_statefulset, request_obj_output),
         (request_obj_job, request_obj_output),
-        (request_obj_tuftuf, None),
+        (request_obj_tuftuf, []),
         (request_obj_pod_with_init_container, request_obj_output_with_init_container),
         (
             request_obj_cronjob_with_init_container,

--- a/connaisseur/util.py
+++ b/connaisseur/util.py
@@ -1,5 +1,15 @@
+import os
+from connaisseur.exceptions import InvalidFormatException
+
+
 def normalize_delegation(delegation_role: str):
     prefix = "targets/"
     if not delegation_role.startswith(prefix):
         delegation_role = prefix + delegation_role
     return delegation_role
+
+
+def safe_path_func(callback: callable, base_dir: str, path: str, *args, **kwargs):
+    if os.path.commonprefix((os.path.realpath(path), base_dir)) != base_dir:
+        raise InvalidFormatException("potential path traversal.", {"path": path})
+    return callback(path, *args, **kwargs)

--- a/helm/alert_payload_templates/keybase.json
+++ b/helm/alert_payload_templates/keybase.json
@@ -1,0 +1,3 @@
+{
+    "msg": "@here\n\n\n*{{ alert_message }}* \n\n_*Cluster*_:                             {{ cluster }}\n_*Request ID*_:                      {{ request_id }}\n_*Images*_:                             {{ images }}\n_*Connaisseur Pod ID*_:       {{ connaisseur_pod_id }}\n_*Created*_:                           {{ timestamp }}\n_*Severity*_:                           {{ priority }}\n\nCheck the logs of `{{ connaisseur_pod_id }}` for more details!"
+}

--- a/helm/alert_payload_templates/opsgenie.json
+++ b/helm/alert_payload_templates/opsgenie.json
@@ -1,0 +1,16 @@
+{
+    "message": "{{ alert_message }}",
+    "alias": "{{ alert_message }} while deploying the images {{ images }}.",
+    "description": "{{ alert_message }} while deploying the following images:\n {{ images }} \n\n Please check the logs of the `{{ connaisseur_pod_id }}` for more details.",
+    "responders": [
+    ],
+    "visibleTo": [
+    ],
+    "actions": [
+    ],
+    "tags": [
+    ],
+    "details":{"pod":"{{ connaisseur_pod_id }}","cluster":"{{ cluster }}", "alert_created": "{{ timestamp }}", "request_id": "{{ request_id }}"},
+    "entity":"Connaisseur",
+    "priority":"P{{ priority }}"
+}

--- a/helm/alert_payload_templates/slack.json
+++ b/helm/alert_payload_templates/slack.json
@@ -1,0 +1,15 @@
+{
+     "text": "Connaisseur Slack Alert Message",
+     "blocks": [
+         {
+             "type": "divider"
+         },
+         {
+             "type": "section",
+             "text": {
+                 "type": "mrkdwn",
+                 "text": "*{{ alert_message }}* \n\n_*Cluster*_:                           {{ cluster }}\n_*Request ID*_:                     {{ request_id }}\n_*Images*_:                           {{ images }}\n_*Connaisseur Pod ID*_:       {{ connaisseur_pod_id }}\n_*Created*_:                          {{ timestamp }}\n_*Severity*_:                          {{ priority }}\n\nCheck the logs of `{{ connaisseur_pod_id }}` for more details!"
+             }
+         }
+     ]
+}

--- a/helm/templates/alertconfig.yaml
+++ b/helm/templates/alertconfig.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-alert-templates
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "helm.name" . }}
+    helm.sh/chart: {{ include "helm.chart" . }}
+    app.kubernetes.io/instance: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{- (.Files.Glob "alert_payload_templates/*").AsConfig | nindent 2 }}
+
+---
+
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Chart.Name }}-alertconfig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "helm.name" . }}
+    helm.sh/chart: {{ include "helm.chart" . }}
+    app.kubernetes.io/instance: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+stringData:
+  alertconfig.json: |
+    {{ mustToJson .Values.alerting | nindent 4 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             - name: {{ .Chart.Name }}-certs
               mountPath: /etc/certs
               readOnly: true
+            - name: {{ .Chart.Name }}-alert-templates
+              mountPath: "/app/config/templates"
+              readOnly: true
+            - name: {{ .Chart.Name }}-alertconfig
+              mountPath: "/app/config"
+              readOnly: true
           envFrom:
             - configMapRef:
                 name: {{ .Chart.Name }}-env
@@ -59,6 +65,11 @@ spec:
                 name: {{ .Chart.Name }}-secret-env
               {{- end }}
             {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:
@@ -91,3 +102,9 @@ spec:
         - name: {{ .Chart.Name }}-certs
           secret:
             secretName: {{ .Chart.Name }}-tls
+        - name: {{ .Chart.Name }}-alertconfig
+          secret:
+            secretName: {{ .Chart.Name }}-alertconfig
+        - name: {{ .Chart.Name }}-alert-templates
+          configMap:
+            name: {{ .Chart.Name }}-alert-templates

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -34,3 +34,10 @@ data:
   {{- if .Values.notary.isAcr }}
   IS_ACR: "1"
   {{- end}}
+  ALERT_CONFIG_DIR: "/app/config"
+  {{- if .Values.alerting.cluster}}
+  CLUSTER_NAME: {{ .Values.alerting.cluster }}
+  {{- else }}
+  {{- fail "Please provide a name for your cluster by appending 'helm install' by '--set alerting.cluster=<cluster_name>'. Using 'make' sets the cluster name automatically." }}
+  {{- end}}
+  HELM_HOOK_IMAGE: {{ .Values.deployment.helmHookImage }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v1.4.6
+  image: securesystemsengineering/connaisseur:v1.5.0
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
   resources: {}
@@ -63,6 +63,7 @@ policy:
   - pattern: "docker.io/securesystemsengineering/connaisseur:*"
     verify: false
 
+
 # in detection mode, deployment will not be denied, but only prompted
 # and logged. This allows testing the functionality without
 # interrupting operation.
@@ -73,3 +74,41 @@ detection_mode: false
 targetNamespaces: ['*']
 
 # debug: true
+
+# alerting is implemented in form of simple POST requests with json payload
+# you can use and/or adapt the predefined Slack/OpsGenie/Keybase templates and the examples below
+# to channel alert notifications to Slack/OpsGenie/Keybase or create a custom template for a customized alert
+# payload to use with a simple POST request to the receiver_url to receive alerts.
+# Parameters you can use in your templates are "alert_message", "priority", "connaisseur_pod_id", "cluster",
+# "timestamp", "request_id" and "images" each one basically meaning what their names indicate
+#
+# Below is an example config
+
+#alerting:
+#  admit_request:
+#    templates:
+#      # <template> needs to be chosen such that <template>.json matches one of the file names
+#      # in the ./alert_payload_templates directory
+#      - template: opsgenie #REQUIRED!
+#        receiver_url: https://api.eu.opsgenie.com/v2/alerts #REQUIRED!
+#        priority: 4 #(defaults to 3)
+#        custom_headers: ["Authorization: GenieKey <Your-Genie-Key>"]
+#        payload_fields:
+#          responders:
+#            - username: "testuser@testcompany.de"
+#              type: user
+#          visibleTo:
+#            - username: "testuser@testcompany.de"
+#              type: user
+#          tags:
+#            - "deployed_an_image"
+#        fail_if_alert_sending_fails: True  # (defaults to False, turning it to True will make Connaisseur deny your
+#                                           # deployment (even in detection mode))
+#      - template: slack #REQUIRED!
+#        receiver_url: https://hooks.slack.com/services/<Your-Slack-Hook-Path>
+#        priority: 1
+#  reject_request:
+#    templates:
+#      - template: keybase  #REQUIRED!
+#        receiver_url: https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>
+#        fail_if_alert_sending_fails: True

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,5 @@
 pytest-cov~=2.10.0
 parsedatetime~=2.6
 pylint~=2.7.2
+requests-mock~=1.8.0
+pytest-mock~=3.3.1


### PR DESCRIPTION
In cases where there is no kubecontext set (automatic builds) all make commands fail as the cluster variable is defined globally. In any case, no make command should fail in case the cluster variable cannot be discovered. This PR fixes this issue.