### PR TITLE
Alert - Support for authentication when calling receiver endpoint.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAMESPACE = connaisseur
-IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
+IMAGE := $(shell yq -e '.deployment.image' helm/values.yaml)
 COSIGN_VERSION = 1.5.1
 
 .PHONY: all docker install unistall upgrade annihilate

--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -48,6 +48,166 @@ class AlertingConfiguration:
         return bool(self.config.get(event_category))
 
 
+class AlertReceiverAuthentication:
+    """
+    Class to store authentication information for securely sending events to the alert receiver.
+    """
+
+    class AlertReceiverBasicAuthentication:
+        """
+        Class to store authentication information for basic authentication type with username and password.
+        """
+        username: str
+        password: str
+        authentication_type: str
+        authorization_prefix: str = "Basic"
+
+        def __init__(self, alert_receiver_config: dict):
+            basic_authentication_config = alert_receiver_config.get(
+                "receiver_authentication_basic", None
+            )
+
+            if (
+                basic_authentication_config is None
+            ):  # TODO maybe remove this check since it is included in the json validation?
+                raise ConfigurationError("No basic authentication configuration found.")
+
+            username_env = basic_authentication_config.get("username_env", None)
+            password_env = basic_authentication_config.get("password_env", None)
+
+            if (
+                username_env is None or password_env is None
+            ):  # TODO maybe remove this check since it is included in the json validation?
+                raise ConfigurationError(
+                    "No username_env or password_env configuration found."
+                )
+
+            self.username = os.environ.get(username_env, None)
+            self.password = os.environ.get(password_env, None)
+
+            if self.username is None or self.password is None:
+                raise ConfigurationError(
+                    f"No username or password found from environmental variables {username_env} and {password_env}."
+                )
+
+            self.authorization_prefix = basic_authentication_config.get(
+                "authorization_prefix", "Basic"
+            )
+            # TODO maybe validate authorization prefix
+
+        def get_header(self) -> dict:
+            return {
+                "Authorization": f"{self.authorization_prefix} {self.username}:{self.password}"
+            }
+
+    class AlertReceiverBearerAuthentication:
+        """
+        Class to store authentication information for bearer authentication type which uses a token.
+        """
+        token: str
+        authorization_prefix: str = "Bearer"  # default is bearer
+
+        def __init__(self, alert_receiver_config: dict):
+            bearer_authentication_config = alert_receiver_config.get(
+                "receiver_authentication_bearer", None
+            )
+
+            if (
+                bearer_authentication_config is None
+            ):  # TODO maybe remove this check since it is included in the json validation?
+                raise ConfigurationError(
+                    "No bearer authentication configuration found."
+                )
+
+            token_env = bearer_authentication_config.get("token_env", None)
+            token_file = bearer_authentication_config.get("token_file", None)
+
+            if (
+                token_env is None and token_file is None
+            ):  # TODO maybe remove this check since it is included in the json validation?
+                raise ConfigurationError(
+                    "No token_env and token_file configuration found."
+                )
+
+            if (
+                token_env is not None and token_file is not None
+            ):  # TODO maybe remove this check since it is included in the json validation?
+                raise ConfigurationError(
+                    "Both token_env and token_file configuration found. Only one is required."
+                )
+
+            if token_env is not None:
+                self.token = os.environ.get(token_env, None)
+
+                if self.token is None:
+                    raise ConfigurationError(
+                        f"No token found from environmental variable {token_env}."
+                    )
+            else:
+                try:
+                    with open(token_file, "r") as token_file:
+                        self.token = token_file.read()
+                except FileNotFoundError:
+                    raise ConfigurationError(f"No token file found at {token_file}.")
+                except Exception as err:
+                    raise ConfigurationError(
+                        f"An error occurred while loading the token file {token_file}: {str(err)}"
+                    )
+
+            self.authorization_prefix = bearer_authentication_config.get(
+                "authorization_prefix", "Bearer"
+            )
+            # TODO maybe validate authorization prefix
+
+        def get_header(self) -> dict:
+            return {"Authorization": f"{self.authorization_prefix} {self.token}"}
+
+    def __init__(self, alert_receiver_config: dict):
+        self.authentication_type = alert_receiver_config.get(
+            "receiver_authentication_type", "none"
+        )
+
+        if self.is_basic():
+            self.__init_basic_authentication(alert_receiver_config)
+        elif self.is_bearer():
+            self.__init_bearer_authentication(alert_receiver_config)
+
+    def is_basic(self):
+        return self.authentication_type == "basic"
+
+    def is_bearer(self):
+        return self.authentication_type == "bearer"
+
+    def is_none(self):
+        return self.authentication_type == "none"
+
+    def __init_bearer_authentication(self, alert_receiver_config: dict):
+        self.bearer_authentication = (
+            AlertReceiverAuthentication.AlertReceiverBearerAuthentication(
+                alert_receiver_config
+            )
+        )
+
+    def __init_basic_authentication(self, alert_receiver_config: dict):
+        self.basic_authentication = (
+            AlertReceiverAuthentication.AlertReceiverBasicAuthentication(
+                alert_receiver_config
+            )
+        )
+
+    def get_auth_header(self) -> dict:
+        if self.is_basic():
+            return self.basic_authentication.get_header()
+        elif self.is_bearer():
+            return self.bearer_authentication.get_header()
+        elif self.is_none():
+            return {}
+        else:
+            raise ConfigurationError(
+                "No authentication type found."
+            )  # hopefully this never happens
+
+
 class Alert:
     """
     Class to store image information about an alert as attributes and a sending
@@ -59,6 +219,7 @@ class Alert:
 
     template: str
     receiver_url: str
+    receiver_authentication: AlertReceiverAuthentication
     payload: str
     headers: dict
 
@@ -101,12 +262,13 @@ class Alert:
             "images": images,
         }
         self.receiver_url = receiver_config["receiver_url"]
+        self.receiver_authentication = AlertReceiverAuthentication(receiver_config)
         self.template = receiver_config["template"]
         self.throw_if_alert_sending_fails = receiver_config.get(
             "fail_if_alert_sending_fails", False
         )
         self.payload = self.__construct_payload(receiver_config)
-        self.headers = self.__get_headers(receiver_config)
+        self.headers = self.__get_headers(receiver_config, self.receiver_authentication)
 
     def __construct_payload(self, receiver_config: dict) -> str:
         try:
@@ -153,13 +315,18 @@ class Alert:
         return response
 
     @staticmethod
-    def __get_headers(receiver_config):
+    def __get_headers(
+        receiver_config: dict, receiver_authentication: AlertReceiverAuthentication
+    ) -> dict:
         headers = {"Content-Type": "application/json"}
         additional_headers = receiver_config.get("custom_headers")
         if additional_headers is not None:
             for header in additional_headers:
                 key, value = header.split(":", 1)
                 headers.update({key.strip(): value.strip()})
+        auth_header = receiver_authentication.get_auth_header()
+        if auth_header:  # not None and not empty
+            headers.update(auth_header)
         return headers
 
 

--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -79,7 +79,7 @@ class AlertReceiverAuthentication:
                 raise ConfigurationError(
                     "The authentication scheme cannot be null or empty."
                 )
-            # check if self.authentication_scheme contains only letters
+
             if not self.authentication_scheme.isalpha():
                 raise ConfigurationError(
                     "The authentication scheme must contain only letters."

--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -90,6 +90,7 @@ class AlertReceiverAuthentication:
         """
         Placeholder class for AlertReceiver without authentication.
         """
+
         def __init__(self, alert_receiver_config: dict):
             pass
 
@@ -141,7 +142,7 @@ class AlertReceiverAuthentication:
 
         def __init__(self, alert_receiver_config: dict):
             super().__init__(alert_receiver_config, "receiver_authentication_bearer")
-        
+
             token_env = self.authentication_config.get("token_env")
             token_file = self.authentication_config.get("token_file")
 

--- a/connaisseur/res/alertconfig_schema.json
+++ b/connaisseur/res/alertconfig_schema.json
@@ -18,6 +18,50 @@
               "receiver_url": {
                 "type": "string"
               },
+              "receiver_authentication_type": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "basic",
+                  "bearer"
+                ]
+              },
+              "receiver_authentication_basic": {
+                "type": "object",
+                "properties": {
+                  "username_env": {
+                    "type": "string"
+                  },
+                  "password_env": {
+                    "type": "string"
+                  },
+                  "authorization_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username_env",
+                  "password_env"
+                ]
+              },
+              "receiver_authentication_bearer": {
+                "type": "object",
+                "oneOf": [
+                  {"required": ["token_file"]},
+                  {"required": ["token_env"]}
+                ],
+                "properties": {
+                  "authorization_prefix": {
+                    "type": "string"
+                  },
+                  "token_file": {
+                    "type": "string"
+                  },
+                  "token_env": {
+                    "type": "string"
+                  }
+                }
+              },
               "priority": {
                 "type": "integer"
               },
@@ -35,6 +79,35 @@
                 "type": "boolean"
               }
             },
+            "anyOf": [
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "basic"
+                  }
+                },
+                "required": [
+                  "receiver_authentication_basic"
+                ]
+              },
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "bearer"
+                  }
+                },
+                "required": [
+                  "receiver_authentication_bearer"
+                ]
+              },
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "none"
+                  }
+                }
+              }
+            ],
             "required": [
               "template",
               "receiver_url"
@@ -60,6 +133,50 @@
               "receiver_url": {
                 "type": "string"
               },
+              "receiver_authentication_type": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "basic",
+                  "bearer"
+                ]
+              },
+              "receiver_authentication_basic": {
+                "type": "object",
+                "properties": {
+                  "username_env": {
+                    "type": "string"
+                  },
+                  "password_env": {
+                    "type": "string"
+                  },
+                  "authorization_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "username_env",
+                  "password_env"
+                ]
+              },
+              "receiver_authentication_bearer": {
+                "type": "object",
+                "oneOf": [
+                  {"required": ["token_file"]},
+                  {"required": ["token_env"]}
+                ],
+                "properties": {
+                  "authorization_prefix": {
+                    "type": "string"
+                  },
+                  "token_file": {
+                    "type": "string"
+                  },
+                  "token_env": {
+                    "type": "string"
+                  }
+                }
+              },
               "priority": {
                 "type": "integer"
               },
@@ -77,6 +194,35 @@
                 "type": "boolean"
               }
             },
+            "anyOf": [
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "basic"
+                  }
+                },
+                "required": [
+                  "receiver_authentication_basic"
+                ]
+              },
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "bearer"
+                  }
+                },
+                "required": [
+                  "receiver_authentication_bearer"
+                ]
+              },
+              {
+                "properties": {
+                  "receiver_authentication_type": {
+                    "const": "none"
+                  }
+                }
+              }
+            ],
             "required": [
               "template",
               "receiver_url"

--- a/connaisseur/res/alertconfig_schema.json
+++ b/connaisseur/res/alertconfig_schema.json
@@ -35,7 +35,7 @@
                   "password_env": {
                     "type": "string"
                   },
-                  "authorization_prefix": {
+                  "authentication_scheme": {
                     "type": "string"
                   }
                 },
@@ -51,7 +51,7 @@
                   {"required": ["token_env"]}
                 ],
                 "properties": {
-                  "authorization_prefix": {
+                  "authentication_scheme": {
                     "type": "string"
                   },
                   "token_file": {
@@ -150,7 +150,7 @@
                   "password_env": {
                     "type": "string"
                   },
-                  "authorization_prefix": {
+                  "authentication_scheme": {
                     "type": "string"
                   }
                 },
@@ -166,7 +166,7 @@
                   {"required": ["token_env"]}
                 ],
                 "properties": {
-                  "authorization_prefix": {
+                  "authentication_scheme": {
                     "type": "string"
                   },
                   "token_file": {

--- a/docs/features/alerting.md
+++ b/docs/features/alerting.md
@@ -16,15 +16,24 @@ alerts at the same time.
 
 Currently, Connaisseur supports alerting on either admittance of images, denial of images or both. These event categories can be configured independently of each other under the relevant category (i.e. `admit_request` or `reject_request`):
 
-| Key                                                |  Accepted values                                      | Default           | Required           | Description                                                                                        |
-| -------------------------------------------------- | ----------------------------------------------------  | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------- |
-| `alerting.cluster_identifier`                      | string                                                | `"not specified"` |                    | Cluster identifier used in alert payload to distinguish between alerts from different clusters.     |
-| `alerting.<category>.template`                     | `opsgenie`, `slack`, `keybase`, `ecs-1-12-0` or custom<sup>*</sup>  | -                 | :heavy_check_mark: | File in `helm/alert_payload_templates/` to be used as alert payload template.           |
-| `alerting.<category>.receiver_url`                 | string                                                | -                 | :heavy_check_mark: | URL of alert-receiving endpoint.                                                                    |
-| `alerting.<category>.priority`                     | int                                                   | `3`               |                    | Priority of alert (to enable fitting Connaisseur alerts into alerts from other sources).            |
-| `alerting.<category>.custom_headers`               | list[string]                                          | -                 |                    | Additional headers required by alert-receiving endpoint.                                            |
-| `alerting.<category>.payload_fields`               | subyaml                                               | -                 |                    | Additional (`yaml`) key-value pairs to be appended to alert payload (as `json`). |
-| `alerting.<category>.fail_if_alert_sending_fails`  | bool                                                  | `False`           |                    | Whether to make Connaisseur deny images if the corresponding alert cannot be successfully sent.    |
+| Key                                                 |  Accepted values                                      | Default           | Required           | Description                                                                                         |
+| --------------------------------------------------- | ----------------------------------------------------- | ----------------- | ------------------ | --------------------------------------------------------------------------------------------------- |
+| `alerting.cluster_identifier`                       | string                                                | `"not specified"` |                    | Cluster identifier used in alert payload to distinguish between alerts from different clusters.     |
+| `alerting.<category>.template`                      | `opsgenie`, `slack`, `keybase`, `ecs-1-12-0` or custom<sup>*</sup>  | -   | :heavy_check_mark: | File in `helm/alert_payload_templates/` to be used as alert payload template.                       |
+| `alerting.<category>.receiver_url`                  | string                                                | -                 | :heavy_check_mark: | URL of alert-receiving endpoint.                                                                    |
+| `alerting.<category>.priority`                      | int                                                   | `3`               |                    | Priority of alert (to enable fitting Connaisseur alerts into alerts from other sources).            |
+| `alerting.<category>.custom_headers`                | list[string]                                          | -                 |                    | Additional headers required by alert-receiving endpoint.                                            |
+| `alerting.<category>.payload_fields`                | subyaml                                               | -                 |                    | Additional (`yaml`) key-value pairs to be appended to alert payload (as `json`).                    |
+| `alerting.<category>.fail_if_alert_sending_fails`   | bool                                                  | `False`           |                    | Whether to make Connaisseur deny images if the corresponding alert cannot be successfully sent.     |
+| `alerting.<category>.receiver_authentication_type`  | string enum `basic`, `bearer`, `none`                 | `none`            |                    | Authentication type of the alert-receiving webhook endpoint .                                       |
+| `alerting.<category>.receiver_authentication_basic`               | object              | -                 | only when `receiver_authentication_type` is `basic`  | Authentication credentials for basic authentication.                                  |
+| `alerting.<category>.receiver_authentication_basic.username_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Username Environmental variable for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_basic.password_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Password Environmental variable for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_basic.authorization_prefix`  | string      | `Basic`           |                                                      | Prefix for Authorization header for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_bearer`              | object              | -                 | only when `receiver_authentication_type` is `bearer` | Authentication credentials for bearer authentication.                                 |
+| `alerting.<category>.receiver_authentication_bearer.token_env`    | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token Environmental variable for bearer authentication (Exclusive with `token_file`). |
+| `alerting.<category>.receiver_authentication_bearer.token_file`   | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token file for bearer authentication (Exclusive with `token_env`).                    |
+| `alerting.<category>.receiver_authentication_bearer.authorization_prefix` | string      | `Bearer`          |                                                      | Prefix for Authorization header for bearer authentication.                            |
 
 <sup>*basename of the custom template file in `helm/alerting_payload_templates` without file extension </sup>
 
@@ -51,6 +60,54 @@ alerting:
       - template: keybase
         receiver_url: https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>
 ```
+
+## Example With Authentication
+
+For example, if you would like to receive notifications in your custom webhook authenticated with a bearer token taken from an environmental variable whenever Connaisseur admits a request to your cluster, your alerting configuration would look similar to the following snippet:
+
+```
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: bearer
+        receiver_authentication_bearer: 
+          token_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN
+```
+
+You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN` environment variable referencing the bearer token secret you want to use into the connaisseur deployment.
+
+Or if you would like to use the service account token as the bearer token, you can use the following snippet:
+
+```
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: bearer
+        receiver_authentication_bearer: 
+          token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+```
+
+Finally in case of basic authentication, you can use the following snippet:
+
+
+```
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: basic
+        receiver_authentication_basic: 
+          username_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME
+          password_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD
+```
+
+You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME` and `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD` environment variables referencing the secret you want to use into the connaisseur deployment.
+
 
 ## Additional notes
 

--- a/docs/features/alerting.md
+++ b/docs/features/alerting.md
@@ -29,11 +29,11 @@ Currently, Connaisseur supports alerting on either admittance of images, denial 
 | `alerting.<category>.receiver_authentication_basic`               | object              | -                 | only when `receiver_authentication_type` is `basic`  | Authentication credentials for basic authentication.                                  |
 | `alerting.<category>.receiver_authentication_basic.username_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Username Environmental variable for basic authentication.                             |
 | `alerting.<category>.receiver_authentication_basic.password_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Password Environmental variable for basic authentication.                             |
-| `alerting.<category>.receiver_authentication_basic.authorization_prefix`  | string      | `Basic`           |                                                      | Prefix for Authorization header for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_basic.authentication_scheme`  | string (without spaces) | `Basic`           |                                         | Prefix for Authorization header for basic authentication.                             |
 | `alerting.<category>.receiver_authentication_bearer`              | object              | -                 | only when `receiver_authentication_type` is `bearer` | Authentication credentials for bearer authentication.                                 |
 | `alerting.<category>.receiver_authentication_bearer.token_env`    | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token Environmental variable for bearer authentication (Exclusive with `token_file`). |
 | `alerting.<category>.receiver_authentication_bearer.token_file`   | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token file for bearer authentication (Exclusive with `token_env`).                    |
-| `alerting.<category>.receiver_authentication_bearer.authorization_prefix` | string      | `Bearer`          |                                                      | Prefix for Authorization header for bearer authentication.                            |
+| `alerting.<category>.receiver_authentication_bearer.authentication_scheme` | string (without spaces) | `Bearer`         |                                          | Prefix for Authorization header for bearer authentication.                            |
 
 <sup>*basename of the custom template file in `helm/alerting_payload_templates` without file extension </sup>
 

--- a/docs/features/alerting.md
+++ b/docs/features/alerting.md
@@ -25,15 +25,6 @@ Currently, Connaisseur supports alerting on either admittance of images, denial 
 | `alerting.<category>.custom_headers`                | list[string]                                          | -                 |                    | Additional headers required by alert-receiving endpoint.                                            |
 | `alerting.<category>.payload_fields`                | subyaml                                               | -                 |                    | Additional (`yaml`) key-value pairs to be appended to alert payload (as `json`).                    |
 | `alerting.<category>.fail_if_alert_sending_fails`   | bool                                                  | `False`           |                    | Whether to make Connaisseur deny images if the corresponding alert cannot be successfully sent.     |
-| `alerting.<category>.receiver_authentication_type`  | string enum `basic`, `bearer`, `none`                 | `none`            |                    | Authentication type of the alert-receiving webhook endpoint .                                       |
-| `alerting.<category>.receiver_authentication_basic`               | object              | -                 | only when `receiver_authentication_type` is `basic`  | Authentication credentials for basic authentication.                                  |
-| `alerting.<category>.receiver_authentication_basic.username_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Username Environmental variable for basic authentication.                             |
-| `alerting.<category>.receiver_authentication_basic.password_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Password Environmental variable for basic authentication.                             |
-| `alerting.<category>.receiver_authentication_basic.authentication_scheme`  | string (without spaces) | `Basic`           |                                         | Prefix for Authorization header for basic authentication.                             |
-| `alerting.<category>.receiver_authentication_bearer`              | object              | -                 | only when `receiver_authentication_type` is `bearer` | Authentication credentials for bearer authentication.                                 |
-| `alerting.<category>.receiver_authentication_bearer.token_env`    | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token Environmental variable for bearer authentication (Exclusive with `token_file`). |
-| `alerting.<category>.receiver_authentication_bearer.token_file`   | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token file for bearer authentication (Exclusive with `token_env`).                    |
-| `alerting.<category>.receiver_authentication_bearer.authentication_scheme` | string (without spaces) | `Bearer`         |                                          | Prefix for Authorization header for bearer authentication.                            |
 
 <sup>*basename of the custom template file in `helm/alerting_payload_templates` without file extension </sup>
 
@@ -53,60 +44,13 @@ one it needs to be one of `slack`, `keybase`, `opsgenie` or `ecs-1-12-0`.
 For example, if you would like to receive notifications in Keybase whenever Connaisseur admits a request to your cluster, your alerting configuration would look similar to the following snippet:
 
 
-```
+```yaml
 alerting:
   admit_request:
     templates:
       - template: keybase
         receiver_url: https://bots.keybase.io/webhookbot/<Your-Keybase-Hook-Token>
 ```
-
-## Example With Authentication
-
-For example, if you would like to receive notifications in your custom webhook authenticated with a bearer token taken from an environmental variable whenever Connaisseur admits a request to your cluster, your alerting configuration would look similar to the following snippet:
-
-```
-alerting:
-  admit_request:
-    templates:
-      - template: ecs-1-12-0 
-        receiver_url: https://your.custom.domain.com/webhook/admit
-        receiver_authentication_type: bearer
-        receiver_authentication_bearer: 
-          token_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN
-```
-
-You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN` environment variable referencing the bearer token secret you want to use into the connaisseur deployment.
-
-Or if you would like to use the service account token as the bearer token, you can use the following snippet:
-
-```
-alerting:
-  admit_request:
-    templates:
-      - template: ecs-1-12-0 
-        receiver_url: https://your.custom.domain.com/webhook/admit
-        receiver_authentication_type: bearer
-        receiver_authentication_bearer: 
-          token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-```
-
-Finally in case of basic authentication, you can use the following snippet:
-
-
-```
-alerting:
-  admit_request:
-    templates:
-      - template: ecs-1-12-0 
-        receiver_url: https://your.custom.domain.com/webhook/admit
-        receiver_authentication_type: basic
-        receiver_authentication_basic: 
-          username_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME
-          password_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD
-```
-
-You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME` and `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD` environment variables referencing the secret you want to use into the connaisseur deployment.
 
 
 ## Additional notes
@@ -132,4 +76,92 @@ to JSON by Helm as is. If your REST endpoint requires particular headers, you ca
 specify them as described above in `custom_headers`.
 
 Feel free to make a PR to share with the community if you add new neat templates for other third parties :pray:
+
+
+### Webhook Authentication
+
+
+#### Configuration options
+
+Currently, Connaisseur supports alerting on either admittance of images, denial of images or both. These event categories can be configured independently of each other under the relevant category (i.e. `admit_request` or `reject_request`):
+
+| Key                                                 |  Accepted values                                      | Default           | Required           | Description                                                                                         |
+| --------------------------------------------------- | ----------------------------------------------------- | ----------------- | ------------------ | --------------------------------------------------------------------------------------------------- |
+| `alerting.<category>.receiver_authentication_type`  | string enum `basic`, `bearer`, `none`                 | `none`            |                    | Authentication type of the alert-receiving webhook endpoint .                                       |
+| `alerting.<category>.receiver_authentication_basic`               | object              | -                 | only when `receiver_authentication_type` is `basic`  | Authentication credentials for basic authentication.                                  |
+| `alerting.<category>.receiver_authentication_basic.username_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Username Environmental variable for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_basic.password_env`  | string              | -                 | only when `receiver_authentication_type` is `basic`  | Password Environmental variable for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_basic.authentication_scheme`  | string (without spaces) | `Basic`           |                                         | Prefix for Authorization header for basic authentication.                             |
+| `alerting.<category>.receiver_authentication_bearer`              | object              | -                 | only when `receiver_authentication_type` is `bearer` | Authentication credentials for bearer authentication.                                 |
+| `alerting.<category>.receiver_authentication_bearer.token_env`    | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token Environmental variable for bearer authentication (Exclusive with `token_file`). |
+| `alerting.<category>.receiver_authentication_bearer.token_file`   | string              | -                 | only when `receiver_authentication_type` is `bearer` | Token file for bearer authentication (Exclusive with `token_env`).                    |
+| `alerting.<category>.receiver_authentication_bearer.authentication_scheme` | string (without spaces) | `Bearer`         |                                          | Prefix for Authorization header for bearer authentication.                            |
+
+
+#### Examples
+
+It is possible to provide credentials for authentication of webhook requests beyond a hard to guess URL.
+
+For example, if you would like to receive notifications in your custom webhook authenticated with a bearer token taken from an environmental variable whenever Connaisseur admits a request to your cluster, your alerting configuration would look similar to the following snippet:
+
+```yaml
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: bearer
+        receiver_authentication_bearer: 
+          token_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN
+```
+
+You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_TOKEN` environment variable referencing the bearer token secret you want to use into the connaisseur deployment.
+
+Or if you need to load the token from a file you can use the following snipped:
+
+```yaml
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: bearer
+        receiver_authentication_bearer: 
+          token_file: /etc/webhook/your-token
+```
+
+Finally in case of basic authentication, you can use the following snippet:
+
+```yaml
+alerting:
+  admit_request:
+    templates:
+      - template: ecs-1-12-0 
+        receiver_url: https://your.custom.domain.com/webhook/admit
+        receiver_authentication_type: basic
+        receiver_authentication_basic: 
+          username_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME
+          password_env: CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD
+```
+
+You then have to set the `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_USERNAME` and `CONNAISSEUR_ADMIT_REQUEST_WEBHOOK_AUTH_PASSWORD` environment variables referencing the secret you want to use into the connaisseur deployment.
+This is an example of values configuration for basic authentication:
+The referenced secret `connaisseur-webhook-user` should already exist.
+
+```yaml
+deployment:
+  # Add environmental variables to the pod in the deployment
+  # referencing secrets, configMaps, or fields.
+  envValueFrom:
+    - name: CONNAISSSEUR_WEBHOOK_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: connaisseur-webhook-user
+          key: username
+    - name: CONNAISSSEUR_WEBHOOK_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: connaisseur-webhook-user
+          key: password
+```
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -80,6 +80,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          {{- if .Values.deployment.env }}
+            {{- range $e := .Values.deployment.env }}
+            - name: {{ $e.name }}
+              value: {{ $e.value }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.deployment.envValueFrom}}
+            {{- range $e := .Values.deployment.envValueFrom }}
+            - name:  {{ $e.name }}
+              valueFrom:
+                {{- if $e.valueFrom.secretKeyRef }}
+                secretKeyRef:
+                  name: {{ $e.valueFrom.secretKeyRef.name }}
+                  key: {{ $e.valueFrom.secretKeyRef.key }}
+                {{- else if $e.valueFrom.configMapKeyRef }}
+                configMapKeyRef:
+                  name: {{ $e.valueFrom.configMapKeyRef.name }}
+                  key: {{ $e.valueFrom.configMapKeyRef.key }}
+                {{- else if $e.valueFrom.fieldRef }}
+                fieldRef:
+                  fieldPath: {{ $e.valueFrom.fieldRef.fieldPath }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
           securityContext:

--- a/tests/data/alerting/misconfigured_config/alertconfig_basic_1.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_basic_1.json
@@ -1,0 +1,13 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic"
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_basic_2.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_basic_2.json
@@ -1,0 +1,16 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic",
+                "receiver_authentication_basic": {
+                    "username": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_basic_3.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_basic_3.json
@@ -1,0 +1,13 @@
+{
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic"
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_basic_4.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_basic_4.json
@@ -1,0 +1,16 @@
+{
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic",
+                "receiver_authentication_basic": {
+                    "username": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_bearer_1.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_bearer_1.json
@@ -1,0 +1,17 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_bearer": {
+                    "token_env": "123",
+                    "token_file": "123"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_bearer_2.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_bearer_2.json
@@ -1,0 +1,17 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_basic": {
+                    "username": "",
+                    "password": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_bearer_3.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_bearer_3.json
@@ -1,0 +1,17 @@
+{
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_bearer": {
+                    "token_env": "123",
+                    "token_file": "123"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/misconfigured_config/alertconfig_bearer_4.json
+++ b/tests/data/alerting/misconfigured_config/alertconfig_bearer_4.json
@@ -1,0 +1,17 @@
+{
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_basic": {
+                    "username": "",
+                    "password": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/valid_config/alertconfig_basic_1.json
+++ b/tests/data/alerting/valid_config/alertconfig_basic_1.json
@@ -1,0 +1,32 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic",
+                "receiver_authentication_basic": {
+                    "username_env": "",
+                    "password_env": ""
+                }
+            }
+        ]
+    },
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "basic",
+                "receiver_authentication_basic": {
+                    "username_env": "",
+                    "password_env": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/alerting/valid_config/alertconfig_bearer_1.json
+++ b/tests/data/alerting/valid_config/alertconfig_bearer_1.json
@@ -1,0 +1,30 @@
+{
+    "reject_request": {
+        "message": "CONNAISSEUR rejected a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_bearer": {
+                    "token_env": ""
+                }
+            }
+        ]
+    },
+    "admit_request": {
+        "message": "CONNAISSEUR admitted a request",
+        "templates": [
+            {
+                "priority": 3,
+                "receiver_url": "https://hooks.slack.com/services/123",
+                "template": "slack",
+                "receiver_authentication_type": "bearer",
+                "receiver_authentication_bearer": {
+                    "token_file": ""
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -67,6 +67,16 @@ receiver_config_bearer_env = {
     "template": "slack",
 }
 
+receiver_config_bearer_env_invalid_scheme = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "bearer",
+    "receiver_authentication_bearer": {
+        "token_env": "CONNAISSEUR_ALERTING_TOKEN",
+        "authentication_scheme": "",
+    },
+    "template": "slack",
+}
+
 receiver_config_bearer_file = {
     "receiver_url": "this.is.a.testurl.conn",
     "receiver_authentication_type": "bearer",
@@ -76,12 +86,12 @@ receiver_config_bearer_file = {
     "template": "slack",
 }
 
-receiver_config_bearer_env_prefix = {
+receiver_config_bearer_env_scheme = {
     "receiver_url": "this.is.a.testurl.conn",
     "receiver_authentication_type": "bearer",
     "receiver_authentication_bearer": {
         "token_env": "CONNAISSEUR_ALERTING_TOKEN",
-        "authorization_prefix": "Newprefix",
+        "authentication_scheme": "Newscheme",
     },
     "template": "slack",
 }
@@ -96,13 +106,24 @@ receiver_config_basic = {
     "template": "slack",
 }
 
-receiver_config_basic_prefix = {
+receiver_config_basic_invalid_scheme = {
     "receiver_url": "this.is.a.testurl.conn",
     "receiver_authentication_type": "basic",
     "receiver_authentication_basic": {
         "username_env": "CONNAISSEUR_ALERTING_USERNAME",
         "password_env": "CONNAISSEUR_ALERTING_PASSWORD",
-        "authorization_prefix": "Newprefix",
+        "authentication_scheme": "Ba sic",
+    },
+    "template": "slack",
+}
+
+receiver_config_basic_scheme = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "basic",
+    "receiver_authentication_basic": {
+        "username_env": "CONNAISSEUR_ALERTING_USERNAME",
+        "password_env": "CONNAISSEUR_ALERTING_PASSWORD",
+        "authentication_scheme": "Newscheme",
     },
     "template": "slack",
 }
@@ -372,11 +393,11 @@ def test_alert_init(
             fix.no_exc(),
         ),
         (
-            receiver_config_bearer_env_prefix,
+            receiver_config_bearer_env_scheme,
             {"CONNAISSEUR_ALERTING_TOKEN": "AAABBBCCCDDD"},
             {},
             2,
-            {"Authorization": "Newprefix AAABBBCCCDDD"},
+            {"Authorization": "Newscheme AAABBBCCCDDD"},
             fix.no_exc(),
         ),
         (
@@ -399,6 +420,17 @@ def test_alert_init(
             ),
         ),
         (
+            receiver_config_bearer_env_invalid_scheme,
+            {},
+            {},
+            1,
+            {},
+            pytest.raises(
+                ConfigurationError,
+                match=r"The authentication scheme cannot be null or empty.",
+            ),
+        ),
+        (
             receiver_config_bearer_file,
             {},
             {},
@@ -418,14 +450,14 @@ def test_alert_init(
             fix.no_exc(),
         ),
         (
-            receiver_config_basic_prefix,
+            receiver_config_basic_scheme,
             {
                 "CONNAISSEUR_ALERTING_USERNAME": "user",
                 "CONNAISSEUR_ALERTING_PASSWORD": "password",
             },
             {},
             2,
-            {"Authorization": "Newprefix user:password"},
+            {"Authorization": "Newscheme user:password"},
             fix.no_exc(),
         ),
         (
@@ -437,6 +469,17 @@ def test_alert_init(
             pytest.raises(
                 ConfigurationError,
                 match=r"No username or password found from environmental variables.*",
+            ),
+        ),
+        (
+            receiver_config_basic_invalid_scheme,
+            {},
+            {},
+            1,
+            {},
+            pytest.raises(
+                ConfigurationError,
+                match=r"The authentication scheme cannot contain any space.",
             ),
         ),
     ],

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from datetime import datetime, timedelta
 import json
@@ -55,6 +56,55 @@ slack_receiver_config = {
 custom_receiver_config = {
     "receiver_url": "this.is.a.testurl.conn",
     "template": "custom",
+}
+
+receiver_config_bearer_env = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "bearer",
+    "receiver_authentication_bearer": {
+        "token_env": "CONNAISSEUR_ALERTING_TOKEN",
+    },
+    "template": "slack",
+}
+
+receiver_config_bearer_file = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "bearer",
+    "receiver_authentication_bearer": {
+        "token_file": "/tmp/token123456",
+    },
+    "template": "slack",
+}
+
+receiver_config_bearer_env_prefix = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "bearer",
+    "receiver_authentication_bearer": {
+        "token_env": "CONNAISSEUR_ALERTING_TOKEN",
+        "authorization_prefix": "Newprefix",
+    },
+    "template": "slack",
+}
+
+receiver_config_basic = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "basic",
+    "receiver_authentication_basic": {
+        "username_env": "CONNAISSEUR_ALERTING_USERNAME",
+        "password_env": "CONNAISSEUR_ALERTING_PASSWORD",
+    },
+    "template": "slack",
+}
+
+receiver_config_basic_prefix = {
+    "receiver_url": "this.is.a.testurl.conn",
+    "receiver_authentication_type": "basic",
+    "receiver_authentication_basic": {
+        "username_env": "CONNAISSEUR_ALERTING_USERNAME",
+        "password_env": "CONNAISSEUR_ALERTING_PASSWORD",
+        "authorization_prefix": "Newprefix",
+    },
+    "template": "slack",
 }
 
 keybase_receiver_config = {
@@ -129,6 +179,57 @@ injection_string = '"]}, "test": "Can I inject into json?", "cluster":'
             pytest.raises(ConfigurationError, match=r".*invalid format.*"),
         ),
         ("/", True, pytest.raises(ConfigurationError, match=r".*error occurred.*")),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_bearer_1.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_bearer_2.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_bearer_3.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_bearer_4.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_basic_1.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_basic_2.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_basic_3.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/misconfigured_config/alertconfig_basic_4.json",
+            True,
+            pytest.raises(ConfigurationError, match=r".*invalid format.*"),
+        ),
+        (
+            "tests/data/alerting/valid_config/alertconfig_bearer_1.json",
+            False,
+            fix.no_exc(),
+        ),
+        (
+            "tests/data/alerting/valid_config/alertconfig_basic_1.json",
+            False,
+            fix.no_exc(),
+        ),
+        ("tests/data/alerting/missing.json", True, fix.no_exc()),
     ],
 )
 def test_alert_config_init(
@@ -257,6 +358,125 @@ def test_alert_init(
             )
         if receiver_config["template"] == "custom":
             assert alert_payload == json.loads(alert_.payload)
+
+
+@pytest.mark.parametrize(
+    "receiver_config, envs, files, headers_count, header, exception",
+    [
+        (
+            receiver_config_bearer_env,
+            {"CONNAISSEUR_ALERTING_TOKEN": "AAABBBCCCDDD"},
+            {},
+            2,
+            {"Authorization": "Bearer AAABBBCCCDDD"},
+            fix.no_exc(),
+        ),
+        (
+            receiver_config_bearer_env_prefix,
+            {"CONNAISSEUR_ALERTING_TOKEN": "AAABBBCCCDDD"},
+            {},
+            2,
+            {"Authorization": "Newprefix AAABBBCCCDDD"},
+            fix.no_exc(),
+        ),
+        (
+            receiver_config_bearer_file,
+            {},
+            {"/tmp/token123456": "AAABBBCCCDDDEEE"},
+            2,
+            {"Authorization": "Bearer AAABBBCCCDDDEEE"},
+            fix.no_exc(),
+        ),
+        (
+            receiver_config_bearer_env,
+            {"CONNAISSEUR_ALERTING_TOKEN": ""},
+            {},
+            1,
+            {},
+            pytest.raises(
+                ConfigurationError,
+                match=r"No token found from environmental variable.*",
+            ),
+        ),
+        (
+            receiver_config_bearer_file,
+            {},
+            {},
+            1,
+            {},
+            pytest.raises(ConfigurationError, match=r"No token file found.*"),
+        ),
+        (
+            receiver_config_basic,
+            {
+                "CONNAISSEUR_ALERTING_USERNAME": "user",
+                "CONNAISSEUR_ALERTING_PASSWORD": "password",
+            },
+            {},
+            2,
+            {"Authorization": "Basic user:password"},
+            fix.no_exc(),
+        ),
+        (
+            receiver_config_basic_prefix,
+            {
+                "CONNAISSEUR_ALERTING_USERNAME": "user",
+                "CONNAISSEUR_ALERTING_PASSWORD": "password",
+            },
+            {},
+            2,
+            {"Authorization": "Newprefix user:password"},
+            fix.no_exc(),
+        ),
+        (
+            receiver_config_basic,
+            {"CONNAISSEUR_ALERTING_USERNAME": "", "CONNAISSEUR_ALERTING_PASSWORD": ""},
+            {},
+            1,
+            {},
+            pytest.raises(
+                ConfigurationError,
+                match=r"No username or password found from environmental variables.*",
+            ),
+        ),
+    ],
+)
+def test_alert_init_auth(
+    monkeypatch,
+    m_ad_schema_path,
+    m_alerting_without_send,
+    receiver_config: dict,
+    envs: dict,
+    files: dict,
+    headers_count: int,
+    header: dict,
+    exception,
+):
+    alert_message = "Alert Message"
+    admission_request = admission_request_deployment
+
+    for env, value in envs.items():
+        if value == "":
+            if env in os.environ:
+                del os.environ[env]
+        else:
+            os.environ[env] = envs[env]
+        # monkeypatch.setenv(os.environ[env], envs[env])
+
+    for filepath, content in files.items():
+        with open(filepath, "w") as f:
+            f.write(content)
+
+    with exception:
+        alert_ = alert.Alert(
+            alert_message, receiver_config, AdmissionRequest(admission_request)
+        )
+        assert len(alert_.headers) == headers_count
+        assert header.items() <= alert_.headers.items()
+        # assert list(header.keys())[0] in alert_.headers.keys()
+
+    for filepath in files:
+        os.remove(filepath)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -479,7 +479,7 @@ def test_alert_init(
             {},
             pytest.raises(
                 ConfigurationError,
-                match=r"The authentication scheme cannot contain any space.",
+                match=r"The authentication scheme must contain only letters.",
             ),
         ),
     ],


### PR DESCRIPTION
The changes implement more authentication options without requiring to hard-code the secret inside the url.

Until now is not possible to call an alert webhook which requires a basic or a bearer authentication.

The secrets should not be passed directly inside the configuration, instead they can be injected as environmental variables or files. 


## Description

Three authentication options have been implemented:
- **basic** from environmental variables
- **bearer** token from environmental variables
- **bearer** token from file (for example the service account token file in kubernetes)

Is however possible to specify a custom header prefix other than *Basic* and *Bearer*.

The **validation schema** has been updated to support the new options and the **unit test** has been written. All tests pass (running them inside the alpine container as suggested by the documentation).

The **documentation** reports a description of the new functionalities and few examples.

The new connaisseur image has been installed manually (forked from master) inside a K3S cluster and it worked correctly .


## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Updated schema validation (if necessary) 
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)
