### PR TITLE
fix: Remove development files from image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,8 @@
 connaisseur/tests/
 # ignore img
 img/
+# ignore coverage files
+connaisseur/coverage.xml
+connaisseur/coverage.txt
+# ignore pycache
+connaisseur/__pycache__/


### PR DESCRIPTION
Previously, we erronously built with code coverage files and the python cache if it was present on the developer's machine