### PR TITLE
fix: health probe fails after some time

### DIFF
--- a/connaisseur/flask_server.py
+++ b/connaisseur/flask_server.py
@@ -81,11 +81,6 @@ def healthz():
     server. Sends back either '200' for a healthy status or '500'
     otherwise.
     """
-    for validator in CONFIG.validators:
-        if not validator.healthy:
-            logging.error(  # pylint: disable=logging-fstring-interpolation
-                f"{validator.name} is unhealthy."
-            )
 
     return ("", 200)
 

--- a/tests/test_flask_server.py
+++ b/tests/test_flask_server.py
@@ -47,7 +47,7 @@ def test_mutate(
     assert admission_response["status"]["code"] == status_code
 
 
-def test_healthz(m_config):
+def test_healthz():
     assert pytest.fs.healthz() == ("", 200)
 
 


### PR DESCRIPTION
After installing connaisseur the health probe will fail after some time though it only returns true it runs health checks on validators that will not influence the health status but be logged if unhealthy. In case the health checks for the validators take too long, the pod health probe timeouts and the pod is considered unhealthy. Validator health checks are now separated from the pod health.