### PR TITLE
feat: add reinvocationPolicy option

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -55,12 +55,15 @@ The upper `deployment` section offers some general Kubernetes typical configurat
 Noteworthy configurations are:
 
 - `deployment.failurePolicy`: Failure policy allows configuration whether the mutating admission webhook should fail closed (`Fail`, *default*) or open (`Ignore`) should the Connaisseur service become unavailable. While Connaisseur is configured to be secure by default, setting the [failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) to `Ignore` allows to prioritize cluster access[^1].
-- `deployment.securityContext`: Connaisseur ships with secure defaults. However, some keys are not supported by all versions or flavors of Kubernetes and might need adjustment[^2]. This is mentioned in the comments to the best of our knowledge.
+- `deployment.reinvocationPolicy`: [Reinvocation Policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy) defines whether Connaisseur is called again as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call (`IfNeeded`) or not (`Never`, *default*). Note that if Connaisseur is invoked a second time, the policy to be applied might change in between[^2]. Make sure, your Connaisseur policies are set up to handle multiple mutations of the image originally specified in the manifest, e.g. `my.private.registry/image:1.0.0` and `my.private.registry/image@sha256:<hash-of-1.0.0-image>`.
+- `deployment.securityContext`: Connaisseur ships with secure defaults. However, some keys are not supported by all versions or flavors of Kubernetes and might need adjustment[^3]. This is mentioned in the comments to the best of our knowledge.
 - `deployment.podSecurityPolicy`: Some clusters require a PSP. A secure default PSP for Connaisseur is available.
 
 [^1]: This is not to be confused with the [detection mode](features/detection_mode.md) feature: In detection mode, Conaisseur service admits all requests to the cluster independent of the validation result while the failure policy only takes effect when the service itself becomes unavailable.
 
-[^2]: In those cases, consider using security annotations via `deployment.annotations` or pod security policies `deployment.podSecurityPolicy` if available.
+[^2]: During the first mutation, Connaisseur converts the image tag to its digests. Read more in the [overview of Connaisseur](https://sse-secure-systems.github.io/connaisseur/v2.4.1/#trusted-digests)
+
+[^3]: In those cases, consider using security annotations via `deployment.annotations` or pod security policies `deployment.podSecurityPolicy` if available.
 
 The actual configuration consists of the `validators` and image `policy` sections.
 These are described in detail [below](#detailed-configuration) and for initials steps it is instructive to follow the [getting started guide](getting_started.md).
@@ -84,7 +87,7 @@ Install Connaisseur via Helm:
 === "Added via Helm"
 
     Install Connaisseur using the default configuration from the chart repository:
-    
+
     ```bash
     helm install connaisseur connaisseur/connaisseur --atomic --create-namespace --namespace connaisseur
     ```

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -33,6 +33,7 @@ metadata:
 webhooks:
   - name: {{ .Chart.Name }}-svc.{{ .Release.Namespace }}.svc
     failurePolicy: Ignore
+    reinvocationPolicy: {{ .Values.deployment.reinvocationPolicy | default "Never" }}
     clientConfig:
       service:
         name: {{ .Chart.Name }}-svc
@@ -61,11 +62,8 @@ metadata:
     "helm.sh/hook": post-install, post-upgrade, post-rollback
 webhooks:
   - name: {{ .Chart.Name }}-svc.{{ .Release.Namespace }}.svc
-    {{- if .Values.deployment.failurePolicy }}
-    failurePolicy: {{ .Values.deployment.failurePolicy }}
-    {{- else }}
-    failurePolicy: Fail
-    {{- end }}
+    failurePolicy: {{ .Values.deployment.failurePolicy | default "Fail" }}
+    reinvocationPolicy: {{ .Values.deployment.reinvocationPolicy | default "Never" }}
     clientConfig:
       service:
         name: {{ .Chart.Name }}-svc

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,12 @@ deployment:
   # imagePullSecrets:
   # - name: "my-container-secret"
   failurePolicy: Fail  # use 'Ignore' to fail open if Connaisseur becomes unavailable
+  # Use 'reinvocationPolicy: IfNeeded' to be called again as part of the admission evaluation if the object
+  # being admitted is modified by other admission plugins after the initial webhook call
+  # Note that if Connaisseur is invoked a second time, the policy to be applied might change in between.
+  # Make sure, your Connaisseur policies are set up to handle multiple mutations of the image originally
+  # specified in the manifest, e.g. my.private.registry/image:1.0.0 and my.private.registry/image@sha256:<hash-of-1.0.0-image>
+  reinvocationPolicy: Never
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add a value in the Helm chart to set `reinvocationPolicy` of `MutatingWebhookConfiguration`

## Description

It should be possible to set `reinvocationPolicy` (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy) for the MutatingWebhookConfiguration resource. 

My use case is:
- I want to make sure that only images from my private registry (which are signed) are used in my cluster
- Thus, for public images, I pull them, sign and then push them to my private registry
- I use `kyverno` to mutate all public images to my private images (e.g. `bitnami/bitnami-shell:10-debian-10-r99` become `my.private.registry/bitnami/bitnami-shell:10-debian-10-r99`
- So, I need `reinvocationPolicy: IfNeeded` to let Connaisseur reevaluate the request after it was mutated by `kyverno`.

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

