### PR TITLE
Fix/nv1 parallel

### DIFF
--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -5,7 +5,6 @@ import requests
 import yaml
 from connaisseur.image import Image
 from connaisseur.validators.notaryv1.tuf_role import TUFRole
-from connaisseur.validators.notaryv1.trust_data import TrustData
 from connaisseur.exceptions import (
     UnreachableError,
     NotFoundException,
@@ -150,7 +149,7 @@ class Notary:
 
         response.raise_for_status()
 
-        return TrustData(response.json(), str(role))
+        return response.json()
 
     def get_delegation_trust_data(self, image: Image, role: TUFRole, token: str = None):
         try:

--- a/tests/validators/notaryv1/test_notary.py
+++ b/tests/validators/notaryv1/test_notary.py
@@ -157,8 +157,8 @@ def test_get_trust_data(
     with exception:
         no = notary.Notary(**sample_notaries[index])
         td = no.get_trust_data(Image(image), role)
-        assert td.signed == output["signed"]
-        assert td.signatures == output["signatures"]
+        assert td["signed"] == output["signed"]
+        assert td["signatures"] == output["signatures"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A major amount of connaisseur's runtime (for nv1 validation) is wasted with receiving the trust data from the notary server. To reduce this time, the requests have been parallelized.