### PR TITLE
test: fix unset variable in preconfig integration test

### DIFF
--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -282,7 +282,7 @@ case $1 in
   deployment_int_test
   ;;
 "pre-config")
-  IPP=`yq e '.deployment.imagePullPolicy' tests/integration/update.yaml`
+  export IPP=`yq e '.deployment.imagePullPolicy' tests/integration/update.yaml`
   update_values '.deployment.imagePullPolicy=strenv(IPP)'
   helm_install
   pre_config_int_test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As the actual update of the config values happens in its own bash function, the `IPP` variable is no longer set when performing the values.yaml update resulting in an empty value in the yaml file (`imagePullPolicy: ""`).

<!--- Reference respective issue if it exists -->
Fixes #

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

