### PR TITLE
ci/test: Remove debug option from integration test server

### DIFF
--- a/connaisseur/tests/integration/alerting/app/alert_checker.py
+++ b/connaisseur/tests/integration/alerting/app/alert_checker.py
@@ -69,4 +69,4 @@ def keybase_payload_verification():
 
 
 if __name__ == "__main__":
-    APP.run(debug=True, host="0.0.0.0", port=56243)
+    APP.run(host="0.0.0.0", port=56243)


### PR DESCRIPTION
This commit removes the debug option from the flask server run during the integration test as it is not necessary and generates a security warning