### PR TITLE
[Docs] Add clarity re generating registry credential secrets

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -17,8 +17,8 @@ The image policy defines a set of rules which maps different images to those val
 This is done via glob matching of the image name which for example allows to use different validators for different registries, repositories, images or even tags.
 This is specifically useful when using public or external images from other entities like Docker's official images or different keys in a more complex development team.
 
-:octicons-light-bulb-16: **Note**: Typically, the public key of a known entity is used to validate the signature over an image's content in order to ensure integrity and provenance.
-However, other ways to implement such trust pinning exist and as a consequence we refer to all types of trust anchors in a generalized form as *trust roots*.
+> :octicons-light-bulb-16: **Note**: Typically, the public key of a known entity is used to validate the signature over an image's content in order to ensure integrity and provenance.
+> However, other ways to implement such trust pinning exist and as a consequence we refer to all types of trust anchors in a generalized form as *trust roots*.
 
 ## Using Connaisseur
 

--- a/docs/validators/sigstore_cosign.md
+++ b/docs/validators/sigstore_cosign.md
@@ -144,10 +144,22 @@ The secret can for example be created directly from your local `config.json` (fo
 ```bash
 kubectl create secret generic my-secret \
   --from-file=.dockerconfigjson=path/to/config.json \
-  --type=kubernetes.io/dockerconfigjson -n connaisseur
+  -n connaisseur
 ```
 
-In the above case, the secret name in Connaisseur configuration would be `secret_name: my-secret`.
+The secret can also be generated directly from supplied credentials (which may differ from your local `config.json`, using:
+
+```bash
+kubectl create secret docker-registry my-secret \
+  --docker-server=https://index.docker.io/v1/ \
+  --docker-username='<your username>' \
+  --docker-password='<your password>' \
+  -n connaisseur
+```
+
+> :octicons-light-bulb-16: **Note**: At present, it [seems to be necessary](https://github.com/sigstore/cosign/issues/587#issuecomment-1062510930) to suffix your registry server URL with `/v1/`. This may become unnecessary in the future.
+
+In the above cases, the secret name in Connaisseur configuration would be `secret_name: my-secret`.
 It is possible to provide one Kubernetes secret with a `config.json` for authentication to multiple private registries and referencing this in multiple validators.
 
 #### k8s_keychain


### PR DESCRIPTION
Hey guys,

This PR clarifies the process of generating / supplying registry secrets for cosign to verify images in private repositories. It's the result of some trial-and-error and debugging efforts today!

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [X] PR is rebased to/aimed at branch `develop`
- [X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [X] Added tests (if necessary)
- [X] Extended README/Documentation (if necessary)
- [X] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

