### PR TITLE
Add PodSecurityPolicy to the Helm manifests

### DIFF
--- a/helm/templates/podsecuritypolicy.yaml
+++ b/helm/templates/podsecuritypolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.deployment.podSecurityPolicy }}
+{{- if .Values.deployment.podSecurityPolicy.enabled }}
+{{- if has "connaisseur-psp" .Values.deployment.podSecurityPolicy.name }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Chart.Name }}-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,docker/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  volumes:
+  - configMap
+  - secret
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -9,3 +9,14 @@ rules:
 - apiGroups: ["*"]
   resources: ["deployments", "pods", "replicacontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "imagepolicies", "mutatingwebhookconfigurations"]
   verbs: ["get"]
+{{- if .Values.deployment.podSecurityPolicy }}
+{{- if .Values.deployment.podSecurityPolicy.enabled }}
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+    {{- range  .Values.deployment.podSecurityPolicy.name }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end}}
+{{- end}}

--- a/helm/templates/webhook/role.yaml
+++ b/helm/templates/webhook/role.yaml
@@ -18,3 +18,14 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["delete", "get", "list"]
+{{- if .Values.deployment.podSecurityPolicy }}
+{{- if .Values.deployment.podSecurityPolicy.enabled }}
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+    {{- range  .Values.deployment.podSecurityPolicy.name }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end}}
+{{- end}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -26,6 +26,10 @@ deployment:
                     - connaisseur
             topologyKey: kubernetes.io/hostname
           weight: 100
+  # PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25
+  podSecurityPolicy:
+    enabled: false
+    name: ["connaisseur-psp"]  # list of PSPs to use, "connaisseur-psp" is the project-provided default
 
 # configure Connaisseur service
 service:


### PR DESCRIPTION
Installing Connaisseur on a Kubernetes cluster that has the
PodSecurityPolicy feature enabled is not working.

This PR fixes this issue by adding the option on Helm chart to take into
acccount the PSP feature.

Fixes: #258

Signed-off-by: Youssef Azrak <yazrak.tech@gmail.com>