### PR TITLE
test: fix stresstest failure due to node w/o DCT

### DIFF
--- a/tests/integration/deployments/stresstest.yaml
+++ b/tests/integration/deployments/stresstest.yaml
@@ -32,7 +32,7 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: node
+      image: mongo
     - name: container4
       image: nginx
     - name: container5
@@ -56,7 +56,7 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: node
+      image: mongo
     - name: container4
       image: nginx
     - name: container5
@@ -87,7 +87,7 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: node
+      image: mongo
     - name: container4
       image: nginx
   initContainers:
@@ -112,7 +112,7 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: node
+      image: mongo
   initContainers:
     - name: init1
       image: busybox
@@ -120,4 +120,4 @@ spec:
     - name: init2
       image: redis
     - name: init3
-      image: node
+      image: mongo


### PR DESCRIPTION
node image seems to have dropped DCT support. switching to mongo image instead.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

- node seems to have deprecated DCT support causing stresstests to fail
- switching to mongo image instead for stresstests

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

