### PR TITLE
Fix/wrong image path

### DIFF
--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -86,3 +86,6 @@ class Image:
         )
         tag = f":{self.tag}" if not self.digest else f"@sha256:{self.digest}"
         return f"{repo_reg}{self.name}{tag}"
+
+    def __eq__(self, other):
+        return str(self) == str(other)

--- a/tests/data/sample_admission_requests/ad_request_deployments_multi_image.json
+++ b/tests/data/sample_admission_requests/ad_request_deployments_multi_image.json
@@ -1,0 +1,122 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "request": {
+        "uid": "4784c1dc-553f-4d53-a8d3-23c4bda880b6",
+        "kind": {
+            "group": "apps",
+            "version": "v1",
+            "kind": "Deployment"
+        },
+        "resource": {
+            "group": "apps",
+            "version": "v1",
+            "resource": "deployments"
+        },
+        "requestKind": {
+            "group": "apps",
+            "version": "v1",
+            "kind": "Deployment"
+        },
+        "requestResource": {
+            "group": "apps",
+            "version": "v1",
+            "resource": "deployments"
+        },
+        "name": "test",
+        "namespace": "connaisseur",
+        "operation": "CREATE",
+        "userInfo": {
+            "username": "minikube-user",
+            "groups": [
+                "system:masters",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Deployment",
+            "apiVersion": "apps/v1",
+            "metadata": {
+                "name": "test",
+                "namespace": "connaisseur",
+                "creationTimestamp": "",
+                "labels": {
+                    "app": "test"
+                }
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {
+                        "app": "test"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": "",
+                        "labels": {
+                            "app": "test"
+                        }
+                    },
+                    "spec": {
+                        "initContainers": [
+                            {
+                                "name": "init",
+                                "image": "busybox:1.32",
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "sleep 5s"
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "IfNotPresent"
+                            }
+                        ],
+                        "containers": [
+                            {
+                                "name": "redis",
+                                "image": "redis:alpine",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "IfNotPresent"
+                            },
+                            {
+                                "name": "mysql",
+                                "image": "mysql:8",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "IfNotPresent"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 30,
+                        "dnsPolicy": "ClusterFirst",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                },
+                "strategy": {
+                    "type": "RollingUpdate",
+                    "rollingUpdate": {
+                        "maxUnavailable": "25%",
+                        "maxSurge": "25%"
+                    }
+                },
+                "revisionHistoryLimit": 10,
+                "progressDeadlineSeconds": 600
+            },
+            "status": {}
+        },
+        "oldObject": "",
+        "dryRun": false,
+        "options": {
+            "kind": "CreateOptions",
+            "apiVersion": "meta.k8s.io/v1",
+            "fieldManager": "kubectl-client-side-apply"
+        }
+    }
+}

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -108,6 +108,18 @@ else
   echo 'Successfully denied unsigned image in init container'
 fi
 
+echo 'Testing deployment of valid init container along with a valid container...'
+kubectl apply -f tests/integration/valid_init_container.yaml >output.log 2>&1 || true
+NUMBER_OF_VALID_DEPLOYMENTS+=1
+
+if [[ "$(cat output.log)" != 'pod/connaisseur-integration-test-pod-valid-init created' ]]; then
+  echo 'Failed to deploy a valid initContainer along with a valid container. Output:'
+  cat output.log
+  exit 1
+else
+  echo 'Successfully allowed valid image in init container and container'
+fi
+
 echo 'Checking whether alert endpoints have been called successfully'
 ENDPOINT_HITS=$(curl ${ALERTING_ENDPOINT_IP}:56243 --header "Content-Type: application/json")
 let NUMBER_OF_DEPLOYMENTS=${NUMBER_OF_INVALID_DEPLOYMENTS}+${NUMBER_OF_VALID_DEPLOYMENTS}

--- a/tests/integration/valid_init_container.yaml
+++ b/tests/integration/valid_init_container.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: connaisseur-integration-test-pod-valid-init
+  namespace: default
+spec:
+  containers:
+  - name: valid-container
+    image: securesystemsengineering/testimage:signed
+    command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+  initContainers:
+  - name: valid-init-container
+    image: securesystemsengineering/testimage:signed
+    command: ['sh', '-c', 'sleep 5']

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -80,8 +80,8 @@ alert_headers_slack = {"Content-Type": "application/json"}
 
 alert_payload_opsgenie_deployment = {
     "message": "CONNAISSEUR admitted a request",
-    "alias": "CONNAISSEUR admitted a request to deploy the images ['securesystemsengineering/alice-image:test'].",
-    "description": "CONNAISSEUR admitted a request to deploy the following images:\n ['securesystemsengineering/alice-image:test'] \n\n Please check the logs of the `connaisseur-pod-123` for more details.",
+    "alias": "CONNAISSEUR admitted a request to deploy the images ['docker.io/securesystemsengineering/alice-image:test'].",
+    "description": "CONNAISSEUR admitted a request to deploy the following images:\n ['docker.io/securesystemsengineering/alice-image:test'] \n\n Please check the logs of the `connaisseur-pod-123` for more details.",
     "responders": [{"type": "user", "username": "testuser@testcompany.de"}],
     "visibleTo": [{"type": "user", "username": "testuser@testcompany.de"}],
     "actions": [],
@@ -104,7 +104,7 @@ alert_payload_slack_deployment = {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "*CONNAISSEUR admitted a request* \n\n_*Cluster*_:                           minikube\n_*Request ID*_:                     3a3a7b38-5512-4a85-94bb-3562269e0a6a\n_*Images*_:                           ['securesystemsengineering/alice-image:test']\n_*Connaisseur Pod ID*_:       connaisseur-pod-123\n_*Created*_:                          ${datetime.now()}\n_*Severity*_:                          4\n\nCheck the logs of `connaisseur-pod-123` for more details!",
+                "text": "*CONNAISSEUR admitted a request* \n\n_*Cluster*_:                           minikube\n_*Request ID*_:                     3a3a7b38-5512-4a85-94bb-3562269e0a6a\n_*Images*_:                           ['docker.io/securesystemsengineering/alice-image:test']\n_*Connaisseur Pod ID*_:       connaisseur-pod-123\n_*Created*_:                          ${datetime.now()}\n_*Severity*_:                          4\n\nCheck the logs of `connaisseur-pod-123` for more details!",
             },
         },
     ],

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -97,33 +97,6 @@ def test_create_logging_msg(msg, kwargs, out):
 
 
 @pytest.mark.parametrize(
-    "path, index, image, out",
-    [
-        (
-            "/sample/path/{}/image",
-            3,
-            (
-                "sample-image@sha256:aaaaaaaaaaaaaaaaaaaaa"
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            ),
-            {
-                "op": "replace",
-                "path": "/sample/path/3/image",
-                "value": (
-                    "docker.io/library/sample-image@sha256:aaaaaaaaaaaaaaa"
-                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-            },
-        ),
-    ],
-)
-def test_create_json_patch(path, index, image, out):
-
-    patches = pytest.fs.__create_json_patch(path, index, Image(image))
-    assert patches == out
-
-
-@pytest.mark.parametrize(
     "index, out, exception",
     [
         (

--- a/tests/test_workload_object.py
+++ b/tests/test_workload_object.py
@@ -2,6 +2,7 @@ import pytest
 from . import conftest as fix
 import connaisseur.workload_object as wl
 import connaisseur.exceptions as exc
+from connaisseur.image import Image
 
 
 static_k8s = [
@@ -29,6 +30,13 @@ static_k8s = [
         "namespace": "default",
         "name": "yooob",
     },
+    {},
+    {
+        "kind": "Deployment",
+        "apiVersion": "apps/v1",
+        "namespace": "default",
+        "name": "test",
+    },
 ]
 
 
@@ -36,7 +44,14 @@ static_k8s = [
 def adm_req_sample_objects():
     return [
         fix.get_admreq(t)["request"]["object"]
-        for t in ("deployments", "pods", "replicasets", "cronjob", "wrong_version")
+        for t in (
+            "deployments",
+            "pods",
+            "replicasets",
+            "cronjob",
+            "wrong_version",
+            "deployments_multi_image",
+        )
     ]
 
 
@@ -47,6 +62,7 @@ def adm_req_sample_objects():
         (1, wl.Pod),
         (2, wl.WorkloadObject),
         (3, wl.CronJob),
+        (5, wl.WorkloadObject),
     ],
 )
 def test_k8s_object_new(adm_req_sample_objects, index, wl_class):
@@ -62,6 +78,7 @@ def test_k8s_object_new(adm_req_sample_objects, index, wl_class):
         (2, fix.no_exc()),
         (3, fix.no_exc()),
         (4, pytest.raises(exc.UnknownAPIVersionError)),
+        (5, fix.no_exc()),
     ],
 )
 def test_k8s_object_init(adm_req_sample_objects, index, exception):
@@ -76,46 +93,125 @@ def test_k8s_object_init(adm_req_sample_objects, index, exception):
 @pytest.mark.parametrize(
     "index, parent_list, exception",
     [
-        (0, [], fix.no_exc()),
+        (0, {}, fix.no_exc()),
         (
             1,
-            [
-                (
+            {
+                ("containers", 0): Image(
                     "securesystemsengineering/charlie-image@sha256"
-                    ":91ac9b26df583762234c1cdb2fc930364754ccc59bc752a2bfe298d2ea68f9ff"
-                )
-            ],
+                    ":91ac9b26df583762234c1cdb2fc930364754ccc59bc7"
+                    "52a2bfe298d2ea68f9ff"
+                ),
+            },
             fix.no_exc(),
         ),
-        (2, [], pytest.raises(exc.ParentNotFoundError)),
-        (3, [], fix.no_exc()),
+        (2, {}, pytest.raises(exc.ParentNotFoundError)),
+        (3, {}, fix.no_exc()),
     ],
 )
-def test_k8s_object_parent_images(
+def test_k8s_object_parent_containers(
     adm_req_sample_objects, m_request, index, parent_list, exception
 ):
     obj = wl.WorkloadObject(adm_req_sample_objects[index], "default")
     with exception:
-        assert obj.parent_images == parent_list
+        assert obj.parent_containers == parent_list
 
 
 @pytest.mark.parametrize(
     "index, images",
     [
-        (0, ["securesystemsengineering/alice-image:test"]),
+        (0, {("containers", 0): Image("securesystemsengineering/alice-image:test")}),
         (
             1,
-            [
-                (
+            {
+                ("containers", 0): Image(
                     "securesystemsengineering/charlie-image@sha256:"
                     "91ac9b26df583762234c1cdb2fc930364754ccc59bc752a2bfe298d2ea68f9ff"
                 )
-            ],
+            },
         ),
-        (2, ["securesystemsengineering/sample-san-sama:hai"]),
-        (3, ["busybox"]),
+        (
+            2,
+            {("containers", 0): Image("securesystemsengineering/sample-san-sama:hai")},
+        ),
+        (3, {("containers", 0): Image("busybox")}),
+        (
+            5,
+            {
+                ("containers", 0): Image("redis:alpine"),
+                ("containers", 1): Image("mysql:8"),
+                ("initContainers", 0): Image("busybox:1.32"),
+            },
+        ),
     ],
 )
 def test_k8s_object_container_images(adm_req_sample_objects, index, images):
     obj = wl.WorkloadObject(adm_req_sample_objects[index], "default")
-    assert obj.container_images == images
+    assert obj.containers == images
+
+
+@pytest.mark.parametrize(
+    "index, image, image_index, image_type, patches",
+    [
+        (
+            0,
+            Image("redis:alpine"),
+            0,
+            "containers",
+            {
+                "op": "replace",
+                "path": "/spec/template/spec/containers/0/image",
+                "value": "docker.io/library/redis:alpine",
+            },
+        ),
+        (
+            0,
+            Image("redis:alpine"),
+            1,
+            "containers",
+            {
+                "op": "replace",
+                "path": "/spec/template/spec/containers/1/image",
+                "value": "docker.io/library/redis:alpine",
+            },
+        ),
+        (
+            0,
+            Image("redis:alpine"),
+            1,
+            "initContainers",
+            {
+                "op": "replace",
+                "path": "/spec/template/spec/initContainers/1/image",
+                "value": "docker.io/library/redis:alpine",
+            },
+        ),
+        (
+            1,
+            Image("redis:alpine"),
+            1,
+            "containers",
+            {
+                "op": "replace",
+                "path": "/spec/containers/1/image",
+                "value": "docker.io/library/redis:alpine",
+            },
+        ),
+        (
+            3,
+            Image("redis:alpine"),
+            0,
+            "initContainers",
+            {
+                "op": "replace",
+                "path": "/spec/jobTemplate/spec/template/spec/initContainers/0/image",
+                "value": "docker.io/library/redis:alpine",
+            },
+        ),
+    ],
+)
+def test_k8s_object_json_patch(
+    adm_req_sample_objects, index, image, image_type, image_index, patches
+):
+    obj = wl.WorkloadObject(adm_req_sample_objects[index], "default")
+    assert obj.get_json_patch(image, image_type, image_index) == patches


### PR DESCRIPTION
Fixed an error where acquiring image references and patching them pointed to different locations. The acquisition of image references previsouly just stored all in a list, whether they were from the initContainers or not. During validation we iterated over this list, keeping each items index in mind so we can then patch the correct location in the received request. Problem is, that the initContainers and regular containers have differnt indizes in the request, while we stored all in the same list. The consequence of this was, should someone deploy a resource with valid initContainer and valid regular container, connaisseur will attempt to patch container indizes, that don't exist. Now each image will keep track of its own index and container_type ("containers" or "initContainers"), so when patching the request after validation, the correct container gets patched.