### PR TITLE
ci: fix changelogger for non-semantic commits

### DIFF
--- a/scripts/changelogger.py
+++ b/scripts/changelogger.py
@@ -1,10 +1,9 @@
-import re
 import requests
-import json
 import subprocess
 import time
 import argparse
 import base64
+import logging
 
 sep = "@@__CHGLOG__@@"
 delim = "@@__CHGLOG_DELIMITER__@@"
@@ -28,8 +27,13 @@ class Commit:
     def __init__(self, hash_: str, sub_cat_: str, token: str = None):
         self.hash_ = hash_.strip()
         cat_sub_split = sub_cat_.split(":", 1)
-        self.subject_ = cat_sub_split[1].strip()
-        self.categories_ = cat_sub_split[0].split("/")
+        try:
+            self.subject_ = ":".join(cat_sub_split[1:]).strip()
+            self.categories_ = cat_sub_split[0].split("/")
+        except IndexError:
+            logging.warn("Non semantic commit")
+            self.subject_ = cat_sub_split[0]
+            self.categories_ = ["none"]
         self.token = token
         self.pr_ = self.get_pr_link()
 


### PR DESCRIPTION
Should the changelogger find a non sematic commit, it previously crashed and could only run should the commit be reworded, resulting in a rebase of develop. Instead the changelogger has been changed to work with non semantic commits, giving a warning should one appear.

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

