### PR TITLE
ci: drop redundant dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
       prefix: "update"
     insecure-external-code-execution: "deny"
     target-branch: "develop"
-  - package-ecosystem: "pip"
-    directory: "/docs"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "update"
-    insecure-external-code-execution: "deny"
-    target-branch: "develop"
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:


### PR DESCRIPTION
dependabot is already checking for all requirements.txt including the `docs` subdirectory which currently causes duplicate update PRs