### PR TITLE
ci:add kube-linter

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -41,6 +41,17 @@ jobs:
         run: |
           python3 -m black . 2>&1 | grep -q "reformatted" && { echo 'Not properly formatted.'; exit 1; } || true
 
+  kube-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Scan repo
+        id: kube-lint-repo
+        uses: stackrox/kube-linter-action@v1.0.0
+        with:
+          directory: helm
+          config: .kube-linter/config.yaml
+
   hadolint:
     runs-on: ubuntu-latest
     container:

--- a/.kube-linter/config.yaml
+++ b/.kube-linter/config.yaml
@@ -1,0 +1,2 @@
+checks:
+  doNotAutoAddDefaults: false

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,12 +13,14 @@ Releasing a new version of Connaisseur includes the following steps:
 
 ## Check readiness
 
-Before starting the release, make sure everything is ready and in order.
-See that all tests are running smoothly.
-Check that documentation changes show up correctly [here](https://sse-secure-systems.github.io/connaisseur/develop/).
-Make sure the Connaisseur version is incremented correctly according to the changes.
-See if the docs announcements should be adjusted [here](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/overrides/main.html).
-Consider making a [GitHub Discussions *announcement*](https://github.com/sse-secure-systems/connaisseur/discussions).
+Before starting the release, make sure everything is ready and in order:
+
+- See that all tests are running smoothly.
+- Check that documentation changes show up correctly [here](https://sse-secure-systems.github.io/connaisseur/develop/).
+- Make sure the Connaisseur version is incremented correctly according to the changes.
+- Make sure Connaisseur version `helm/values.yaml` is matched to `helm/Chart.yaml`.
+- See if the docs announcements should be adjusted [here](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/overrides/main.html).
+- Consider making a [GitHub Discussions *announcement*](https://github.com/sse-secure-systems/connaisseur/discussions).
 
 ## Add new tag
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: connaisseur
-description: A Helm chart for the Connaisseur Admission Controller to validate docker image signatures.
+description: A Helm chart for the Connaisseur Admission Controller to validate container image signatures.
 type: application
 version: 1.0.0
-appVersion: 2.0.0
+appVersion: 2.1.1
 keywords:
-  - docker image
+  - container image
   - signature
   - verification
-home: https://github.com/sse-secure-systems/connaisseur
+home: https://sse-secure-systems.github.io/connaisseur/latest
 sources:
   - https://github.com/sse-secure-systems/connaisseur
 maintainers:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -39,6 +39,30 @@ app.kubernetes.io/instance: {{ .Chart.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
+{{- define "helm.webhook-securitycontext" -}}
+allowPrivilegeEscalation: false
+capabilities:
+  drop:
+    - ALL
+privileged: false
+readOnlyRootFilesystem: true
+runAsGroup: 2000
+runAsNonRoot: true
+runAsUser: 1000
+{{- if gt (.Capabilities.KubeVersion.Minor | int) 18 }}
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}
+{{- end -}}
+
+{{- define "helm.webhook-resources" -}}
+requests:
+ memory: "32Mi"
+ cpu: "50m"
+limits:
+ memory: "64Mi"
+ cpu: "100m"
+{{- end -}}
 
 {{- define "config-secrets" -}}
 {{- $secret_dict := dict -}}

--- a/helm/templates/bootstrap-sentinel.yaml
+++ b/helm/templates/bootstrap-sentinel.yaml
@@ -11,4 +11,25 @@ spec:
     image: busybox
     imagePullPolicy: Always
     command: ['sh', '-c', 'sleep 300s']
+    resources:
+      requests:
+        memory: "16Mi"
+        cpu: "25m"
+      limits:
+        memory: "32Mi"
+        cpu: "50m"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsGroup: 2000
+      runAsNonRoot: true
+      runAsUser: 1000
+      {{- if gt (.Capabilities.KubeVersion.Minor | int) 18 }}
+      seccompProfile:
+        type: RuntimeDefault
+      {{- end }}
   restartPolicy: Never

--- a/helm/templates/webhook/job.yaml
+++ b/helm/templates/webhook/job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Chart.Name }}-install-webhook-job
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-weight: "5"
@@ -14,10 +14,7 @@ spec:
     metadata:
       name: {{ .Chart.Name }}-install-webhook
       labels:
-        app.kubernetes.io/name: {{ include "helm.name" . }}
-        helm.sh/chart: {{ include "helm.chart" . }}
-        app.kubernetes.io/instance: {{ .Chart.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- include "helm.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
@@ -34,6 +31,10 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Chart.Name }}-env
+          resources:
+            {{- include "helm.webhook-resources" . | nindent 12 }}
+          securityContext:
+            {{- include "helm.webhook-securitycontext" . | nindent 12 }}
       volumes:
         - name: webhook-data
           configMap:
@@ -45,25 +46,19 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Chart.Name }}-delete-webhook-job
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-delete, pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: hook-succeeded, hook-failed
   labels:
-    app.kubernetes.io/name: {{ include "helm.name" . }}
-    helm.sh/chart: {{ include "helm.chart" . }}
-    app.kubernetes.io/instance: {{ .Chart.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "helm.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
       name: {{ .Chart.Name }}-delete-webhook
       labels:
-        app.kubernetes.io/name: {{ include "helm.name" . }}
-        helm.sh/chart: {{ include "helm.chart" . }}
-        app.kubernetes.io/instance: {{ .Chart.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- include "helm.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
@@ -77,6 +72,10 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Chart.Name }}-env
+          resources:
+            {{- include "helm.webhook-resources" . | nindent 12 }}
+          securityContext:
+            {{- include "helm.webhook-securitycontext" . | nindent 12 }}
       restartPolicy: OnFailure
 ---
 
@@ -84,25 +83,19 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Chart.Name }}-upgrade-webhook-job
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: post-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: hook-succeeded, hook-failed
   labels:
-    app.kubernetes.io/name: {{ include "helm.name" . }}
-    helm.sh/chart: {{ include "helm.chart" . }}
-    app.kubernetes.io/instance: {{ .Chart.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "helm.labels" . | nindent 4 }}
 spec:
   template:
     metadata:
       name: {{ .Chart.Name }}-upgrade-webhook
       labels:
-        app.kubernetes.io/name: {{ include "helm.name" . }}
-        helm.sh/chart: {{ include "helm.chart" . }}
-        app.kubernetes.io/instance: {{ .Chart.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- include "helm.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-hook-serviceaccount
       containers:
@@ -119,6 +112,10 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ .Chart.Name }}-env
+          resources:
+            {{- include "helm.webhook-resources" . | nindent 12 }}
+          securityContext:
+            {{- include "helm.webhook-securitycontext" . | nindent 12 }}
       volumes:
         - name: webhook-data
           configMap:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,19 +1,30 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.1.0
+  image: securesystemsengineering/connaisseur:v2.1.1
   helmHookImage: securesystemsengineering/connaisseur:helm-hook-v1.0
   imagePullPolicy: Always
-  resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   nodeSelector: {}
   tolerations: []
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - connaisseur
+            topologyKey: kubernetes.io/hostname
+          weight: 100
 
 # configure Connaisseur service
 service:


### PR DESCRIPTION
KubeLinter is a SAST tool to scan Kubernetes YAML and Helm Charts: https://github.com/stackrox/kube-linter
The documentation can be found here: https://docs.kubelinter.io/

The following questions arise:
* KL is currently in early development and we have to see whether that is okay for us
* Check the findings
* Does it provide value? Yes. It actually found bugs in our charts.

Open Questions if we want to proceed:
- [x] reasonable resource limits for **connaisseur**
- [x] reasonable resource limits for **hook**
- [x] reasonable resource limits for **sentinel**
- [x] solid security settings for **connaisseur**
- [x] solid security settings for **hook**
- [x] solid security settings for **sentinel**
- [x] connaisseur pod affinity for **connaisseur**
  - [x] test pod affinity
- [x] fix service account failure for **hook**

To see the results, check the GH Action.

**For Review:**
- Please closely review and extend security settings. We should configure this very rigorously.
- Should we bump *MINOR* Version?