### PR TITLE
fix: use signed base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,15 @@ COSIGN_VERSION = 1.0.0
 all: docker install
 
 docker:
-	docker build --build-arg COSIGN_VERSION=$(COSIGN_VERSION) -f docker/Dockerfile -t $(IMAGE) .
-	docker build -f docker/Dockerfile.hook -t $(HELM_HOOK_IMAGE) .
+	docker build \
+	  	--disable-content-trust=false \
+		--build-arg COSIGN_VERSION=$(COSIGN_VERSION) \
+		-f docker/Dockerfile \
+		-t $(IMAGE) .
+	docker build \
+		--disable-content-trust=false \
+		-f docker/Dockerfile.hook \
+		-t $(HELM_HOOK_IMAGE) .
 
 install:
 	#

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
-FROM python:3-alpine as base
-
 # Build dependencies
-FROM base as builder
+FROM python:3-alpine as builder
 
 RUN mkdir /install
 WORKDIR /install
@@ -24,7 +22,7 @@ RUN apt-get update \
  && openssl dgst -sha256 -verify release-cosign.pub -signature <(base64 -d cosign-linux-amd64.sig) cosign-linux-amd64
 
 # Build Connaisseur image
-FROM base
+FROM python:3-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
works. Only downside is that signed version of docker official images seems somewhat dated. Not clear why that is.

WARN: NOT CLEAR WHETHER DOCKER STILL SUPPORTS THE OFFICIAL IMAGES