### PR TITLE
feat: implement imagePullSecrets for private container registries

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ .Chart.Name }}-serviceaccount
+    {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.deployment.image }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,6 +3,10 @@ deployment:
   replicasCount: 3
   image: securesystemsengineering/connaisseur:v2.3.0
   imagePullPolicy: IfNotPresent
+  # imagePullSecrets contains an optional list of Kubernetes Secrets, in connaisseur namespace,
+  # that are needed to access the registry containing connaisseur image.
+  # imagePullSecrets:
+  # - name: "my-container-secret"
   failurePolicy: Fail  # use 'Ignore' to fail open if Connaisseur becomes unavailable
   resources:
     limits:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow the deployment manifests to use a secret to pull images.

<!--- Reference respective issue if it exists -->
Fixes #

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

