### PR TITLE
feat: silent healthz endpoints logging

### DIFF
--- a/connaisseur/logging_wrapper.py
+++ b/connaisseur/logging_wrapper.py
@@ -31,7 +31,10 @@ class ConnaisseurLoggingWrapper:
         result = self.app(environ, custom_start_response)
         # the server can "change it's mind" before sending the first response if exc_info is provided
         # hence we need to use the last status code provided
-        self.logger.info(_format_log(status_codes[-1], environ))
+        if environ.get("REQUEST_URI") in ["/ready", "/health"]:
+            self.logger.debug(_format_log(status_codes[-1], environ))
+        else:
+            self.logger.info(_format_log(status_codes[-1], environ))
         return result
 
 


### PR DESCRIPTION
## Issue
In INFO loglevel, the application healthz endpoints prints lot of logs (because of K8s live/ready-ness) which make hard to read the logs and consume logging storage.
A solution would be to disable the INFO loglevel, but this hides the genuine logs such as image verification operations.

Some flask module suggest to disable the logs on these endpoints, for example: https://pypi.org/project/flask-healthz/, using `no_log` option.

## Description
This PR changes the loglevel of the HTTP requests handled by the healthz endpoints to DEBUG, to avoid cluttering the web log files with automated requests.