### PR TITLE
fix: corrected typo in ClusterRole helm template

### DIFF
--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "helm.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["*"]
-  resources: ["deployments", "pods", "replicacontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "imagepolicies", "mutatingwebhookconfigurations"]
+  resources: ["deployments", "pods", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "imagepolicies", "mutatingwebhookconfigurations"]
   verbs: ["get"]
 {{- if .Values.deployment.podSecurityPolicy }}
 {{- if .Values.deployment.podSecurityPolicy.enabled }}


### PR DESCRIPTION
# General summary
"replicacontrollers" is not a valid kubernetes object.
Authors probably meant "replicationcontrollers".

## Description
In my connaisseur pods, I see error logs such as:
"requests.exceptions.HTTPError: 403 Client Error: Forbidden" for replicationcontrollers api calls.
After editing clusterrole connaisseur-role, replacing "replicacontrollers" with "replicationcontrollers", and doing a rolling restart, those errors msg went away.

## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

