### PR TITLE
feat: cosign private registry

### DIFF
--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -130,6 +130,10 @@
                                     },
                                     "minItems": 1,
                                     "uniqueItems": true
+                                },
+                                "cert": {
+                                    "type": "string",
+                                    "pattern": "(?:-+BEGIN\\sCERTIFICATE[-]+)\n(?:(?:[A-Za-z0-9+\/\\s])*={0,4})\n(?:-+END\\sCERTIFICATE[-]+)"
                                 }
                             },
                             "required": [

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -14,6 +14,7 @@ from connaisseur.exceptions import (
     ValidationError,
 )
 from connaisseur.image import Image
+from connaisseur.util import safe_path_func  # nosec
 from connaisseur.validators.interface import ValidatorInterface
 
 
@@ -121,9 +122,13 @@ class CosignValidator(ValidatorInterface):
         """
         pubkey_config, env_vars, pubkey = CosignValidator.__get_pubkey_config(key)
 
-        env = os.environ
+        env = os.environ.copy()
         # Extend the OS env vars only for passing to the subprocess below
         env["DOCKER_CONFIG"] = f"/app/connaisseur-config/{self.name}/.docker/"
+        if safe_path_func(
+            os.path.exists, "/app/certs/cosign", f"/app/certs/cosign/{self.name}.crt"
+        ):
+            env["SSL_CERT_FILE"] = f"/app/certs/cosign/{self.name}.crt"
         env.update(env_vars)
 
         cmd = [

--- a/docs/validators/sigstore_cosign.md
+++ b/docs/validators/sigstore_cosign.md
@@ -96,6 +96,7 @@ kubectl run altsigned --image=docker.io/securesystemsengineering/testimage:co-si
 | `host` | | | Not yet implemented. |
 | `auth.` | | | Authentication credentials for private registries. |
 | `auth.secret_name` | | | Name of a Kubernetes secret in Connaisseur namespace that contains [dockerconfigjson](https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets) for registry authentication. See additional notes [below](#authentication). |
+| `cert` | | | A certificate in PEM format for private registries. |
 
 ### Example
 

--- a/helm/templates/config-secrets.yaml
+++ b/helm/templates/config-secrets.yaml
@@ -8,3 +8,16 @@ metadata:
 type: Opaque
 data:
   config-secrets.yaml: {{ include "config-secrets" . | b64enc }}
+---
+{{- if (include "hasCosignCerts" .) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Chart.Name }}-cosign-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "helm.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- include "getCosignCerts" . -}}
+{{- end -}}

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -14,6 +14,7 @@ data:
         {{- $_ := unset $validator "auth" -}}
       {{- else if eq $validator.type "notaryv2" -}}
       {{- else if eq $validator.type "cosign" -}}
+        {{- $_ := unset $validator "cert" -}}
       {{- end }}
     - {{- $validator | toYaml | trim | nindent 6 -}}
     {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
               subPath: config-secrets.yaml
               readOnly: true
             {{ include "external-secrets-mount" . | nindent 12}}
+            {{ include "cosignCertVolMount" . | nindent 12 }}
           envFrom:
             - configMapRef:
                 name: {{ .Chart.Name }}-env
@@ -105,3 +106,4 @@ spec:
           secret:
             secretName: {{ .Chart.Name }}-config-secrets
         {{ include "external-secrets-vol" . | nindent 8}}
+        {{ include "cosignCertVol" . | nindent 8 }}


### PR DESCRIPTION
For cosign validators, a new field (`cert`) has been added so that cosign signatures can be validated against registries with selfsigned certificates.

fixes #324