### PR TITLE
docs: add information on github discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 We hope to steer development of Connaisseur from demand of the community and are excited about direct contributions to improve the tool!
 
-The following guide is meant to help you get started with contributing to Connaisseur. In case of questions, feel free to reach out to us.
+The following guide is meant to help you get started with contributing to Connaisseur. In case of questions or feedback, feel free to [reach out to us](https://github.com/sse-secure-systems/connaisseur/discussions).
 
 We are committed to positive interactions between all contributors of the project. To ensure this, please follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all communications.
 
@@ -15,7 +15,7 @@ We are committed to positive interactions between all contributors of the projec
 - [Enjoy!](#enjoy)
 
 ## Discuss Problems, Raise Bugs and Propose Feature Ideas
-We are happy you made it here! If you want to raise any bugs you found, discuss issues from using Connaisseur in your own projects or have ideas for new features to be implemented, please [create an issue](https://github.com/sse-secure-systems/connaisseur/issues/new) with an informative title and description.
+We are happy you made it here! In case you want to share your feedback, need support, want to discuss issues from using Connaisseur in your own projects, have ideas for new features or just want to connect with us, please reach out via [GitHub Discussions](https://github.com/sse-secure-systems/connaisseur/discussions). If you want to raise any bugs you found or make a feature request, feel free to [create an issue](https://github.com/sse-secure-systems/connaisseur/issues/new) with an informative title and description.
 
 While issues are a great way to discuss problems, bugs and new features, a direct proposal via a pull request can sometimes say more than a thousand words. So be bold and contribute to the code as described in the [next section](#contribute-to-source-code)!
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Connaisseur is an admission controller for Kubernetes that integrates Image Signature Verification into a cluster, as a means to ensure that only valid images are being deployed.
 
+Have feedback? Feel free to [reach out to us](https://github.com/sse-secure-systems/connaisseur/discussions)!
+
 ## Contents
 
 - [Introduction](#introduction)
@@ -24,6 +26,7 @@ Connaisseur is an admission controller for Kubernetes that integrates Image Sign
   * [(3) Notary Server](#-3--notary-server)
   * [(4) Registry](#-4--registry)
 - [Additional Information](#additional-information)
+- [Discussions, Support & Feedback](#discussions-support--feedback)
 - [Contributing](#contributing)
 - [Security Policy](#security-policy)
 - [Contact](#contact)
@@ -219,8 +222,11 @@ The STRIDE threat model has been used as a reference for threat modeling. Each o
 - An introduction to Connaisseur is available in our [Medium article](https://medium.com/sse-blog/container-image-signatures-in-kubernetes-19264ac5d8ce)
 - A recording on "Integrity of Docker images" diving into supply chain security, *The Update Framework*, *Notary*, *Docker Content Trust* and Connaisseur including a live demo is available on [YouTube](https://youtu.be/M3KAiBXhsPQ)
 
+## Discussions, Support & Feedback
+We hope to steer development of Connaisseur from demand of the community, are excited about your feedback and happy to help if you need support! So feel free to connect with us via [GitHub Discussions](https://github.com/sse-secure-systems/connaisseur/discussions).
+
 ## Contributing
-We hope to steer development of Connaisseur from demand of the community and are excited about direct contributions to improve the tool! Please refer to our [contributing guide](CONTRIBUTING.md) to learn how to contribute to Connaisseur.
+We are always excited about direct contributions to improve the tool! Please refer to our [contributing guide](CONTRIBUTING.md) to learn how to contribute to Connaisseur.
 
 ## Security Policy
 We are grateful for any community support reporting vulnerabilities! How to submit a report is described in our [Security Policy](SECURITY.md).

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,6 +1,6 @@
 # Setup
 
-Setting up Connaisseur for the first time can be a bit of a hassle, especially if you are not familiar with Docker Content Trust (DCT). Furthermore, Connaisseur requires/links several other services (Kubernetes cluster, container registry, notary server) for which many common providers exist. Hence, we've created multiple guides for various environments to help you on the way.
+Setting up Connaisseur for the first time can be a bit of a hassle, especially if you are not familiar with Docker Content Trust (DCT). Furthermore, Connaisseur requires/links several other services (Kubernetes cluster, container registry, notary server) for which many common providers exist. Hence, we've created multiple guides for various environments to help you on the way. If you still can't get it to work or have any feedback, feel free to reach out to us via [GitHub Discussions](https://github.com/sse-secure-systems/connaisseur/discussions)!
 
 The guide below offers a simple default configuration for setting up Connaisseur using public infrastructure and is aimed at quick testing. It uses [Docker Hub](https://hub.docker.com/) as both container registry and notary, but is expected to work for other solutions as well. It has been tested for the following Kubernetes services:
 - [x] [K3s](https://github.com/rancher/k3s)
@@ -256,4 +256,4 @@ In case you deployed the `signed` image above, you might want to clean that up b
 
 Congratulations, you have successfully deployed Connaisseur. When testing further with it, should you be missing features or run into bugs, do not hesitate to open either a Pull Request (see our [Contributing Guidelines](../CONTRIBUTING.md)) or [create an Issue](https://github.com/sse-secure-systems/connaisseur/issues/new) to let us know.
 
-Stay safe!
+Feel free to [share your feedback](https://github.com/sse-secure-systems/connaisseur/discussions) with us and stay safe!


### PR DESCRIPTION
GitHub Discussions can help us to better interact with the community beyond simple issues for bugs and feature requests. This commit makes this communication option transparent to our users.