### PR TITLE
feat: multi-signer support for cosign

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -206,6 +206,7 @@ jobs:
             "load",
             "regular",
             "cosign",
+            "multi-cosigned",
             "namespace-val",
             "deployment",
             "pre-config",

--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -25,5 +25,17 @@ jobs:
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:co-unsigned
       - name: Check Cosign test image signed with alternative key
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:co-signed-alt
+      - name: Check Cosign multisigner test image signed by alice
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-alice
+      - name: Check Cosign multisigner test image signed by bob
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-bob
+      - name: Check Cosign multisigner test image signed by charlie
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-charlie
+      - name: Check Cosign multisigner test image signed by bob and charlie
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-bob-charlie
+      - name: Check Cosign multisigner test image signed by charlie and alice
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-charlie-alice
+      - name: Check Cosign multisigner test image signed by alice, bob and charlie
+        run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/testimage:multi-cosigned-alice-bob-charlie
       - name: Check alerting endpoint image
         run: DOCKER_CONTENT_TRUST=0 docker pull docker.io/securesystemsengineering/alerting-endpoint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,14 @@ jobs:
     needs: [version-match]
     strategy:
       matrix:
-        integration-test-arg: ["regular", "cosign", "deployment", "pre-config"]
+        integration-test-arg:
+          [
+            "regular",
+            "cosign",
+            "multi-cosigned",
+            "deployment",
+            "pre-config",
+          ]
     services:
       alerting-endpoint:
         image: securesystemsengineering/alerting-endpoint

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -1,8 +1,11 @@
+# import asyncio
 import json
 import logging
 import os
 import re
 import subprocess  # nosec
+
+from concurrent.futures import ThreadPoolExecutor
 
 from connaisseur.crypto import load_key
 from connaisseur.exceptions import (
@@ -21,42 +24,115 @@ from connaisseur.validators.interface import ValidatorInterface
 class CosignValidator(ValidatorInterface):
     name: str
     trust_roots: list
+    vals: dict  # validations, a dict for each required trust root containing validated digests or errors
     k8s_keychain: bool
 
     def __init__(self, name: str, trust_roots: list, auth: dict = None, **kwargs):
         super().__init__(name, **kwargs)
         self.trust_roots = trust_roots
+        self.vals = {}
         self.k8s_keychain = False if auth is None else auth.get("k8s_keychain", False)
-
-    def __get_key(self, key_name: str = None):
-        key_name = key_name or "default"
-        try:
-            key = next(
-                key["key"] for key in self.trust_roots if key["name"] == key_name
-            )
-        except StopIteration as err:
-            msg = 'Trust root "{key_name}" not configured for validator "{validator_name}".'
-            raise NotFoundException(
-                message=msg, key_name=key_name, validator_name=self.name
-            ) from err
-        return "".join(key)
 
     async def validate(
         self, image: Image, trust_root: str = None, **kwargs
     ):  # pylint: disable=arguments-differ
-        key = self.__get_key(trust_root)
-        return self.__get_cosign_validated_digests(str(image), key).pop()
+        required = kwargs.get("required", [])
+        # if not configured, `threshold` is 1 if trust root is not "*" or
+        # `required` is specified and number of trust roots otherwise
+        threshold = kwargs.get(
+            "threshold",
+            1 if trust_root != "*" or any(required) else len(self.trust_roots),
+        )
 
-    def __get_cosign_validated_digests(self, image: str, key: str):
+        self.vals = self.__get_pinned_keys(trust_root, required, threshold)
+
+        # use concurrent.futures for now
+        # tasks = [self.__validation_task(k, str(image)) for k in self.vals.keys()]
+        # await asyncio.gather(*tasks)
+
+        # prepare executor
+        num_workers = len(self.vals)
+        executor = ThreadPoolExecutor(num_workers)
+        # prepare tasks
+        arguments = [(k, str(image)) for k in self.vals.keys()]
+        futures = [executor.submit(self.__validation_task, *arg) for arg in arguments]
+        # await results (output dropped as `self.vals` is updated within function)
+        for future in futures:
+            future.result()
+
+        return CosignValidator.__apply_policy(
+            vals=self.vals, threshold=threshold, required=required
+        )
+
+    def __get_pinned_keys(self, key_name: str, required: list, threshold: int):
+        """
+        Extract the pinned key(s) selected for validation from the list of trust roots.
+        """
+        key_name = key_name or "default"
+        available_keys = list(map(lambda k: k["name"], self.trust_roots))
+
+        # generate list of pinned keys
+        if key_name == "*":
+            if len(required) >= threshold:
+                pinned_keys = required
+            else:
+                pinned_keys = available_keys
+        else:
+            pinned_keys = [key_name]
+
+        # check if pinned keys exist in available trust roots
+        missing_keys = set(pinned_keys) - set(available_keys)
+        if missing_keys:
+            msg = 'Trust roots "{key_names}" not configured for validator "{validator_name}".'
+            raise NotFoundException(
+                message=msg,
+                key_names=", ".join(missing_keys),
+                validator_name=self.name,
+            )
+
+        # construct key validation dictionary for pinned keys
+        keys = {
+            k["name"]: {
+                "name": k["name"],
+                "key": "".join(k["key"]),
+                "digest": None,
+                "error": None,
+            }
+            for k in self.trust_roots
+            if k["name"] in pinned_keys
+        }
+
+        return keys
+
+    # async def __validation_task(self, trust_root: str, image: str):
+    def __validation_task(self, trust_root: str, image: str):
+        """
+        Async task for each validation to gather all required validations,
+        execute concurrently and update results.
+        """
+        try:
+            # self.vals[trust_root]["digest"] = await self.__get_cosign_validated_digests(
+            self.vals[trust_root]["digest"] = self.__get_cosign_validated_digests(
+                image, self.vals[trust_root]
+            )
+        except Exception as err:
+            self.vals[trust_root]["error"] = err
+            logging.info(err)
+
+    # async def __get_cosign_validated_digests(self, image: str, trust_root: dict):
+    def __get_cosign_validated_digests(self, image: str, trust_root: dict):
         """
         Get and process Cosign validation output for a given `image` and `key`
         and either return a list of valid digests or raise a suitable exception
         in case no valid signature is found or Cosign fails.
         """
-        returncode, stdout, stderr = self.__invoke_cosign(image, key)
+        # returncode, stdout, stderr = await self.__invoke_cosign(image, trust_root["key"])
+        returncode, stdout, stderr = self.__invoke_cosign(image, trust_root["key"])
+
         logging.info(
-            "COSIGN output for image: %s; RETURNCODE: %s; STDOUT: %s; STDERR: %s",
-            image,
+            "COSIGN output of trust root '%s' for image'%s': RETURNCODE: %s; STDOUT: %s; STDERR: %s",
+            trust_root["name"],
+            str(image),
             returncode,
             stdout,
             stderr,
@@ -79,7 +155,13 @@ class CosignValidator(ValidatorInterface):
                             "received by Cosign: {err_type}: {err}"
                         )
                         raise UnexpectedCosignData(
-                            message=msg, err_type=type(err).__name__, err=str(err)
+                            message=msg,
+                            err_type=type(err).__name__,
+                            err=str(err),
+                            trust_data_type="dev.cosignproject.cosign/signature",
+                            stderr=stderr,
+                            image=str(image),
+                            trust_root=trust_root["name"],
                         ) from err
                     # remove prefix 'sha256'
                     digests.append(digest.removeprefix("sha256:"))
@@ -92,6 +174,8 @@ class CosignValidator(ValidatorInterface):
                 message=msg,
                 trust_data_type="dev.cosignproject.cosign/signature",
                 stderr=stderr,
+                image=str(image),
+                trust_root=trust_root["name"],
             )
         elif "Error: no matching signatures:\n\nmain.go:" in stderr:
             msg = 'No trust data for image "{image}".'
@@ -100,6 +184,7 @@ class CosignValidator(ValidatorInterface):
                 trust_data_type="dev.cosignproject.cosign/signature",
                 stderr=stderr,
                 image=str(image),
+                trust_root=trust_root["name"],
             )
         else:
             msg = 'Unexpected Cosign exception for image "{image}": {stderr}.'
@@ -108,30 +193,29 @@ class CosignValidator(ValidatorInterface):
                 trust_data_type="dev.cosignproject.cosign/signature",
                 stderr=stderr,
                 image=str(image),
+                trust_root=trust_root["name"],
             )
         if not digests:
             msg = (
                 "Could not extract any digest from data received by Cosign "
                 "despite successful image verification."
             )
-            raise UnexpectedCosignData(message=msg)
-        return digests
+            raise UnexpectedCosignData(
+                message=msg,
+                trust_data_type="dev.cosignproject.cosign/signature",
+                stderr=stderr,
+                image=str(image),
+                trust_root=trust_root["name"],
+            )
+        return digests.pop()
 
-    def __invoke_cosign(self, image, key):
+    # async def __invoke_cosign(self, image: str, key: str):
+    def __invoke_cosign(self, image: str, key: str):
         """
         Invoke the Cosign binary in a subprocess for a specific `image` given a `key` and
         return the returncode, stdout and stderr. Will raise an exception if Cosign times out.
         """
         pubkey_config, env_vars, pubkey = CosignValidator.__get_pubkey_config(key)
-
-        env = os.environ.copy()
-        # Extend the OS env vars only for passing to the subprocess below
-        env["DOCKER_CONFIG"] = f"/app/connaisseur-config/{self.name}/.docker/"
-        if safe_path_func(
-            os.path.exists, "/app/certs/cosign", f"/app/certs/cosign/{self.name}.crt"
-        ):
-            env["SSL_CERT_FILE"] = f"/app/certs/cosign/{self.name}.crt"
-        env.update(env_vars)
 
         cmd = [
             "/app/cosign/cosign",
@@ -145,7 +229,7 @@ class CosignValidator(ValidatorInterface):
 
         with subprocess.Popen(  # nosec
             cmd,
-            env=env,
+            env=self.__get_envs().update(env_vars),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -184,6 +268,90 @@ class CosignValidator(ValidatorInterface):
 
         msg = "Public key (reference) '{input_str}' does not match expected patterns."
         raise InvalidFormatException(message=msg, input_str=key)
+
+    def __get_envs(self):
+        """
+        Sets up environment variables used by cosign.
+        """
+        env = os.environ.copy()
+        # Extend the OS env vars only for passing to the subprocess below
+        env["DOCKER_CONFIG"] = f"/app/connaisseur-config/{self.name}/.docker/"
+        if safe_path_func(
+            os.path.exists, "/app/certs/cosign", f"/app/certs/cosign/{self.name}.crt"
+        ):
+            env["SSL_CERT_FILE"] = f"/app/certs/cosign/{self.name}.crt"
+        return env
+
+    @staticmethod
+    def __apply_policy(vals: dict, threshold: int, required: list):
+        """
+        Validates the signature verification outcome against the policy for
+        threshold and required trust roots.
+
+        Raises an exception if not compliant.
+        """
+
+        # verify threshold
+        signed_digests = [k["digest"] for k in vals.values() if k["digest"] is not None]
+        # raise exception if the same digest does not appear 'threshold' times
+        if not len(set(signed_digests)) == 1 or not len(signed_digests) >= threshold:
+            # simply raise the specific error if single specified trust root
+            if len(vals) == 1:
+                raise list(vals.values())[0]["error"]
+
+            # aggregate exception message and reasons for multiple trust roots
+            errs = "\n".join(
+                [
+                    f"* trust root '{e['name']}': {e['error'].message}"
+                    for e in vals.values()
+                    if e["error"] is not None
+                ]
+            )
+            msg = (
+                "Image not compliant with validation policy (threshold of "
+                "'{threshold}' not reached). The following errors occurred "
+                "(please check the logs for more information):\n{errors}"
+            )
+            raise ValidationError(
+                message=msg,
+                trust_data_type="dev.cosignproject.cosign/signature",
+                threshold=str(threshold),
+                required=required,
+                errors=errs,
+            )
+
+        digest = signed_digests[0]
+
+        # verify required trust roots
+        missing_trust_roots = []
+        for trust_root in required:
+            if not vals[trust_root]["digest"] == digest:
+                missing_trust_roots.append(trust_root)
+
+        if missing_trust_roots:
+            errs = "\n".join(
+                [
+                    f"* trust root '{e['name']}': {e['error'].message}"
+                    for e in vals.values()
+                    if e["name"] in missing_trust_roots
+                ]
+            )
+            msg = (
+                "Image not compliant with validation policy (missing signatures "
+                "for required trust roots: {missing}). The following errors occurred "
+                "(please check the logs for more information):\n{errors}"
+            )
+
+            raise ValidationError(
+                message=msg,
+                trust_data_type="dev.cosignproject.cosign/signature",
+                threshold=str(threshold),
+                required=required,
+                missing=", ".join(missing_trust_roots),
+                errors=errs,
+            )
+
+        return digest
 
     @property
     def healthy(self):

--- a/docs/validators/sigstore_cosign.md
+++ b/docs/validators/sigstore_cosign.md
@@ -99,6 +99,15 @@ kubectl run altsigned --image=docker.io/securesystemsengineering/testimage:co-si
 | `auth.k8s_keychain` | false | | When true, pass `--k8s-keychain` argument to `cosign verify` in order to use workload identities for authentication. See additional notes [below](#k8s_keychain). |
 | `cert` | | | A certificate in PEM format for private registries. |
 
+`.policy[*]` in `helm/values.yaml` supports the following additional keys and modifications for sigstore/Cosign (refer to [basics](../basics.md#image-policy) for more information on default keys):
+
+| Key | Default | Required | Description |
+| - | - | - | - |
+| `with.trust_root` | - | :heavy_check_mark: | Setting the name of trust root to `"*"` enables verification of multiple trust roots. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
+| `with.threshold` | - | - | Minimum number of signatures required in case `with.trust_root` is set to `"*"`. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
+| `with.required` | `[]` | - | Array of required trust roots referenced by name in case `with.trust_root` is set to `"*"`. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
+
+
 ### Example
 
 ```yaml
@@ -119,6 +128,7 @@ policy:
   with:
     key: mykey
 ```
+
 
 ## Additional notes
 
@@ -220,6 +230,95 @@ Such environment variables can be injected into Connaisseur via `deployment.envs
     VAULT_ADDR: myvault.com
     VAULT_TOKEN: secrettoken
 ```
+
+### Multi-signature verification
+
+> :warning: This is currently an experimental feature that might be unstable over time.
+> As such, it is not part of our semantic versioning guarantees and we take the liberty to adjust or remove it with any version at any time without incrementing MAJOR or MINOR.
+
+Connaisseur can verify multiple signatures for a single image.
+It is possible to configure a threshold number and specific set of required valid signatures.
+This allows to implement several advanced use cases (and policies):
+
+* Five maintainers of a repository are able to sign a single derived image, however at least 3 signatures are required for the image to be valid.
+* In a CI pipeline, a container image is signed directly after pushing by the build job and at a later time by passing quality gates such as security scanners or integration tests, each with their own key (trust root). Validation requires all of these signatures for deployment to enforce integrity and quality gates.
+* A mixture of the above use cases whereby several specific trust roots are enforced (e.g. automation tools) and the overall number of signatures has to surpass a certain threshold (e.g. at least one of the testers admits).
+* Key rotation is possible by adding a new key as an additional key and require at least one valid signature.
+
+Multi-signature verification is scoped to the trust roots specified within a referenced validator.
+Consider the following validator configuration:
+
+```yaml
+validators:
+- name: multicosigner
+  type: cosign
+  trust_roots:
+  - name: alice
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEusIAt6EJ3YrTHdg2qkWVS0KuotWQ
+      wHDtyaXlq7Nhj8279+1u/l5pZhXJPW8PnGRRLdO5NbsuM6aT7pOcP100uw==
+      -----END PUBLIC KEY-----
+  - name: bob
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01DasuXJ4rfzAEXsURSnbq4QzJ6o
+      EJ2amYV/CBKqEhhl8fDESxsmbdqtBiZkDV2C3znIwV16SsJlRRYO+UrrAQ==
+      -----END PUBLIC KEY-----
+  - name: charlie
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEHBUYJVrH+aFYJPuryEkRyE6m0m4
+      ANj+o/oW5fLRiEiXp0kbhkpLJR1LSwKYiX5Toxe3ePcuYpcWZn8Vqe3+oA==
+      -----END PUBLIC KEY-----
+```
+
+The trust roots `alice`, `bob`, and `charlie` are all included for verification in case `.policy[*].with.trust_root` is set to `"*"` (note that this is a special flag, not a real wildcard):
+
+```yaml
+- pattern: "*:*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+```
+
+As neither `threshold` nor `required` are specified, Connaisseur will require signatures of all trust roots (`alice`, `bob`, and `charlie`) and deny an image otherwise.
+If either `threshold` or `required` is specified, it takes precedence.
+For example, it is possible to configure a threshold number of required signatures via the `threshold` key:
+
+```yaml
+- pattern: "*:*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+    threshold: 2
+```
+
+In this case, valid signatures of two or more out of the three trust roots are required for admittance.
+Using the `required` key, it is possible to enforce specific trusted roots:
+
+```yaml
+- pattern: "*:*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+    required: ["alice", "bob"]
+```
+
+Now, only images with valid signatures of trust roots `alice` and `bob` are admitted.
+It is possible to combine `threshold` and `required` keys:
+
+```yaml
+- pattern: "*:*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+    threshold: 3
+    required: ["alice", "bob"]
+```
+
+Thus, at least 3 valid signatures are required and `alice` and `bob` must be among those.
+
 
 ### Verification against transparency log
 

--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -78,6 +78,49 @@ test_cases:
     namespace: default
     expected_msg: pod/pod-cs created
     expected_result: null
+  multi-cosigned:
+  - id: mc-u
+    txt: Testing multi-cosigned image `threshold` => undefined, not reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-alice
+    namespace: default
+    expected_msg: Image not compliant with validation policy (threshold of '3' not reached).
+    expected_result: null
+  - id: mc-s
+    txt: Testing multi-cosigned image `threshold` => undefined, reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-alice-bob-charlie
+    namespace: default
+    expected_msg: pod/pod-mc-s created
+    expected_result: null
+  - id: mct2-u
+    txt: Testing multi-cosigned image `threshold` => 2, not reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-bob
+    namespace: default
+    expected_msg: Image not compliant with validation policy (threshold of '2' not reached).
+    expected_result: null
+  - id: mct2-s
+    txt: Testing multi-cosigned image `threshold` => 2, reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-bob-charlie
+    namespace: default
+    expected_msg: pod/pod-mct2-s created
+    expected_result: null
+  - id: mcr-u
+    txt: Testing multi-cosigned image `required` signers => ['alice', 'charlie'], not reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-charlie
+    namespace: default
+    expected_msg: "Image not compliant with validation policy (missing signatures for required trust roots: alice)."
+    expected_result: null
+  - id: mcr-s
+    txt: Testing multi-cosigned image `required` signers => ['alice', 'charlie'], reached...
+    type: deploy
+    ref: securesystemsengineering/testimage:multi-cosigned-charlie-alice
+    namespace: default
+    expected_msg: pod/pod-mcr-s created
+    expected_result: null
   ignore-namespace-val:
   - id: iuu
     txt: Testing unsigned image in unlabelled namespace...

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -235,6 +235,11 @@ cosign_int_test() {
   multi_test "cosign"
 }
 
+### MULTI-COSIGNed TEST ####################################
+multi-cosigned_int_test() {
+  multi_test "multi-cosigned"
+}
+
 ### NAMESPACE VALIDATION TEST ####################################
 namespace_val_int_test() {
   echo -n "Creating namespaces..."
@@ -271,6 +276,11 @@ case $1 in
   update_via_env_vars
   make_install
   cosign_int_test
+  ;;
+"multi-cosigned")
+  update_via_env_vars
+  make_install
+  multi-cosigned_int_test
   ;;
 "namespace-val")
   update_via_env_vars

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -36,6 +36,27 @@ validators:
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvtc/qpHtx7iUUj+rRHR99a8mnGni
       qiGkmUb9YpWWTS4YwlvwdmMDiGzcsHiDOYz6f88u2hCRF5GUCvyiZAKrsA==
       -----END PUBLIC KEY-----
+- name: multicosigner
+  type: cosign
+  trust_roots:
+  - name: alice
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEusIAt6EJ3YrTHdg2qkWVS0KuotWQ
+      wHDtyaXlq7Nhj8279+1u/l5pZhXJPW8PnGRRLdO5NbsuM6aT7pOcP100uw==
+      -----END PUBLIC KEY-----
+  - name: bob
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01DasuXJ4rfzAEXsURSnbq4QzJ6o
+      EJ2amYV/CBKqEhhl8fDESxsmbdqtBiZkDV2C3znIwV16SsJlRRYO+UrrAQ==
+      -----END PUBLIC KEY-----
+  - name: charlie
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEHBUYJVrH+aFYJPuryEkRyE6m0m4
+      ANj+o/oW5fLRiEiXp0kbhkpLJR1LSwKYiX5Toxe3ePcuYpcWZn8Vqe3+oA==
+      -----END PUBLIC KEY-----
 policy:
 - pattern: "*:*"
   validator: dockerhub-basics
@@ -47,6 +68,20 @@ policy:
   validator: allow
 - pattern: docker.io/securesystemsengineering/testimage:co-*
   validator: cosign
+- pattern: "docker.io/securesystemsengineering/testimage:multi-cosigned-alice*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+- pattern: "docker.io/securesystemsengineering/testimage:multi-cosigned-bob*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+    threshold: 2
+- pattern: "docker.io/securesystemsengineering/testimage:multi-cosigned-charlie*"
+  validator: multicosigner
+  with:
+    trust_root: "*"
+    required: ["alice", "charlie"]
 - pattern: "docker.io/securesystemsengineering/testimage:special_sig"
   validator: dockerhub-basics
   with:


### PR DESCRIPTION
Fixes #375

## Description

- a container image can be signed by multiple signers using different keys
- this feature enables validation against all, a threshold number of or specific required trust roots of a validator
- concurrent processing of signatures via asyncio is currently blocked by a asyncio bug
  - [Stackoverflow discussion](https://stackoverflow.com/questions/70624413/how-to-read-from-dev-stdin-with-asyncio-create-subprocess-exec)
  - [Python bug report](https://bugs.python.org/issue46364)
- concurrency is (for now) implemented via [`concurrent.futures`](https://docs.python.org/3/library/concurrent.futures.html)
  - futures yield a significant speedup as shown below
  - once the asyncio bug is fixed, both should be benchmarked again

## concurrency benchmark
### 3 signers, denying
#### asyncio (non-functional)
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.18s user 0.07s system 3% cpu 7.411 total
```

#### concurrent.futures
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.18s user 0.06s system 6% cpu 3.456 total
```

### 6 signers, denying
#### asyncio (non-functional)
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'doug': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'eve': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'fein': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.22s user 0.04s system 1% cpu 14.861 total
```


#### concurrent.futures
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'doug': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'eve': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'fein': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.20s user 0.05s system 6% cpu 3.535 total
```


### 9 signers, denying
#### asyncio (non-functional)
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'doug': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'eve': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'fein': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'george': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'harry': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'ines': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.22s user 0.04s system 1% cpu 22.449 total
```


#### concurrent.futures
```bash
$ time k run unsigned --image=docker.io/securesystemsengineering/testimage:unsigned
Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Image not compliant with validation policy (threshold of '2' not reached). The following errors occurred (please check the logs for more information):
* trust root 'alice': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'bob': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'charlie': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'doug': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'eve': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'fein': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'george': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'harry': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
* trust root 'ines': No trust data for image "docker.io/securesystemsengineering/testimage:unsigned".
kubectl run unsigned   0.20s user 0.04s system 4% cpu 4.838 total

```


## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

