### PR TITLE
feat: support extra configuration in helm chart

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
               readOnly: true
             {{ include "external-secrets-mount" . | nindent 12}}
             {{ include "cosignCertVolMount" . | nindent 12 }}
+            {{- if .Values.deployment.extraVolumeMounts }}
+            {{ tpl (toYaml .Values.deployment.extraVolumeMounts) . | nindent 12}}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ .Chart.Name }}-env
@@ -81,6 +84,9 @@ spec:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+        {{- if .Values.deployment.extraContainers }}
+        {{ tpl (toYaml .Values.deployment.extraContainers) . | nindent 8}}
+        {{- end }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -111,3 +117,6 @@ spec:
             secretName: {{ .Chart.Name }}-config-secrets
         {{ include "external-secrets-vol" . | nindent 8}}
         {{ include "cosignCertVol" . | nindent 8 }}
+        {{- if .Values.deployment.extraVolumes }}
+        {{ tpl (toYaml .Values.deployment.extraVolumes) . | nindent 8}}
+        {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,6 +48,10 @@ deployment:
     enabled: false
     name: ["connaisseur-psp"]  # list of PSPs to use, "connaisseur-psp" is the project-provided default
   envs: {} # dict of additional environment variables, which will be stored as a secret and injected into the Connaisseur pods
+  # Extra config
+  extraContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
 
 # configure Connaisseur service
 service:


### PR DESCRIPTION
## Description
It is common practice for helm charts to provide "extra configuration" abilities to tweak the kubernetes deployment.
This PR provides a generic approach to bring extra configuration such as sidecar containers and extra volumes.

This make it easier to fixes https://github.com/sse-secure-systems/connaisseur/issues/390

## Use case example
For example, with only helm values on the user side, this allow to configure a sidecar container to run a ECR token refresher.

This is another alternative of the cronjob solution (https://github.com/sse-secure-systems/connaisseur/discussions/411) to address the private ECR (short-life) token refresh need, without pod restarts, thanks to the use of sidecar container.

User config example:
```
deployment:
  extraVolumes:
    - name: refresher-vol
      emptyDir: {}
  extraVolumeMounts:
    - mountPath: /app/connaisseur-config/verify-aws-ecr/.docker/
      name: refresher-vol
      readOnly: true
  extraContainers:
    - name: refresher
      image: amazon/aws-cli:2.4.12
      volumeMounts:
        - mountPath: /app/connaisseur-config/verify-aws-ecr/.docker/
          name: refresher-vol
      command:
        - bash
        - -c
        - |
          while true; do
          password="`aws ecr get-login-password`"
          cat > /app/connaisseur-config/verify-aws-ecr/.docker/config.json <<EOF
          {
            "auths": {
              "[AWS_ACCOUNT_ID].dkr.ecr.us-west-2.amazonaws.com": {
                "username": "AWS",
                "password": "$password"
              }
            }
          }
          EOF

          echo ECR token refreshed
          sleep 3600; done
```