### PR TITLE
fix: Handle invalid admission requests

### DIFF
--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -69,23 +69,31 @@ class Alert:
     def __init__(
         self, alert_message, receiver_config, admission_request: AdmissionRequest
     ):
-        try:
-            images = str(
-                [
-                    str(image)
-                    for image in admission_request.wl_object.containers.values()
-                ]
-            )
-        except InvalidImageFormatError:
-            images = "Error retrieving images."
+        if admission_request is None:
+            images = "Invalid admission request."
+            namespace = "Invalid admission request."
+            request_id = "Invalid admission request."
+        else:
+            namespace = admission_request.namespace
+            request_id = admission_request.uid
+            try:
+                images = str(
+                    [
+                        str(image)
+                        for image in admission_request.wl_object.containers.values()
+                    ]
+                )
+            except InvalidImageFormatError:
+                images = "Error retrieving images."
+
         self.context = {
             "alert_message": alert_message,
             "priority": str(receiver_config.get("priority", 3)),
             "connaisseur_pod_id": os.getenv("POD_NAME"),
             "cluster": os.getenv("CLUSTER_NAME"),
-            "namespace": admission_request.namespace,
+            "namespace": namespace,
             "timestamp": datetime.now(),
-            "request_id": admission_request.uid or "No given UID",
+            "request_id": request_id or "No given UID",
             "images": images,
         }
         self.receiver_url = receiver_config["receiver_url"]

--- a/connaisseur/flask_server.py
+++ b/connaisseur/flask_server.py
@@ -45,6 +45,7 @@ def mutate():
     Handles the '/mutate' path and accepts CREATE and UPDATE requests.
     Sends its response back, which either denies or allows the request.
     """
+    admission_request = None
     try:
         logging.debug(request.json)
         admission_request = AdmissionRequest(request.json)
@@ -58,14 +59,16 @@ def mutate():
             msg = "unknown error. please check the logs."
         send_alerts(admission_request, False, msg)
         logging.error(err_log)
+        uid = admission_request.uid if admission_request else ""
         return jsonify(
             get_admission_review(
-                admission_request.uid,
+                uid,
                 False,
                 msg=msg,
                 detection_mode=DETECTION_MODE,
             )
         )
+
     send_alerts(admission_request, True)
     return jsonify(response)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -348,6 +348,7 @@ def adm_req_samples(m_ad_schema_path):
             "err",
             "invalid_image",
             "auto_approval",
+            "invalid",
         )
     ]
 
@@ -365,6 +366,23 @@ def m_alerting(monkeypatch, m_safe_path_func):
     monkeypatch.setenv("DETECTION_MODE", "0")
     monkeypatch.setenv("POD_NAME", "connaisseur-pod-123")
     monkeypatch.setenv("CLUSTER_NAME", "minikube")
+    connaisseur.alert.AlertingConfiguration._AlertingConfiguration__PATH = (
+        "tests/data/alerting/alertconfig.json"
+    )
+    connaisseur.alert.AlertingConfiguration._AlertingConfiguration__SCHEMA_PATH = (
+        "connaisseur/res/alertconfig_schema.json"
+    )
+    connaisseur.alert.Alert._Alert__TEMPLATE_PATH = "tests/data/alerting/templates"
+
+
+@pytest.fixture
+def m_alerting_without_send(monkeypatch, m_safe_path_func, mocker):
+    monkeypatch.setenv("DETECTION_MODE", "0")
+    monkeypatch.setenv("POD_NAME", "connaisseur-pod-123")
+    monkeypatch.setenv("CLUSTER_NAME", "minikube")
+    monkeypatch.setattr(
+        connaisseur.alert.Alert, "send_alert", mocker.stub("alert.Alert.send_alert")
+    )
     connaisseur.alert.AlertingConfiguration._AlertingConfiguration__PATH = (
         "tests/data/alerting/alertconfig.json"
     )

--- a/tests/data/sample_admission_requests/ad_request_invalid.json
+++ b/tests/data/sample_admission_requests/ad_request_invalid.json
@@ -1,0 +1,5 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "request": {}
+}


### PR DESCRIPTION
This commit adds graceful handling to Connaisseur receiving syntactically invalid admission requests, such that e.g. an alert can be sent out that admission failed