### PR TITLE
fix: increase timeout

### DIFF
--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -85,6 +85,9 @@ webhooks:
         resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
         {{- end }}
     sideEffects: None
+    {{- if gt (.Capabilities.KubeVersion.Minor | int) 13 }}
+    timeoutSeconds: 30
+    {{- end }}
     {{- if lt (.Capabilities.KubeVersion.Minor | int) 16 }}
     admissionReviewVersions: ["v1beta1"]
     {{- else }}


### PR DESCRIPTION
With the switch to api version 'v1' on the webhook the default timeout was decreased to 10 seconds. This is reverted back to 30 seconds, for whichever api version.