### PR TITLE
fix: broken cosign validator authentication for registries

### DIFF
--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -226,10 +226,12 @@ class CosignValidator(ValidatorInterface):
             *(["--k8s-keychain"] if self.k8s_keychain else []),
             image,
         ]
+        env = self.__get_envs()
+        env.update(env_vars)
 
         with subprocess.Popen(  # nosec
             cmd,
-            env=self.__get_envs().update(env_vars),
+            env=env,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.3.0
-appVersion: 2.5.0
+version: 1.3.1
+appVersion: 2.5.1
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.5.0
+  image: securesystemsengineering/connaisseur:v2.5.1
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #575 

## Description

<!--- Provide a short description of the PR: why? how? -->
* in `v2.5.0` handling of env vars for registry authentication of the cosign validator was modified
* a bug was introduced by which no env vars were set at all
* this caused cosign registry authentication to fail as described in #575 and #573 

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

