### PR TITLE
Openshift fix

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -18,10 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "helm.name" . }}
         app.kubernetes.io/instance: {{ .Chart.Name }}
-      {{- /* This will be set automatically by Kubernetes 1.19 when using the securityContext.seccompProfile  */ -}}
-      {{- if lt (.Capabilities.KubeVersion.Minor | int) 19 }}
+      {{- if .Values.deployment.annotations }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        {{- toYaml .Values.deployment.annotations | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-serviceaccount
@@ -73,19 +72,7 @@ spec:
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 20001
-            runAsNonRoot: true
-            runAsUser: 10001
-            {{- if gt (.Capabilities.KubeVersion.Minor | int) 18 }}
-            seccompProfile:
-              type: RuntimeDefault
-            {{- end }}
+            {{- toYaml .Values.deployment.securityContext | nindent 12 }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,6 +25,20 @@ deployment:
                     - connaisseur
             topologyKey: kubernetes.io/hostname
           weight: 100
+  #annotations:  # uncomment when using Kubernetes prior v1.19
+  #  seccomp.security.alpha.kubernetes.io/pod: runtime/default  # uncomment when using Kubernetes prior v1.19
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10001  # remove when using openshift or OKD 4
+    runAsGroup: 20001  # remove when using openshift or OKD 4
+    seccompProfile:  # remove when using Kubernetes prior v1.19, openshift or OKD 4
+      type: RuntimeDefault  # remove when using Kubernetes prior v1.19, openshift or OKD 4
   # PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25
   podSecurityPolicy:
     enabled: false


### PR DESCRIPTION
After this small fix connaisseur runs as a normal helm deployment inside OKD / OpenShift 4 (tested with OKd 4.7).

Only set the value: `openshift: true` in your value.yaml file.

## Reason

Openshift and OKD are using secure container by default (randomized user and group execution). So we have to disable the fixed user and group setting. This let OpenShift decide ;-)

