### PR TITLE
fix: disable aiohttp content type check

### DIFF
--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -228,7 +228,7 @@ class Notary:
 
                 try:
                     token_key = "access_token" if self.is_acr else "token"
-                    token = (await response.json())[token_key]
+                    token = (await response.json(content_type=None))[token_key]
                 except KeyError as err:
                     msg = "Unable to retrieve authentication token from {auth_url} response."
                     raise NotFoundException(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

* it seems the content type for auth.docker.io/token was unexpectedly changed from application/json to text/plain which causes the response parsing to json to fail. the content type check is disabled
* for more details: #566

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

