### PR TITLE
fix: support api versions for k8s workloadobjects, add tests

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -263,8 +263,12 @@ jobs:
           yq e '.policy +={"pattern": "docker.io/securesystemsengineering/connaisseur:v*"} | .policy[4].pattern style="double"' -i helm/values.yaml
           yq e '.policy[4].validator = "allow"' -i helm/values.yaml
           yq e '.deployment.replicasCount = "1"' -i helm/values.yaml
-      - name: Run actual integration test
+      - name: Run preconfig integration test
         run: |
           bash tests/integration/preconfig-integration-test.sh
+        shell: bash
+      - name: Run workload objects integration test
+        run: |
+          bash tests/integration/workload-objects-integration-test.sh
         shell: bash
 

--- a/connaisseur/workload_object.py
+++ b/connaisseur/workload_object.py
@@ -11,7 +11,7 @@ SUPPORTED_API_VERSIONS = {
     "DaemonSet": ["apps/v1", "apps/v1beta1", "apps/v1beta2"],
     "StatefulSet": ["apps/v1", "apps/v1beta1", "apps/v1beta2"],
     "Job": ["batch/v1"],
-    "CronJob": ["batch/v1beta1", "batch/v2alpha1"],
+    "CronJob": ["batch/v1", "batch/v1beta1", "batch/v2alpha1"],
 }
 
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.2.0
+  image: securesystemsengineering/connaisseur:v2.2.1
   imagePullPolicy: IfNotPresent
   failurePolicy: Fail  # use 'Ignore' to fail open if Connaisseur becomes unavailable
   resources:

--- a/tests/integration/workload-objects-integration-test.sh
+++ b/tests/integration/workload-objects-integration-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is expected to be called from the root folder of Connaisseur
+
+# List of Workload Objects
+woList=("CronJob" "DaemonSet" "Deployment" "Job" "Pod" "ReplicaSet" "ReplicationController" "StatefulSet")
+
+echo '** Prepare Connaisseur config'
+yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' helm/values.yaml tests/integration/preconfig-update.yaml
+echo '>> Config set'
+
+echo -e '\n** Install Connaisseur'
+helm install connaisseur helm --atomic --create-namespace --namespace connaisseur || { echo '>> Failed to install Connaisseur'; exit 1; }
+echo '>> Successfully installed Connaisseur'
+
+for wo in "${woList[@]}"; do
+    export KIND=${wo}
+    echo -e "\n##################################\n** Kubernetes Resource: ${KIND}"
+
+    export APIVERSION=$(kubectl api-resources | awk -v KIND=${KIND} '{ if($NF == ""KIND"") print $(NF-2);}')
+    echo "** API Version: ${APIVERSION}"
+
+    # UNSIGNED
+    export TAG=unsigned
+
+    echo -e "\n** Render '${KIND}' using '${APIVERSION}' and '${TAG}' image"
+    envsubst < tests/integration/workload-objects/${KIND}.yaml | cat
+
+    echo -e "\n** Deploy '${KIND}' using '${APIVERSION}' and '${TAG}' image"
+    envsubst < tests/integration/workload-objects/${KIND}.yaml | kubectl apply -f - >output.log 2>&1 || true
+
+    if [[ ! "$(cat output.log)" =~ 'Unable to find signed digest for image docker.io/securesystemsengineering/testimage:unsigned.' ]]; then
+      echo '>> Failed to deny unsigned image or failed with unexpected error. Output:'
+      cat output.log
+      exit 1
+    else
+      echo '>> Successfully denied usage of unsigned image'
+    fi
+
+    # SIGNED
+    export TAG=signed
+
+    echo -e "\n** Render '${KIND}' using '${APIVERSION}' and '${TAG}' image"
+    envsubst < tests/integration/workload-objects/${KIND}.yaml | cat
+
+    echo -e "\n** Deploy '${KIND}' using '${APIVERSION}' and '${TAG}' image"
+    envsubst < tests/integration/workload-objects/${KIND}.yaml | kubectl apply -f - >output.log 2>&1 || true
+
+    if [[ ! "$(cat output.log)" =~ ' created' ]]; then
+      echo '>> Failed to allow signed image. Output:'
+      cat output.log
+      exit 1
+    else
+      cat output.log
+      echo '>> Successfully allowed usage of signed image'
+    fi
+
+    echo -e "\n** Delete '${KIND}' using '${APIVERSION}' and '${TAG}' image"
+    envsubst < tests/integration/workload-objects/${KIND}.yaml | kubectl delete -f - || true
+
+done
+
+echo -e '\n** Uninstall Connaisseur'
+helm uninstall connaisseur --namespace connaisseur || { echo 'Failed to uninstall Connaisseur'; exit 1; }
+echo '>> Successfully uninstalled Connaisseur'
+
+rm output.log
+echo -e '\n##################################\n** Passed workload objects integration test'

--- a/tests/integration/workload-objects/CronJob.yaml
+++ b/tests/integration/workload-objects/CronJob.yaml
@@ -1,0 +1,16 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+apiVersion: $APIVERSION
+kind: CronJob
+metadata:
+  name: cronjob-$TAG
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: cronjob-container
+              image: docker.io/securesystemsengineering/testimage:$TAG
+          restartPolicy: OnFailure

--- a/tests/integration/workload-objects/DaemonSet.yaml
+++ b/tests/integration/workload-objects/DaemonSet.yaml
@@ -1,0 +1,19 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+apiVersion: $APIVERSION
+kind: DaemonSet
+metadata:
+  name: daemonset-$TAG
+spec:
+  selector:
+    matchLabels:
+      name: daemonset-test
+  template:
+    metadata:
+      labels:
+        name: daemonset-test
+    spec:
+      containers:
+        - image: docker.io/securesystemsengineering/testimage:$TAG
+          name: daemonset-container
+      terminationGracePeriodSeconds: 30

--- a/tests/integration/workload-objects/Deployment.yaml
+++ b/tests/integration/workload-objects/Deployment.yaml
@@ -1,0 +1,19 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+apiVersion: $APIVERSION
+kind: Deployment
+metadata:
+  name: deployment-$TAG
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-test
+  template:
+    metadata:
+      labels:
+        app: deployment-test
+    spec:
+      containers:
+        - name: deployment-container
+          image: docker.io/securesystemsengineering/testimage:$TAG

--- a/tests/integration/workload-objects/Job.yaml
+++ b/tests/integration/workload-objects/Job.yaml
@@ -1,0 +1,13 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+apiVersion: $APIVERSION
+kind: Job
+metadata:
+  name: job-$TAG
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: job-container
+          image: docker.io/securesystemsengineering/testimage:$TAG

--- a/tests/integration/workload-objects/Pod.yaml
+++ b/tests/integration/workload-objects/Pod.yaml
@@ -1,0 +1,10 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/pods/
+apiVersion: $APIVERSION
+kind: Pod
+metadata:
+  name: pod-$TAG
+spec:
+  containers:
+    - name: pod-container
+      image: docker.io/securesystemsengineering/testimage:$TAG

--- a/tests/integration/workload-objects/ReplicaSet.yaml
+++ b/tests/integration/workload-objects/ReplicaSet.yaml
@@ -1,0 +1,19 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+apiVersion: $APIVERSION
+kind: ReplicaSet
+metadata:
+  name: replicaset-$TAG
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: replicaset-test
+  template:
+    metadata:
+      labels:
+        app: replicaset-test
+    spec:
+      containers:
+      - name: replicaset-container
+        image: docker.io/securesystemsengineering/testimage:$TAG

--- a/tests/integration/workload-objects/ReplicationController.yaml
+++ b/tests/integration/workload-objects/ReplicationController.yaml
@@ -1,0 +1,16 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/
+apiVersion: $APIVERSION
+kind: ReplicationController
+metadata:
+  name: replicationcontroller-$TAG
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: replicationcontroller-test
+    spec:
+      containers:
+        - name: replicationcontroller-container
+          image: docker.io/securesystemsengineering/testimage:$TAG

--- a/tests/integration/workload-objects/StatefulSet.yaml
+++ b/tests/integration/workload-objects/StatefulSet.yaml
@@ -1,0 +1,33 @@
+---
+# https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+apiVersion: $APIVERSION
+kind: StatefulSet
+metadata:
+  name: statefulset-$TAG
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: statefulset-test
+  serviceName: "statefulset-test"
+  template:
+    metadata:
+      labels:
+        app: statefulset-test
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: cronjob-container
+          image: docker.io/securesystemsengineering/testimage:$TAG
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+  volumeClaimTemplates:
+    - metadata:
+        name: tmp
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Mi
+        storageClassName: "my-storage-class"


### PR DESCRIPTION
fixes #382 

## description
- adds integration tests for workload objects and api versions for each Kubernetes version
- fixes currently unsupported api versions

## checklist
- [x] according to Contributing guide
- [x] tests added where necessary