### PR TITLE
update: debian bullseye, ca-certificates, wget

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /requirements.txt
 RUN YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip install --no-cache-dir --prefix=/install -r /requirements.txt
 
 # Load and verify Cosign
-FROM debian:buster-slim as cosign_loader
+FROM debian:bullseye-slim as cosign_loader
 
 SHELL ["/bin/bash", "-c"]
 ARG COSIGN_VERSION
@@ -18,7 +18,7 @@ WORKDIR /go/cosign
 COPY docker/release-cosign.pub /go/cosign/release-cosign.pub
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends openssl=1.1.\* libssl1.1=1.1.\* ca-certificates=20200601\* wget=1.20.\* \
+ && apt-get install -y --no-install-recommends openssl=1.1.\* libssl1.1=1.1.\* ca-certificates=20210119\* wget=1.21\* \
  && wget -nv https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 \
  && wget -nv https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64.sig \
  && openssl dgst -sha256 -verify release-cosign.pub -signature <(base64 -d cosign-linux-amd64.sig) cosign-linux-amd64 \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #

## Description
Address vulnerabilities which require an upgrade of `ca-certificates` which is only available in debian bullseye-slim. Upgrading to debian bullseye-slim requires an upgrade of wget.
<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

