### PR TITLE
Fix get root utility

### DIFF
--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -61,3 +61,16 @@ jobs:
         with:
            name: trivy-reports
            path: trivy-reports
+
+  get-root:
+    runs-on: ubuntu-latest
+    container:
+      image: docker:stable
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test get-root utility
+        run: |
+          docker build -t get-root-key -f docker/Dockerfile.getRoot .
+          docker run --rm get-root-key -i securesystemsengineering/testimage > output
+          cat output | grep "KeyID: 76d211ff8d2317d78ee597dbc43888599d691dbfd073b8226512f0e9848f2508"
+          cat output | grep "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe"

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Feel free to open a PR if you add new neat templates for other third parties!
 For verifying the signatures of images, a public root key is needed, but from where do you get this, especially for public images whose signatures you didn't create? For this we created the *get_root_key* utility. You can use it by building the docker image with `docker build -t get-root-key -f docker/Dockerfile.getRoot .` and the running the image:
 
 ```bash
-$ docker run --rm notaryrootkey -i securesystemsengineering/testimage
+$ docker run --rm get-root-key -i securesystemsengineering/testimage
 KeyID: 76d211ff8d2317d78ee597dbc43888599d691dbfd073b8226512f0e9848f2508
 Key: -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe

--- a/docker/Dockerfile.getRoot
+++ b/docker/Dockerfile.getRoot
@@ -1,8 +1,7 @@
-FROM python:alpine
+FROM python:3-slim
+# based on debian as alpine needs compilation of cryptography package, which bloats image and increases build time immensely
 
 WORKDIR /app
-
-RUN ["apk", "add", "gcc", "musl-dev", "libffi-dev", "openssl-dev", "python3-dev"]
 
 COPY requirements.txt setup.py scripts/get_root_key.py /app/
 COPY connaisseur /app/connaisseur


### PR DESCRIPTION
Previously, building the get-root utility failed due to a new requirement of the cryptography package, that now requires a rust compiler on alpine-based distributions. This commit adds the rust compiler to fix it. Also, the utility was out of sync with the changes to the notary interface, which is also rectified by this commit. Lastly, it fixes a faulty reference in the docs