### PR TITLE
feat: improve automatic child approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It provides several additional features:
 - [Detection Mode](docs/features/detection_mode.md): *warn but do not block invalid images*
 - [Namespaced Validation](docs/features/namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Alerting](docs/features/alerting.md): *send alerts based on verification result*
+- [Automatic Child Approval](docs/features/automatic_child_approval.md): *configure approval of Kubernetes child resources*
 
 
 ## Quick start

--- a/connaisseur/flask_server.py
+++ b/connaisseur/flask_server.py
@@ -104,7 +104,14 @@ def __admit(admission_request: AdmissionRequest):
         # lookups for already approved images. so child resources are automatically
         # approved without further check ups, when their parents were approved
         # earlier.
-        if image in admission_request.wl_object.parent_containers.values():
+
+        child_approval_on = (
+            os.environ.get("AUTOMATIC_CHILD_APPROVAL_ENABLED", "1") == "1"
+        )
+
+        if child_approval_on & (
+            image in admission_request.wl_object.parent_containers.values()
+        ):
             msg = f'automatic child approval for "{original_image}".'
             logging.info(__create_logging_msg(msg, **logging_context))
             continue

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ It provides several additional features:
 - [Detection Mode](features/detection_mode.md): *warn but do not block invalid images*
 - [Namespaced Validation](features/namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Alerting](features/alerting.md): *send alerts based on verification result*
+- [Automatic Child Approval](features/automatic_child_approval.md): *configure approval of Kubernetes child resources*
 
 Feel free to reach out via [GitHub Discussions](https://github.com/sse-secure-systems/connaisseur/discussions)!
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -6,7 +6,12 @@ In the following, we aim to lay the foundation on Connaisseur's core concepts, h
 
 Connaisseur works as a [mutating admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).
 It intercepts all *CREATE* and *UPDATE* resource requests for *Pods*, *Deployments*, *ReplicationControllers*, *ReplicaSets*, *DaemonSets*, *StatefulSets*, *Jobs*, and *CronJobs* and extracts all image references for validation.
-Validation relies on two core concepts: image policy and validators.
+
+Per default, Connaisseur uses *automatic child approval* by which the child of a Kubernetes resource is automatically admitted without re-verification of the signature in order to avoid duplicate validation and handle inconsistencies with the image policy.
+Essentially, this is done since an image that is deployed as part of an already deployed object (e.g. a Pod deployed as a child of a Deployment) has already been validated and potentially mutated during admission of the parent.
+More information and configuration options can be found in the [feature documentation for automatic child approval](features/automatic_child_approval.md).
+
+Validation itself relies on two core concepts: image policy and validators.
 A validator is a set of configuration options required for validation like the type of signature, public key to use for verification, path to signature data, or authentication.
 The image policy defines a set of rules which maps different images to those validators.
 This is done via glob matching of the image name which for example allows to use different validators for different registries, repositories, images or even tags.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -5,6 +5,7 @@ Besides Connaisseur's central functionality, several additional features are ava
 - [Detection Mode](./detection_mode.md): *warn but do not block invalid images*
 - [Namespaced Validation](./namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Alerting](./alerting.md): *send alerts based on verification result*
+- [Automatic Child Approval](automatic_child_approval.md): *configure approval of Kubernetes child resources*
 
 In combination, these features help to improve usability and might better support the DevOps workflow.
 Switching Connaisseur to _detection mode_ and alerting on non-compliant images can for example avoid service interruptions while still benefitting from improved supply-chain security.

--- a/docs/features/automatic_child_approval.md
+++ b/docs/features/automatic_child_approval.md
@@ -1,0 +1,49 @@
+# Automatic Child Approval
+
+> :warning: This is currently an experimental feature that might unstable over time. As such, it is not part of our semantic versioning guarantees and we take the liberty to adjust or remove it with any version at any time without incrementing MAJOR or MINOR.
+
+Per default, Connaisseur uses *automatic child approval* by which the child of a Kubernetes resource is automatically admitted without re-verification of the signature in order to avoid duplicate validation and handle inconsistencies with the image policy.
+This behavior can be configured or even disabled.
+
+When automatic child approval is enabled, images that are deployed as part of already deployed objects (e.g. a Pod deployed as a child of a Deployment) are already validated and potentially mutated during admission of the parent.
+In consequence, the images of child resources are directly admitted without re-verification of the signature.
+This is done as the parent (and thus the child) has already been validated and might have been mutated, which would lead to duplicate validation and could cause image policy pattern mismatch.
+For example, given a Deployment which contains Pods with `image:tag` that gets mutated to contain Pods with `image@sha256:digest`.
+Then a) the Pod would not need another validation as the image was validated during the admittance of the Deployment and b) if there exists a specific rule with pattern `image:tag` and another less specific rule with `image*`, then after mutating the Deployment, the Pod would be falsely validated against `image*` instead of `image:tag`.
+To ensure the child resource is legit in this case, the parent resource is requested via the Kubernetes API and only those images it lists are accepted.
+
+When automatic child approval is disabled, Connaisseur only validates and potentially mutates Pod resources.
+
+There is trade-offs between the two behaviors:
+With automatic child approval, Connaisseur only verifies that the image reference in a child resource is the same as in the parent.
+This means that resources deployed prior to Connaisseur will never be validated until they are re-deployed even if a corresponding Pod is restarted.
+Consequently, a restarting Pod with an expired signature would still be admitted.
+However, this avoids unexpected failures when restarting Pods, avoids inconsistencies with the image policy and reduces the number of validations and thus the load.
+Furthermore, disabling automatic child approval also means that deployments with invalid images will be successful even though the Pods are denied.
+
+The extension of the feature (disabling, caching) is currently under development to improve security without compromising on usability.
+
+## Configuration options
+
+`automaticChildApproval` in `helm/values.yaml` supports the following keys:
+
+| Key | Default | Required | Description |
+| - | - | - | - |
+| `enabled` | true | | `true` or `false`; when `false`, Connaisseur will disable automatic child approval |
+| `ttl` | ? | | Not yet implemented. See [below](#caching-ttl) |
+
+## Example
+
+In `helm/values.yaml`:
+
+```
+automaticChildApproval:
+  enabled: true
+```
+
+## Additional notes
+
+### Caching TTL
+
+It is planned to implement a caching by which Connaisseur might perform automatic child approval only for a limited time after creation of the parent resource.
+

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -75,7 +75,15 @@ webhooks:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
+        {{- if .Values.automaticChildApproval }}
+        {{- if .Values.automaticChildApproval.enabled }}
         resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+        {{- else }}
+        resources: ["pods"]
+        {{- end }}
+        {{- else }}
+        resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+        {{- end }}
     sideEffects: None
     {{- if lt (.Capabilities.KubeVersion.Minor | int) 16 }}
     admissionReviewVersions: ["v1beta1"]

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -16,7 +16,14 @@ data:
   {{- end }}
   {{- if .Values.detectionMode }}
   DETECTION_MODE: "1"
-  {{- end}}
+  {{- end }}
+  {{- if .Values.automaticChildApproval }}
+  {{- if .Values.automaticChildApproval.enabled }}
+  AUTOMATIC_CHILD_APPROVAL_ENABLED: "1"
+  {{- else }}
+  AUTOMATIC_CHILD_APPROVAL_ENABLED: "0"
+  {{- end }}
+  {{- end }}
   {{- if .Values.alerting }}
   CLUSTER_NAME: {{ default "not specified" .Values.alerting.cluster_identifier }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -123,6 +123,10 @@ namespacedValidation:
   enabled: false
   mode: ignore  # 'ignore' or 'validate'
 
+# TODO: document ACA
+automaticChildApproval:
+  enabled: true
+
 # debug: true
 
 # alerting is implemented in form of simple POST requests with json payload

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - features/detection_mode.md
       - features/namespaced_validation.md
       - features/alerting.md
+      - features/automatic_child_approval.md
   - Security:
     - threat_model.md
     - SECURITY.md


### PR DESCRIPTION
- [x] create feature to enable/disable `automaticChildApproval`
  - [ ] ~~expose ACA time~~
  - [x] expose bool to disable
- [x] drop everything but pods when disabling ACA
- [ ] ~~checkout [apigroups config](https://github.com/sigstore/cosign/blob/main/chart/cosigned/templates/webhook/webhook_validating.yaml)~~

automatic child approval was introduced for efficiency and explicitness. it however causes pods that become untrusted to not be blocked when restarting. switching to only pod validation and dropping ACA.

fixes #244