### PR TITLE
Set side effect to None so server-side dry run is possible

### DIFF
--- a/helm/templates/webhook/webhook.yaml
+++ b/helm/templates/webhook/webhook.yaml
@@ -19,9 +19,10 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+    sideEffects: None
   {{- if not (has "*" .context.Values.targetNamespaces) }}
     namespaceSelector:
       matchLabels:
        {{- include  "connaisseur.namespaceLabels" .context | indent 8 }}
-  {{- end }} 
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
👋 

I had troubles deploying a terraform workflow, that executed a server side dry-run:

```txt
...: patch failed 'application/strategic-merge-patch+json': admission webhook "connaisseur-svc.connaisseur.svc" does not support dry run
```
Reading through these [docs](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects), I've updated the webhook config to have `sideEffects: None` (defaults to Unknown), and this solved the problem.

I'm not sure if `None` is the correct value, but I don't think in the case of Connaisseur it is a problem.