### PR TITLE
Expose k8s logs on failure

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -249,6 +249,11 @@ jobs:
         run: |
           bash tests/integration/integration-test.sh "${{ matrix.integration-test-arg }}"
         shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+        shell: bash
 
   k8s-versions:
     runs-on: ubuntu-latest
@@ -279,6 +284,11 @@ jobs:
       - name: Run pre-config and workload integration tests
         run: |
           bash tests/integration/integration-test.sh "pre-and-workload"
+        shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
         shell: bash
 
   upgrade-test:
@@ -319,6 +329,11 @@ jobs:
         run: |
           bash tests/integration/upgrade-integration-test.sh
         shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+        shell: bash
       - uses: actions/checkout@v2
       - name: Upgrade Connaisseur to current branch
         run: |
@@ -329,6 +344,11 @@ jobs:
       - name: Run integration tests (branch)
         run: |
           bash tests/integration/upgrade-integration-test.sh
+        shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
         shell: bash
       - name: Uninstall Connaisseur
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,11 @@ jobs:
         run: |
           bash tests/integration/integration-test.sh "${{ matrix.integration-test-arg }}"
         shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+        shell: bash
 
   publish_chart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Expose k8s logs on failure of integration test

## Description

We can't introspect the deployment during a CI run and if it fails with unknown error it is hard to debug.
This commit adds k8s logs of the deployment to the CI output in case the integration test fails.
See e.g. https://github.com/sse-secure-systems/connaisseur/runs/5245683641?check_suite_focus=true for output with this change

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)

