### PR TITLE
fix: nightly scans

### DIFF
--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -27,7 +27,7 @@ jobs:
   safety:
     runs-on: ubuntu-latest
     container:
-      image: python:alpine
+      image: python:slim
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/safety


### PR DESCRIPTION
With the new dependencies from asyncio, the nightly scans fail as they run on an alpine based container which can't install the dependencies without special enviornment variables. This was fix by switching to a debian based container.