### PR TITLE
fix: use compliant/consistent validator names

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -72,13 +72,13 @@ validators:
   #  username: myuser
   #  password: mypass
 # pre-configured nv1 validator for public notary from Docker Hub
-- name: dockerhub_basics
+- name: dockerhub-basics
   type: notaryv1
   host: notary.docker.io
   trust_roots:
     # public key for official docker images (https://hub.docker.com/search?q=&type=image&image_filter=official)
     # !if not needed feel free to remove the key!
-  - name: docker_official
+  - name: docker-official
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
@@ -86,7 +86,7 @@ validators:
       -----END PUBLIC KEY-----
   # public key securesystemsengineering repo including Connaisseur images
   # !this key is critical for Connaisseur!
-  - name: securesystemsengineering_official
+  - name: securesystemsengineering-official
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
@@ -99,15 +99,15 @@ validators:
 policy:
 - pattern: "*:*"
 - pattern: "docker.io/library/*:*"
-  validator: dockerhub_basics
+  validator: dockerhub-basics
   with:
-    trust_root: docker_official
+    trust_root: docker-official
 - pattern: "k8s.gcr.io/*:*"
   validator: allow
 - pattern: "docker.io/securesystemsengineering/*:*"
-  validator: dockerhub_basics
+  validator: dockerhub-basics
   with:
-    trust_root: securesystemsengineering_official
+    trust_root: securesystemsengineering-official
 
 # in detection mode, deployment will not be denied, but only prompted
 # and logged. this allows testing the functionality without

--- a/tests/integration/deployment-update.yaml
+++ b/tests/integration/deployment-update.yaml
@@ -16,17 +16,17 @@ validators:
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvtc/qpHtx7iUUj+rRHR99a8mnGni
       qiGkmUb9YpWWTS4YwlvwdmMDiGzcsHiDOYz6f88u2hCRF5GUCvyiZAKrsA==
       -----END PUBLIC KEY-----
-- name: dockerhub_basics
+- name: dockerhub-basics
   type: notaryv1
   host: notary.docker.io
   trust_roots:
-  - name: docker_official
+  - name: docker-official
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
       QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
       -----END PUBLIC KEY-----
-  - name: securesystemsengineering_official
+  - name: securesystemsengineering-official
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
@@ -36,15 +36,15 @@ policy:
 - pattern: "*:*"
   validator: deny
 - pattern: "docker.io/library/*:*"
-  validator: dockerhub_basics
+  validator: dockerhub-basics
   with:
-    trust_root: docker_official
+    trust_root: docker-official
 - pattern: "k8s.gcr.io/*:*"
   validator: allow
 - pattern: "docker.io/securesystemsengineering/*:*"
-  validator: dockerhub_basics
+  validator: dockerhub-basics
   with:
-    trust_root: securesystemsengineering_official
+    trust_root: securesystemsengineering-official
 - pattern: "docker.io/securesystemsengineering/testimage:co*"
   validator: sse-cosign
 - pattern: "docker.io/securesystemsengineering/connaisseur:helm-hook-*"


### PR DESCRIPTION
in the docs, we note that validator names should be "lower case alphanumeric or -" which is required as the names are used for volume names in case of cosign authentication. we should be consistent throughout the pre-config.