### PR TITLE
ci: fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,9 +54,7 @@ jobs:
           echo ALERTING_ENDPOINT_IP=${ALERTING_ENDPOINT_IP} >> $GITHUB_ENV
       - name: Configure Connaisseur and show configuration
         run: |
-          if [[ ! (${{ matrix.integration-test-arg }} == 'pre-config') ]]; then
-            yq eval -i '.deployment.imagePullPolicy="IfNotPresent"' helm/values.yaml
-          fi
+          yq eval -i '.deployment.imagePullPolicy="IfNotPresent"' tests/integration/update.yaml
           echo "::group::values.yaml"
           yq e '.' helm/values.yaml
           echo "::endgroup::"

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -282,7 +282,8 @@ case $1 in
   deployment_int_test
   ;;
 "pre-config")
-  update_values '.deployment.imagePullPolicy="Never"'
+  IPP=`yq e '.deployment.imagePullPolicy' tests/integration/update.yaml`
+  update_values '.deployment.imagePullPolicy=strenv(IPP)'
   helm_install
   pre_config_int_test
   helm_uninstall


### PR DESCRIPTION
Fixes the release pipeline.

## Description

The `ImagePullPolicy` for the release pipeline was accedentially set to `Never`, thus no image could be loaded. This was fixed.

## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

