### PR TITLE
refactor: faster trust data

### DIFF
--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -95,12 +95,6 @@ class Notary:
             return False
 
     async def get_trust_data(self, image: Image, role: TUFRole, token: str = None):
-        if not self.healthy:
-            msg = "Unable to reach notary host {notary_name}."
-            raise UnreachableError(
-                message=msg, notary_name=self.name, tuf_role=(str(role))
-            )
-
         im_repo = f"{image.repository}/" if image.repository else ""
         url = (
             f"https://{self.host}/v2/{image.registry}/{im_repo}"

--- a/tests/validators/notaryv1/test_notary.py
+++ b/tests/validators/notaryv1/test_notary.py
@@ -146,7 +146,6 @@ def test_healthy(sample_notaries, m_request, index, host, health):
             fix.no_exc(),
         ),
         (0, "bob-image", "root", fix.get_td("bob-image/root"), fix.no_exc()),
-        (2, "irrelevant", "", {}, pytest.raises(exc.UnreachableError)),
         (
             0,
             "auth.io/alice-image",


### PR DESCRIPTION
By removing the heath check before each acquisition of a trust data file, the run time of connaisseur speeds up dramatically.