### PR TITLE
fix: allow localhost as notary server

### DIFF
--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -37,7 +37,7 @@
                             "properties": {
                                 "host": {
                                     "type": "string",
-                                    "pattern": "[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}"
+                                    "pattern": "([-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}(\\:\\d{2,5})?)|(localhost(\\:\\d{2,5})?)"
                                 },
                                 "trust_roots": {
                                     "type": [

--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -37,7 +37,7 @@
                             "properties": {
                                 "host": {
                                     "type": "string",
-                                    "pattern": "([-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}(\\:\\d{2,5})?)|(localhost(\\:\\d{2,5})?)"
+                                    "pattern": "(([-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6})|(localhost))(\\:\\d{2,5})?"
                                 },
                                 "trust_roots": {
                                     "type": [

--- a/tests/data/config/err6.yaml
+++ b/tests/data/config/err6.yaml
@@ -1,0 +1,7 @@
+validators:
+- name: wrong_host
+  type: notaryv1
+  host: 猫
+  trust_roots: []
+policy:
+- pattern: "*:*"

--- a/tests/data/config/sample_config.yaml
+++ b/tests/data/config/sample_config.yaml
@@ -71,6 +71,14 @@ validators:
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
         QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
         -----END PUBLIC KEY-----
+- name: localhost
+  type: notaryv1
+  host: localhost
+  trust_roots: []
+- name: localhost_port
+  type: notaryv1
+  host: localhost:4443
+  trust_roots: []
 policy:
 - pattern: "*:*"
   with:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,8 @@ static_config = {
         {"name": "deny", "type": static},
         {"name": "cosign-example", "type": cosign},
         {"name": "ext", "type": nv1},
+        {"name": "localhost", "type": nv1},
+        {"name": "localhost_port", "type": nv1},
     ],
     "policy": [
         {"pattern": "*:*", "with": {"delegations": ["phbelitz", "chamsen"]}},
@@ -105,6 +107,13 @@ match_image_digest = (
             "err5",
             pytest.raises(
                 exc.InvalidConfigurationFormatError, match=r".*invalid format.*"
+            ),
+        ),
+        (
+            "err6",
+            pytest.raises(
+                exc.InvalidConfigurationFormatError,
+                match=r".*Connaisseur configuration.*",
             ),
         ),
     ],


### PR DESCRIPTION
The configration pattern no longer blocks localhost as a valid notary host path and also allows port specifications.

fixes #445

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

