### PR TITLE
ci: fail slow on integration tests

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         integration-test-script: [ 'integration-test.sh', 'cosign-integration-test.sh' , 'namespaced-integration-test.sh' ]
     services:


### PR DESCRIPTION
Set the integration test matrix to fail slow. Will allow inspecting the outcome of all integration tests.