### PR TITLE
fix: pod restart on config change

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -132,3 +132,10 @@ Extract Kubernetes Minor Version.
     {{ get $data "tls.key" }}
 {{- end -}}
 {{- end -}}
+
+{{- define "getConfigFiles" -}}
+{{ include (print $.Template.BasePath "/config.yaml") . }}
+{{ include (print $.Template.BasePath "/config-secrets.yaml") . }}
+{{ include (print $.Template.BasePath "/env.yaml") . }}
+{{ include (print $.Template.BasePath "/alertconfig.yaml") . }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "helm.labels" . | nindent 4 }}
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+    checksum/config: {{ include "getConfigFiles" . | sha256sum }}
 spec:
   replicas: {{ .Values.deployment.replicasCount }}
   selector:
@@ -18,10 +18,11 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "helm.name" . }}
         app.kubernetes.io/instance: {{ .Chart.Name }}
-      {{- if .Values.deployment.annotations }}
       annotations:
-        {{- toYaml .Values.deployment.annotations | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include "getConfigFiles" . | sha256sum }}
+        {{- if .Values.deployment.annotations }}
+          {{- toYaml .Values.deployment.annotations | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-serviceaccount
       containers:


### PR DESCRIPTION
Pods are now properly restarted when there are changes on the configuration. The configuration changes now also include environment variables, secrets and alerting configuration.

fixes #347