### PR TITLE
refactor(Makefile): make annihilate deletes everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,5 @@ upgrade:
 	helm upgrade connaisseur helm --wait
 
 annihilate:
-	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,configmaps,imagepolicies,secrets,serviceaccounts -lapp.kubernetes.io/instance=connaisseur
+	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,configmaps,imagepolicies,secrets,serviceaccounts,crds -lapp.kubernetes.io/instance=connaisseur
+	kubectl delete ns $(NAMESPACE)

--- a/helm/crds/imagepolicy.yaml
+++ b/helm/crds/imagepolicy.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: imagepolicies.connaisseur.policy
+  labels:
+    app.kubernetes.io/instance: connaisseur
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: connaisseur.policy


### PR DESCRIPTION
Previously `make annihilate` didn't delete the image policy CRD and the connaisseur namespace. Now it does, which allows to freshly reinstall connaisseur eventhough changes to the image policies format were made.