### PR TITLE
feat: add cosign authentication via k8s dockerconfigjson

### DIFF
--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -122,10 +122,15 @@ class CosignValidator(ValidatorInterface):
         """
 
         key = load_key(pubkey)  # raises if invalid; return value not used
+        home = f"/app/connaisseur-config/{self.name}"
         cmd = ["/app/cosign/cosign", "verify", "-key", "/dev/stdin", image]
 
         with subprocess.Popen(  # nosec
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            env={"HOME": home},
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         ) as process:
             try:
                 stdout, stderr = process.communicate(key.to_pem(), timeout=60)

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -63,8 +63,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- $validator := deepCopy . -}}
     {{- if eq $validator.type "notaryv1" -}}
         {{- if $validator.auth -}}
-            {{- if $validator.auth.secret_name -}}
-    - name: {{ $validator.name }}-vol
+            {{ if $validator.auth.secret_name }}
+- name: {{ $validator.name }}-vol
   secret:
     secretName: {{ $validator.auth.secret_name }}
             {{- end -}}
@@ -72,8 +72,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- else if eq $validator.type "notaryv2" -}}
     {{- else if eq $validator.type "cosign" -}}
         {{- if $validator.auth -}}
-            {{- if $validator.auth.secret_name -}}
-    - name: {{ $validator.name }}-vol
+            {{ if $validator.auth.secret_name }}
+- name: {{ $validator.name }}-vol
   secret:
     secretName: {{ $validator.auth.secret_name }}
     items:
@@ -88,12 +88,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "external-secrets-mount" -}}
 {{- $external_secret := dict -}}
-{{- range .Values.validators -}}
+{{ range .Values.validators }}
     {{- $validator := deepCopy . -}}
     {{- if eq $validator.type "notaryv1" -}}
         {{- if $validator.auth -}}
-            {{- if $validator.auth.secret_name -}}
-    - name: {{ $validator.name }}-vol
+            {{ if $validator.auth.secret_name }}
+- name: {{ $validator.name }}-vol
   mountPath: /app/connaisseur-config/{{ $validator.name }}
   readOnly: True
             {{- end -}}
@@ -101,8 +101,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- else if eq $validator.type "notaryv2" -}}
     {{- else if eq $validator.type "cosign" -}}
         {{- if $validator.auth -}}
-            {{- if $validator.auth.secret_name -}}
-    - name: {{ $validator.name }}-vol
+            {{ if $validator.auth.secret_name }}
+- name: {{ $validator.name }}-vol
   mountPath: /app/connaisseur-config/{{ $validator.name }}/.docker/
   readOnly: True
             {{- end -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -64,17 +64,24 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if eq $validator.type "notaryv1" -}}
         {{- if $validator.auth -}}
             {{- if $validator.auth.secret_name -}}
-                {{- $_ := set $external_secret $validator.name $validator.auth.secret_name -}}
+    - name: {{ $validator.name }}-vol
+  secret:
+    secretName: {{ $validator.auth.secret_name }}
             {{- end -}}
         {{- end -}}
     {{- else if eq $validator.type "notaryv2" -}}
     {{- else if eq $validator.type "cosign" -}}
-    {{- end -}}
-{{- end -}}
-{{- range $k, $v := $external_secret -}}
-    - name: {{ $k }}-vol
+        {{- if $validator.auth -}}
+            {{- if $validator.auth.secret_name -}}
+    - name: {{ $validator.name }}-vol
   secret:
-    secretName: {{ $v }}
+    secretName: {{ $validator.auth.secret_name }}
+    items:
+      - key: .dockerconfigjson
+        path: config.json
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -86,16 +93,20 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if eq $validator.type "notaryv1" -}}
         {{- if $validator.auth -}}
             {{- if $validator.auth.secret_name -}}
-                {{- $_ := set $external_secret $validator.name $validator.auth.secret_name -}}
+    - name: {{ $validator.name }}-vol
+  mountPath: /app/connaisseur-config/{{ $validator.name }}
+  readOnly: True
             {{- end -}}
         {{- end -}}
     {{- else if eq $validator.type "notaryv2" -}}
     {{- else if eq $validator.type "cosign" -}}
-    {{- end -}}
-{{- end -}}
-{{- range $k, $v :=  $external_secret -}}
-    - name: {{ $k }}-vol
-  mountPath: /app/connaisseur-config/{{ $k }}
+        {{- if $validator.auth -}}
+            {{- if $validator.auth.secret_name -}}
+    - name: {{ $validator.name }}-vol
+  mountPath: /app/connaisseur-config/{{ $validator.name }}/.docker/
   readOnly: True
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
cosign authentication is added by mounting a docker config.json under the `/app/connaisseur-config/{validator}/.docker/config.json`. Cosign checks in the home directory for `.docker/config.json` and consequently, the `HOME` env var for the subprocess call for cosign is also adjusted to the validator dir.