### PR TITLE
Allow CAPS in image tag

### DIFF
--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -58,7 +58,7 @@ class Image:
             image.removesuffix(name_tag).removeprefix(self.registry)
         ).strip("/") or ("library" if self.registry == "docker.io" else "")
 
-        if (self.repository + name_tag).lower() != self.repository + name_tag:
+        if (self.repository + self.name).lower() != self.repository + self.name:
             msg = "{image} is not a valid image reference."
             raise InvalidImageFormatError(message=msg, image=image)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -104,6 +104,15 @@ import connaisseur.exceptions as exc
             "docker.io",
             pytest.raises(exc.InvalidImageFormatError),
         ),
+        (
+            "docker.io/library/image:Tag",
+            "image",
+            "Tag",
+            None,
+            "library",
+            "docker.io",
+            fix.no_exc(),
+        ),
     ],
 )
 def test_image(


### PR DESCRIPTION
Only tags can have uppercase characters.
Excluding tags from lowercase comparison.