### PR TITLE
fix: updated REST path for core api group

### DIFF
--- a/connaisseur/workload_object.py
+++ b/connaisseur/workload_object.py
@@ -58,8 +58,13 @@ class WorkloadObject:
             name = owner["name"]
             uid = owner["uid"]
 
+            if api_version == "v1":
+                rest_path = "api"
+            else:
+                rest_path = "apis"
+
             parent = k_api.request_kube_api(
-                f"apis/{api_version}/namespaces/{self.namespace}/{kind}/{name}"
+                f"{rest_path}/{api_version}/namespaces/{self.namespace}/{kind}/{name}"
             )
 
             if parent["metadata"]["uid"] != uid:


### PR DESCRIPTION
## General summary
Connaisseur is making invalid API calls when checking for parent resource, when the parent resource is of type pod.

Fixes #513 

## Description
Adds rest_path variable that takes either following values:
- "api" if the apiVersion is "v1"
- "apis" otherwise

... to make sure the proper API call is made

## Checklist
- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)