### PR TITLE
test: reset values.yaml after test

### DIFF
--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -11,6 +11,9 @@ FAILED="${RED}FAILED${NC}"
 EXIT="0"
 WOLIST=("CronJob" "DaemonSet" "Deployment" "Job" "Pod" "ReplicaSet" "ReplicationController" "StatefulSet")
 
+## Backup helm/values.yaml
+cp helm/values.yaml values.yaml.backup
+
 ### SINGLE TEST CASE ####################################
 single_test() { # ID TXT TYP REF NS MSG RES
   echo -n "[$1] $2"
@@ -325,4 +328,5 @@ fi
 echo 'Cleaning up installation and test resources...'
 make uninstall >/dev/null 2>&1 || true
 kubectl delete all,cronjobs,daemonsets,jobs,replicationcontrollers,statefulsets,namespaces -luse="connaisseur-integration-test" -A >/dev/null
+mv values.yaml.backup helm/values.yaml
 echo 'Finished cleanup.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

* `helm/values.yaml` is updated during integration tests
* this is specifically problematic in local integration tests and may cause problems in CI tests
* backup is created at begin of integration test and played back in the end

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

