### PR TITLE
refactor(nv1): parallel trust data request

### DIFF
--- a/.github/actions/integration-test/action.yaml
+++ b/.github/actions/integration-test/action.yaml
@@ -43,6 +43,9 @@ runs:
         sed s+/.*++g)
         echo ALERTING_ENDPOINT_IP=${ALERTING_ENDPOINT_IP} >> $GITHUB_ENV
       shell: bash
+    - name: Give it some time ...
+      run: sleep 5
+      shell: bash
     - name: Run actual integration test
       run: |
         bash tests/integration/${{ inputs.integration-test-script }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -57,7 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
-        run: pip3 install -r requirements_dev.txt
+        # Since we run inside an alpine based container, we cannot compile yarl and multidic
+        run: YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install -r requirements_dev.txt
       - name: Lint
         run: cd connaisseur && pylint --ignore-patterns=tests,coverage *.*
 
@@ -102,6 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:alpine
+    env:
+      YARL_NO_EXTENSIONS: 1
+      MULTIDICT_NO_EXTENSIONS: 1
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/safety

--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -1,11 +1,14 @@
+import json
 import os
 import re
+import ssl
 from urllib.parse import quote, urlencode
 import requests
 import yaml
+import aiohttp
 from connaisseur.image import Image
-from connaisseur.validators.notaryv1.tuf_role import TUFRole
 from connaisseur.validators.notaryv1.trust_data import TrustData
+from connaisseur.validators.notaryv1.tuf_role import TUFRole
 from connaisseur.exceptions import (
     UnreachableError,
     NotFoundException,
@@ -45,23 +48,14 @@ class Notary:
         self.host = host
         self.pub_root_keys = trust_roots or []
         self.is_acr = is_acr
-        self.auth = auth
-        self.cert = self.__write_cert(cert) if cert else None
+        self.auth = {"login" if k == "username" else k: v for k, v in auth.items()}
+        self.cert = self.__get_context(cert) if cert else None
 
-    def __write_cert(self, cert: str):
-        cert_path = self.CERT_PATH.format(self.name)
-
-        if not safe_path_func(os.path.exists, "/app/connaisseur/certs", cert_path):
-            safe_path_func(
-                os.makedirs,
-                "/app/connaisseur/certs",
-                os.path.dirname(cert_path),
-                exist_ok=True,
-            )
-            with safe_path_func(open, "/app/connaisseur/certs", cert_path, "w") as file:
-                file.write(cert)
-
-        return cert_path
+    def __get_context(self, cert: str):
+        try:
+            return ssl.create_default_context(cadata=cert)
+        except Exception:
+            return None
 
     def get_key(self, key_name: str = None):
         """
@@ -100,7 +94,7 @@ class Notary:
         except Exception:
             return False
 
-    def get_trust_data(self, image: Image, role: TUFRole, token: str = None):
+    async def get_trust_data(self, image: Image, role: TUFRole, token: str = None):
         if not self.healthy:
             msg = "Unable to reach notary host {notary_name}."
             raise UnreachableError(
@@ -113,38 +107,42 @@ class Notary:
             f"{image.name}/_trust/tuf/{str(role)}.json"
         )
 
-        request_kwargs = {
-            "url": url,
-            "verify": self.cert,
-            "headers": ({"Authorization": f"Bearer {token}"} if token else None),
-        }
+        async with aiohttp.ClientSession() as session:
+            request_kwargs = {
+                "url": url,
+                "ssl": self.cert,
+                "headers": ({"Authorization": f"Bearer {token}"} if token else None),
+            }
+            async with session.get(**request_kwargs) as response:
+                status = response.status
+                if (
+                    status == 401
+                    and not token
+                    and ("www-authenticate" in [k.lower() for k in response.headers])
+                ):
+                    auth_url = self.__parse_auth(
+                        {k.lower(): v for k, v in response.headers.items()}[
+                            "www-authenticate"
+                        ]
+                    )
+                    token = await self.__get_auth_token(auth_url)
+                    return await self.get_trust_data(image, role, token)
 
-        response = requests.get(**request_kwargs)
+                if status == 404:
+                    msg = "Unable to get {tuf_role} trust data from {notary_name}."
+                    raise NotFoundException(
+                        message=msg, notary_name=self.name, tuf_role=str(role)
+                    )
 
-        if (
-            response.status_code == 401
-            and not token
-            and ("www-authenticate" in [k.lower() for k in response.headers])
-        ):
-            auth_url = self.__parse_auth(
-                {k.lower(): v for k, v in response.headers.items()}["www-authenticate"]
-            )
-            token = self.__get_auth_token(auth_url)
-            return self.get_trust_data(image, role, token)
+                response.raise_for_status()
+                data = await response.text()
+                return TrustData(json.loads(data), str(role))
 
-        if response.status_code == 404:
-            msg = "Unable to get {tuf_role} trust data from {notary_name}."
-            raise NotFoundException(
-                message=msg, notary_name=self.name, tuf_role=str(role)
-            )
-
-        response.raise_for_status()
-
-        return TrustData(response.json(), str(role))
-
-    def get_delegation_trust_data(self, image: Image, role: TUFRole, token: str = None):
+    async def get_delegation_trust_data(
+        self, image: Image, role: TUFRole, token: str = None
+    ):
         try:
-            return self.get_trust_data(image, role, token)
+            return await self.get_trust_data(image, role, token)
         except Exception as ex:
             if os.environ.get("LOG_LEVEL", "INFO") == "DEBUG":
                 raise ex
@@ -214,44 +212,47 @@ class Notary:
 
         return url
 
-    def __get_auth_token(self, url: str):
+    async def __get_auth_token(self, url: str):
         """
         Return the JWT from the given `url`, using user and password from
         environment variables.
 
         Raises an exception if a HTTP error status code occurs.
         """
-        request_kwargs = {
-            "url": url,
-            "verify": self.cert,
-            "auth": (requests.auth.HTTPBasicAuth(**self.auth) if self.auth else None),
-        }
+        async with aiohttp.ClientSession() as session:
+            request_kwargs = {
+                "url": url,
+                "ssl": self.cert,
+                "auth": (aiohttp.BasicAuth(**self.auth) if self.auth else None),
+            }
+            async with session.get(**request_kwargs) as response:
+                if response.status >= 500:
+                    msg = "Unable to get authentication token from {auth_url}."
+                    raise NotFoundException(
+                        message=msg, notary_name=self.name, auth_url=url
+                    )
 
-        response = requests.get(**request_kwargs)
+                response.raise_for_status()
 
-        if response.status_code >= 500:
-            msg = "Unable to get authentication token from {auth_url}."
-            raise NotFoundException(message=msg, notary_name=self.name, auth_url=url)
+                try:
+                    token_key = "access_token" if self.is_acr else "token"
+                    token = (await response.json())[token_key]
+                except KeyError as err:
+                    msg = "Unable to retrieve authentication token from {auth_url} response."
+                    raise NotFoundException(
+                        message=msg, notary_name=self.name, auth_url=url
+                    ) from err
 
-        response.raise_for_status()
+                token_re = (
+                    r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"  # nosec
+                )
 
-        try:
-            token_key = "access_token" if self.is_acr else "token"
-            token = response.json()[token_key]
-        except KeyError as err:
-            msg = "Unable to retrieve authentication token from {auth_url} response."
-            raise NotFoundException(
-                message=msg, notary_name=self.name, auth_url=url
-            ) from err
-
-        token_re = r"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$"  # nosec
-
-        if not re.match(token_re, token):
-            msg = "{validation_kind} has an invalid format."
-            raise InvalidFormatException(
-                message=msg,
-                validation_kind="Authentication token",
-                notary_name=self.name,
-                auth_url=url,
-            )
-        return token
+                if not re.match(token_re, token):
+                    msg = "{validation_kind} has an invalid format."
+                    raise InvalidFormatException(
+                        message=msg,
+                        validation_kind="Authentication token",
+                        notary_name=self.name,
+                        auth_url=url,
+                    )
+                return token

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,8 @@ FROM base as builder
 RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt /requirements.txt
-RUN pip install --no-cache-dir --prefix=/install -r /requirements.txt
+# Since we run inside an alpine based container, we cannot compile yarl and multidic
+RUN YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip install --no-cache-dir --prefix=/install -r /requirements.txt
 
 # build cosign
 FROM golang:buster as go_builder

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ parsedatetime~=2.6
 pytz~=2020.1
 python-dateutil~=2.8.1
 PyYAML~=5.4.1
+aiohttp~=3.7.4.post0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,5 @@ pylint~=2.7.2
 requests-mock~=1.8.0
 pytest-mock~=3.3.1
 pytest-subprocess~=1.0.1
+pytest-asyncio~=0.15.1
+aioresponses~=0.7.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import re
 import json
 import pytest
 import requests
+from aioresponses import CallbackResult
 import connaisseur.kube_api
 import connaisseur.policy
 import connaisseur.config as co
@@ -55,173 +56,194 @@ def get_cosign_err_msg(path):
 
 @pytest.fixture
 def m_request(monkeypatch):
-    class MockResponse:
-        content: dict
-        headers: dict
-        status_code: int = 200
-
-        def __init__(self, content: dict, headers: dict = None, status_code: int = 200):
-            self.content = content
-            self.headers = headers
-            self.status_code = status_code
-
-        def raise_for_status(self):
-            if self.status_code != 200:
-                raise requests.exceptions.HTTPError
-
-        def json(self):
-            return self.content
-
-    def mock_get_request(url, **kwargs):
-        notary_regex = [
-            (
-                r"https:\/\/([^\/]+)\/v2\/([^\/]+)\/([^\/]+\/)?"
-                r"([^\/]+)\/_trust\/tuf\/(.+)\.json"
-            ),
-            mock_request_notary,
-        ]
-        kube_regex = [
-            (
-                r"https:\/\/[^\/]+\/apis?\/(apps\/v1|v1|batch\/v1beta1)"
-                r"\/namespaces\/([^\/]+)\/([^\/]+)\/([^\/]+)"
-            ),
-            mock_request_kube,
-        ]
-        notary_health_regex = [
-            (r"https:\/\/([^\/]+)\/_notary_server\/health"),
-            mock_request_notary_health,
-        ]
-        notary_token_regex = [
-            (r"https:\/\/([^\/]+)\/token\?((service=[^&]+)|(scope=[^&]+)|&)*"),
-            mock_request_notary_token,
-        ]
-        kube_namespace_less_regex = [
-            (
-                r"https:\/\/[^\/]+\/apis?\/(admissionregistration"
-                r"\.k8s\.io\/v1beta1)\/[^\/]+\/([^\/]+)"
-            ),
-            mock_request_kube_namespace_less,
-        ]
-
-        for reg in (
-            notary_regex,
-            kube_regex,
-            notary_health_regex,
-            notary_token_regex,
-            kube_namespace_less_regex,
-        ):
-            match = re.search(reg[0], url)
-
-            if match:
-                return reg[1](match, **kwargs)
-        return MockResponse({}, status_code=500)
-
-    def mock_request_notary(match: re.Match, **kwargs):
-        host, registry, repo, image, role = (
-            match.group(1),
-            match.group(2),
-            match.group(3),
-            match.group(4),
-            match.group(5),
-        )
-
-        if registry == "auth.io" and not kwargs.get("headers"):
-            return MockResponse(
-                {},
-                headers={
-                    "Www-authenticate": (
-                        'Bearer realm="https://sample.notary.io/token,"'
-                        'service="notary",scope="repository:sample-image:pull"'
-                    )
-                },
-                status_code=401,
-            )
-        if registry == "empty.io":
-            return MockResponse({}, status_code=404)
-
-        return MockResponse(get_td(f"{image}/{role}"))
-
-    def mock_request_kube(match: re.Match, **kwargs):
-        version, namespace, kind, name = (
-            match.group(1),
-            match.group(2),
-            match.group(3),
-            match.group(4),
-        )
-
-        try:
-            if "sentinel" in name or "webhook" in name:
-                return MockResponse(get_k8s_res(name))
-
-            return MockResponse(get_k8s_res(kind))
-        except FileNotFoundError as err:
-            return MockResponse({}, status_code=500)
-
-    def mock_request_notary_health(match: re.Match, **kwargs):
-        host = match.group(1)
-
-        if "unhealthy" in host:
-            return MockResponse({}, status_code=500)
-        elif "exceptional" in host:
-            raise Exception
-        else:
-            return MockResponse({})
-
-    def kube_token(path: str):
-        return ""
-
-    def mock_request_notary_token(match: re.Match, **kwargs):
-        host, scope, service = match.group(1), match.group(2), match.group(3)
-        auth = kwargs.get("auth")
-
-        if host == "notary.acr.io":
-            return MockResponse({"access_token": "a.valid.token"})
-        if host == "empty.io":
-            return MockResponse({}, status_code=500)
-        if host == "notary.hans.io":
-            if (
-                getattr(auth, "username", None) == "hans"
-                and getattr(auth, "password", None) == "wurst"
-            ):
-                return MockResponse({"access_token": "a.valid.token"})
-            return MockResponse({}, status_code=401)
-        if "wrong_token" in scope:
-            return MockResponse({"tocken": "a.valid.token"})
-        if "invalid_token" in scope:
-            return MockResponse({"token": "invalidtoken"})
-        return MockResponse({"token": "a.valid.token"})
-
-    def mock_request_kube_namespace_less(match: re.Match, **kwargs):
-        name = match.group(2)
-        return MockResponse(get_k8s_res(name))
-
-    def mock_post_request(url, **kwargs):
-        opsgenie_regex = [
-            (r"https:\/\/api\.eu\.opsgenie\.com\/v2\/alerts"),
-            mock_opsgenie_request,
-        ]
-
-        for reg in [opsgenie_regex]:
-            match = re.search(reg[0], url)
-
-            if match:
-                return reg[1](match, **kwargs)
-        return MockResponse({}, status_code=500)
-
-    def mock_opsgenie_request(match: re.Match, **kwargs):
-        if kwargs.get("headers", {}).get("Authorization"):
-            return MockResponse(
-                {
-                    "result": "Request will be processed",
-                    "took": 0.302,
-                    "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120",
-                }
-            )
-        return MockResponse({}, status_code=401)
 
     monkeypatch.setattr(requests, "get", mock_get_request)
     monkeypatch.setattr(requests, "post", mock_post_request)
     monkeypatch.setattr(connaisseur.kube_api, "__get_token", kube_token)
+
+
+class MockResponse:
+    content: dict
+    headers: dict
+    status_code: int = 200
+
+    def __init__(self, content: dict, headers: dict = None, status_code: int = 200):
+        self.content = content
+        self.headers = headers
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise requests.exceptions.HTTPError
+
+    def json(self):
+        return self.content
+
+
+def async_callback(url, **kwargs):
+    mock_rsp = mock_get_request(str(url), **kwargs)
+    return CallbackResult(
+        status=mock_rsp.status_code,
+        payload=mock_rsp.content,
+        headers=mock_rsp.headers,
+        reason="irrelevant",
+    )
+
+
+def mock_get_request(url, **kwargs):
+    notary_regex = [
+        (
+            r"https:\/\/([^\/]+)\/v2\/([^\/]+)\/([^\/]+\/)?"
+            r"([^\/]+)\/_trust\/tuf\/(.+)\.json"
+        ),
+        mock_request_notary,
+    ]
+    kube_regex = [
+        (
+            r"https:\/\/[^\/]+\/apis?\/(apps\/v1|v1|batch\/v1beta1)"
+            r"\/namespaces\/([^\/]+)\/([^\/]+)\/([^\/]+)"
+        ),
+        mock_request_kube,
+    ]
+    notary_health_regex = [
+        (r"https:\/\/([^\/]+)\/_notary_server\/health"),
+        mock_request_notary_health,
+    ]
+    notary_token_regex = [
+        (r"https:\/\/([^\/]+)\/token\?((service=[^&]+)|(scope=[^&]+)|&)*"),
+        mock_request_notary_token,
+    ]
+    kube_namespace_less_regex = [
+        (
+            r"https:\/\/[^\/]+\/apis?\/(admissionregistration"
+            r"\.k8s\.io\/v1beta1)\/[^\/]+\/([^\/]+)"
+        ),
+        mock_request_kube_namespace_less,
+    ]
+
+    for reg in (
+        notary_regex,
+        kube_regex,
+        notary_health_regex,
+        notary_token_regex,
+        kube_namespace_less_regex,
+    ):
+        match = re.search(reg[0], url)
+
+        if match:
+            return reg[1](match, **kwargs)
+    return MockResponse({}, status_code=500)
+
+
+def mock_request_notary(match: re.Match, **kwargs):
+    host, registry, repo, image, role = (
+        match.group(1),
+        match.group(2),
+        match.group(3),
+        match.group(4),
+        match.group(5),
+    )
+
+    if registry == "auth.io" and not kwargs.get("headers"):
+        return MockResponse(
+            {},
+            headers={
+                "Www-authenticate": (
+                    'Bearer realm="https://sample.notary.io/token,"'
+                    'service="notary",scope="repository:sample-image:pull"'
+                )
+            },
+            status_code=401,
+        )
+    if registry == "empty.io":
+        return MockResponse({}, status_code=404)
+
+    return MockResponse(get_td(f"{image}/{role}"))
+
+
+def mock_request_kube(match: re.Match, **kwargs):
+    version, namespace, kind, name = (
+        match.group(1),
+        match.group(2),
+        match.group(3),
+        match.group(4),
+    )
+
+    try:
+        if "sentinel" in name or "webhook" in name:
+            return MockResponse(get_k8s_res(name))
+
+        return MockResponse(get_k8s_res(kind))
+    except FileNotFoundError as err:
+        return MockResponse({}, status_code=500)
+
+
+def mock_request_notary_health(match: re.Match, **kwargs):
+    host = match.group(1)
+
+    if "unhealthy" in host:
+        return MockResponse({}, status_code=500)
+    elif "exceptional" in host:
+        raise Exception
+    else:
+        return MockResponse({})
+
+
+def kube_token(path: str):
+    return ""
+
+
+def mock_request_notary_token(match: re.Match, **kwargs):
+    host, scope, service = match.group(1), match.group(2), match.group(3)
+    auth = kwargs.get("auth")
+
+    if host == "notary.acr.io":
+        return MockResponse({"access_token": "a.valid.token"})
+    if host == "empty.io":
+        return MockResponse({}, status_code=500)
+    if host == "notary.hans.io":
+        if (
+            getattr(auth, "login", None) == "hans"
+            and getattr(auth, "password", None) == "wurst"
+        ):
+            return MockResponse({"access_token": "a.valid.token"})
+        return MockResponse({}, status_code=401)
+    if "wrong_token" in scope:
+        return MockResponse({"tocken": "a.valid.token"})
+    if "invalid_token" in scope:
+        return MockResponse({"token": "invalidtoken"})
+    return MockResponse({"token": "a.valid.token"})
+
+
+def mock_request_kube_namespace_less(match: re.Match, **kwargs):
+    name = match.group(2)
+    return MockResponse(get_k8s_res(name))
+
+
+def mock_post_request(url, **kwargs):
+    opsgenie_regex = [
+        (r"https:\/\/api\.eu\.opsgenie\.com\/v2\/alerts"),
+        mock_opsgenie_request,
+    ]
+
+    for reg in [opsgenie_regex]:
+        match = re.search(reg[0], url)
+
+        if match:
+            return reg[1](match, **kwargs)
+    return MockResponse({}, status_code=500)
+
+
+def mock_opsgenie_request(match: re.Match, **kwargs):
+    if kwargs.get("headers", {}).get("Authorization"):
+        return MockResponse(
+            {
+                "result": "Request will be processed",
+                "took": 0.302,
+                "requestId": "43a29c5c-3dbf-4fa4-9c26-f4f71023e120",
+            }
+        )
+    return MockResponse({}, status_code=401)
 
 
 @pytest.fixture
@@ -330,14 +352,10 @@ def alice_key_store(m_trust_data):
 
 @pytest.fixture
 def m_notary(monkeypatch):
-    def mock_selfsigned_cert(self, cert):
-        return f"tests/data/notary/{self.name}.cert" if cert else None
-
     def mock_healthy(self):
         return True
 
     monkeypatch.setattr(no.Notary, "healthy", mock_healthy)
-    monkeypatch.setattr(no.Notary, "_Notary__write_cert", mock_selfsigned_cert)
 
 
 @pytest.fixture

--- a/tests/validators/notaryv1/test_notary.py
+++ b/tests/validators/notaryv1/test_notary.py
@@ -1,6 +1,9 @@
 from requests.models import HTTPError
 import yaml
 import pytest
+import re
+from aioresponses import aioresponses
+from aiohttp.client_exceptions import ClientResponseError
 from ... import conftest as fix
 import connaisseur.validators.notaryv1.notary as notary
 import connaisseur.exceptions as exc
@@ -103,11 +106,16 @@ def test_get_key(sample_notaries, index, key_name, key, exception):
 
 
 @pytest.mark.parametrize(
-    "index, out", [(1, "tests/data/notary/harbor.cert"), (0, None)]
+    "index, out", [(1, "107CB525ED666EBB7445A2C38C36A3B3"), (0, None)]
 )
-def test_write_cert(sample_notaries, index, out):
+def test_get_context(sample_notaries, index, out):
     no = notary.Notary(**sample_notaries[index])
-    assert no.cert == out
+    assert (
+        getattr(no.cert, "get_ca_certs", lambda x: [{}])(None)[0].get(
+            "serialNumber", None
+        )
+        == out
+    )
 
 
 @pytest.mark.parametrize(
@@ -125,6 +133,7 @@ def test_healthy(sample_notaries, m_request, index, host, health):
     assert no.healthy == health
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "index, image, role, output, exception",
     [
@@ -148,16 +157,26 @@ def test_healthy(sample_notaries, m_request, index, host, health):
         (0, "empty.io/alice-image", "root", {}, pytest.raises(exc.NotFoundException)),
     ],
 )
-def test_get_trust_data(
-    sample_notaries, m_request, m_trust_data, index, image, role, output, exception
+async def test_get_trust_data(
+    sample_notaries,
+    m_request,
+    m_trust_data,
+    index,
+    image,
+    role,
+    output,
+    exception,
 ):
     with exception:
-        no = notary.Notary(**sample_notaries[index])
-        td = no.get_trust_data(Image(image), role)
-        assert td.signed == output["signed"]
-        assert td.signatures == output["signatures"]
+        with aioresponses() as aio:
+            aio.get(re.compile(r".*"), callback=fix.async_callback, repeat=True)
+            no = notary.Notary(**sample_notaries[index])
+            td = await no.get_trust_data(Image(image), role)
+            assert td.signed == output["signed"]
+            assert td.signatures == output["signatures"]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "index, image, output, exception, log_lvl",
     [
@@ -172,7 +191,7 @@ def test_get_trust_data(
         ),
     ],
 )
-def test_get_delegation_trust_data(
+async def test_get_delegation_trust_data(
     monkeypatch,
     sample_notaries,
     m_request,
@@ -185,10 +204,11 @@ def test_get_delegation_trust_data(
 ):
     monkeypatch.setenv("LOG_LEVEL", log_lvl)
     with exception:
-        no = notary.Notary(**sample_notaries[index])
-        assert output is bool(
-            no.get_delegation_trust_data(Image(image), "targets/phbelitz")
-        )
+        with aioresponses() as aio:
+            aio.get(re.compile(r".*"), callback=fix.async_callback)
+            no = notary.Notary(**sample_notaries[index])
+            td = await no.get_delegation_trust_data(Image(image), "targets/phbelitz")
+            assert output is bool(td)
 
 
 @pytest.mark.parametrize(
@@ -229,6 +249,7 @@ def test_parse_auth(sample_notaries, headers, url, exception):
         assert no._Notary__parse_auth(headers) == url
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "index, url, token, exception",
     [
@@ -261,7 +282,7 @@ def test_parse_auth(sample_notaries, headers, url, exception):
             0,
             "https://notary.hans.io/token?service=notary",
             "",
-            pytest.raises(HTTPError),
+            pytest.raises(ClientResponseError),
         ),
         (
             1,
@@ -271,7 +292,10 @@ def test_parse_auth(sample_notaries, headers, url, exception):
         ),
     ],
 )
-def test_get_auth_token(sample_notaries, m_request, index, url, token, exception):
+async def test_get_auth_token(sample_notaries, m_request, index, url, token, exception):
     with exception:
-        no = notary.Notary(**sample_notaries[index])
-        assert no._Notary__get_auth_token(url) == token
+        with aioresponses() as aio:
+            aio.get(url, callback=fix.async_callback)
+            no = notary.Notary(**sample_notaries[index])
+            auth_token = await no._Notary__get_auth_token(url)
+            assert auth_token == token


### PR DESCRIPTION
A major amount of connaisseur's runtime (for nv1 validation) is wasted with receiving the trust data from the notary server. To reduce this time, the requests have been parallelized.