### PR TITLE
tests: Add labels to integration test resources

### DIFF
--- a/tests/integration/cosign-integration-test.sh
+++ b/tests/integration/cosign-integration-test.sh
@@ -34,7 +34,7 @@ else
 fi
 
 echo 'Testing signed image...'
-kubectl run pod --image=securesystemsengineering/testimage:co-signed >output.log 2>&1 || true
+kubectl run pod --image=securesystemsengineering/testimage:co-signed -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow signed image. Output:'

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -40,7 +40,7 @@ else
 fi
 
 echo 'Testing signed image...'
-kubectl run pod --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+kubectl run pod --image=securesystemsengineering/testimage:signed -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 NUMBER_OF_VALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
@@ -61,7 +61,7 @@ else
 fi
 
 echo 'Testing signed image with designated signer...'
-kubectl run pod2 --image=securesystemsengineering/testimage:special_sig >output.log 2>&1 || true
+kubectl run pod2 --image=securesystemsengineering/testimage:special_sig -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 NUMBER_OF_VALID_DEPLOYMENTS+=1
 
 if [[ "$(cat output.log)" != 'pod/pod2 created' ]]; then

--- a/tests/integration/namespaced-integration-test.sh
+++ b/tests/integration/namespaced-integration-test.sh
@@ -31,7 +31,7 @@ else
 fi
 
 echo 'Testing signed image in unlabelled namespace...'
-kubectl run pod --namespace connaisseur --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+kubectl run pod --namespace connaisseur --image=securesystemsengineering/testimage:signed -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow signed image. Output:'
@@ -42,7 +42,7 @@ else
 fi
 
 echo 'Testing unsigned image in ignored namespace...'
-kubectl run pod --namespace ignoredns --image=securesystemsengineering/testimage:unsigned >output.log 2>&1 || true
+kubectl run pod --namespace ignoredns --image=securesystemsengineering/testimage:unsigned -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow unsigned image in ignored namespace. Output:'
@@ -77,7 +77,7 @@ else
 fi
 
 echo 'Testing signed image in enabled namespace...'
-kubectl run pod --namespace validatedns --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+kubectl run pod --namespace validatedns --image=securesystemsengineering/testimage:signed -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow signed image. Output:'
@@ -88,7 +88,7 @@ else
 fi
 
 echo 'Testing unsigned image in unlabelled namespace...'
-kubectl run pod --namespace connaisseur --image=securesystemsengineering/testimage:unsigned >output.log 2>&1 || true
+kubectl run pod --namespace connaisseur --image=securesystemsengineering/testimage:unsigned -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/pod created' ]]; then
   echo 'Failed to allow unsigned image in ignored namespace. Output:'

--- a/tests/integration/preconfig-integration-test.sh
+++ b/tests/integration/preconfig-integration-test.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo 'Testing nv1 signed image...'
-kubectl run npod --image=securesystemsengineering/testimage:signed >output.log 2>&1 || true
+kubectl run npod --image=securesystemsengineering/testimage:signed -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/npod created' ]]; then
   echo 'Failed to allow signed image. Output:'
@@ -37,7 +37,7 @@ else
 fi
 
 echo 'Testing signed official docker image...'
-kubectl run dpod --image=docker.io/library/hello-world >output.log 2>&1 || true
+kubectl run dpod --image=docker.io/library/hello-world -lapp.kubernetes.io/instance=connaisseur >output.log 2>&1 || true
 
 if [[ "$(cat output.log)" != 'pod/dpod created' ]]; then
   echo 'Failed to allow signed image. Output:'

--- a/tests/integration/valid_container_with_unsigned_init_container_image.yml
+++ b/tests/integration/valid_container_with_unsigned_init_container_image.yml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: connaisseur-integration-test-pod
   namespace: default
+  labels:
+    app.kubernetes.io/instance: connaisseur
 spec:
   containers:
   - name: valid_container

--- a/tests/integration/valid_init_container.yaml
+++ b/tests/integration/valid_init_container.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: connaisseur-integration-test-pod-valid-init
   namespace: default
+  labels:
+    app.kubernetes.io/instance: connaisseur
 spec:
   containers:
   - name: valid-container


### PR DESCRIPTION
This commit adds the connaisseur label to all resources created during a successful integration test, such that they can be deleted with make annihilate regardless of namespace