### PR TITLE
fix: webhook api version

### DIFF
--- a/connaisseur/util.py
+++ b/connaisseur/util.py
@@ -72,7 +72,7 @@ def get_admission_review(
         }
     """
     _, minor, _ = get_kube_version()
-    api = "v1beta" if minor < 16 else "v1"
+    api = "v1beta" if int(minor) < 17 else "v1"
     review = {
         "apiVersion": f"admission.k8s.io/{api}",
         "kind": "AdmissionReview",
@@ -113,7 +113,16 @@ def validate_schema(data: dict, schema_path: str, kind: str, exception):
 
 
 def get_kube_version():
-    version = os.environ.get("KUBE_VERSION", "v0.0.0")  # e.g. v1.20.0
-    regex = r"v(\d)\.(\d{1,2})\.(\d{1,2})"
+    """
+    Returns the kubernetes version.
+
+     Return
+    ----------
+    (major, minor, patch): Tupel<str, str, str>
+        Major and minor version can always be assumed to be parseable as `int`s, the
+        patch version could be arbitrary text.
+    """
+    version = os.environ.get("KUBE_VERSION", "v0.0.0")  # e.g. `v1.20.0`
+    regex = r"v(\d)\.(\d{1,2})\.(.*)"
     match = re.match(regex, version)
-    return list(map(int, list(match.groups()))) if match else [0, 0, 0]
+    return match.groups() if match else ("0", "0", "0")

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -16,7 +16,7 @@ data:
   tls.crt: {{ default ($certs.Cert | b64enc) (include "getInstalledTLSCert" .) }}
   tls.key: {{ default ($certs.Key | b64enc) (include "getInstalledTLSKey" .) }}
 ---
-{{ if lt (.Capabilities.KubeVersion.Minor | int) 16 }}
+{{ if lt (.Capabilities.KubeVersion.Minor | int) 17 }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{ else }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -40,13 +40,13 @@ webhooks:
       caBundle: {{ default ($certs.Cert | b64enc) (include "getInstalledTLSCert" .) }}
     rules: []
     sideEffects: None
-    {{- if lt (.Capabilities.KubeVersion.Minor | int) 16 }}
+    {{- if lt (.Capabilities.KubeVersion.Minor | int) 17 }}
     admissionReviewVersions: ["v1beta1"]
     {{- else }}
     admissionReviewVersions: ["v1"]
     {{- end }}
 ---
-{{ if lt (.Capabilities.KubeVersion.Minor | int) 16 -}}
+{{ if lt (.Capabilities.KubeVersion.Minor | int) 17 -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{ else -}}
 apiVersion: admissionregistration.k8s.io/v1
@@ -88,7 +88,7 @@ webhooks:
     {{- if gt (.Capabilities.KubeVersion.Minor | int) 13 }}
     timeoutSeconds: 30
     {{- end }}
-    {{- if lt (.Capabilities.KubeVersion.Minor | int) 16 }}
+    {{- if lt (.Capabilities.KubeVersion.Minor | int) 17 }}
     admissionReviewVersions: ["v1beta1"]
     {{- else }}
     admissionReviewVersions: ["v1"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -143,8 +143,13 @@ def test_validate_schema(
 
 @pytest.mark.parametrize(
     "major, minor, patch, set_version",
-    [(1, 20, 0, "v1.20.0"), (0, 0, 0, "wrong_input"), (0, 0, 0, "")],
+    [
+        ("1", "20", "0", "v1.20.0"),
+        ("0", "0", "0", "wrong_input"),
+        ("0", "0", "0", ""),
+        ("1", "20", "11-34+7402e007632498", "v1.20.11-34+7402e007632498"),
+    ],
 )
 def test_get_kube_version(monkeypatch, major, minor, patch, set_version):
     monkeypatch.setenv("KUBE_VERSION", set_version)
-    assert ut.get_kube_version() == [major, minor, patch]
+    assert ut.get_kube_version() == (major, minor, patch)


### PR DESCRIPTION
Fixed an error, where the patch version of Kubernetes in some implementations (microk8s) could look different from what was expected. The regex was generalized so it should properly match now. Additionally for Kubernetes v1.16 and below the 'v1beta1' api version of the webhook is used (previously v1.15 and below).