### PR TITLE
Release 2.5.1

### DIFF
--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -226,10 +226,12 @@ class CosignValidator(ValidatorInterface):
             *(["--k8s-keychain"] if self.k8s_keychain else []),
             image,
         ]
+        env = self.__get_envs()
+        env.update(env_vars)
 
         with subprocess.Popen(  # nosec
             cmd,
-            env=self.__get_envs().update(env_vars),
+            env=env,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,2 +1,2 @@
-mkdocs-material~=8.2.3
+mkdocs-material~=8.2.4
 mike~=1.1.2

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,2 +1,2 @@
-mkdocs-material~=8.2.4
+mkdocs-material~=8.2.5
 mike~=1.1.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.3.0
-appVersion: 2.5.0
+version: 1.3.1
+appVersion: 2.5.1
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.5.0
+  image: securesystemsengineering/connaisseur:v2.5.1
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 aioresponses~=0.7.3
 parsedatetime~=2.6
 pylint~=2.12.2
-pytest-asyncio~=0.18.1
+pytest-asyncio~=0.18.2
 pytest-cov~=3.0.0
 pytest-mock~=3.7.0
 pytest-subprocess~=1.4.1


### PR DESCRIPTION
# v2.5.1
## Major Scope

This Release mainly fixes a bug (#575) in cosign validator authentication to the registry that was introduced in `v2.5.0` (#428): #576 

---

## Changelog

### Fix
- broken cosign authentication for registries #576

### Update
- update mkdocs-material requirement from ~=8.2.4 to ~=8.2.5 #574
- update pytest-asyncio requirement from ~=0.18.1 to ~=0.18.2 #569
- update mkdocs-material requirement from ~=8.2.3 to ~=8.2.4 #568