### PR TITLE
feat: Support cosign --k8s-keychain flag

### DIFF
--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -148,14 +148,28 @@
                                 },
                                 "auth": {
                                     "type": "object",
-                                    "properties": {
-                                        "secret_name": {
-                                            "type": "string",
-                                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                                    "oneOf": [
+                                        {
+                                            "properties": {
+                                              "secret_name": {
+                                                  "type": "string",
+                                                  "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                                              }
+                                            },
+                                            "required": [
+                                                "secret_name"
+                                            ]
+                                        },
+                                        {
+                                            "properties": {
+                                              "k8s_keychain": {
+                                                  "type": "boolean"
+                                              }
+                                            },
+                                            "required": [
+                                                "k8s_keychain"
+                                            ]
                                         }
-                                    },
-                                    "required": [
-                                        "secret_name"
                                     ]
                                 },
                                 "cert": {

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -21,10 +21,12 @@ from connaisseur.validators.interface import ValidatorInterface
 class CosignValidator(ValidatorInterface):
     name: str
     trust_roots: list
+    k8s_keychain: bool
 
-    def __init__(self, name: str, trust_roots: list, **kwargs):
+    def __init__(self, name: str, trust_roots: list, auth: dict = None, **kwargs):
         super().__init__(name, **kwargs)
         self.trust_roots = trust_roots
+        self.k8s_keychain = False if auth is None else auth.get("k8s_keychain", False)
 
     def __get_key(self, key_name: str = None):
         key_name = key_name or "default"
@@ -137,6 +139,7 @@ class CosignValidator(ValidatorInterface):
             "--output",
             "text",
             *pubkey_config,
+            *(["--k8s-keychain"] if self.k8s_keychain else []),
             image,
         ]
 


### PR DESCRIPTION
<!--- Reference respective issue if it exists -->
Fixes #390

## Description

Add configuration option `k8s_keychain` for `cosign` validator that will pass the flag `--k8s-keychain` to `cosign` when set to true. This allows `cosign` to pick up registry credentials from the environment (see https://github.com/sigstore/cosign/pull/972 for details)

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)

