### PR TITLE
ci: frequently pull all connaisseur versions

### DIFF
--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -13,6 +13,8 @@ jobs:
         run: sudo snap install yq
       - name: Check main image
         run: DOCKER_CONTENT_TRUST=1 docker pull docker.io/$(yq e '.deployment.image' helm/values.yaml)
+      - name: Check all images
+        run: DOCKER_CONTENT_TRUST=1 docker pull docker.io/securesystemsengineering/connaisseur -a
       - name: Check signed test image
         run: DOCKER_CONTENT_TRUST=1 docker pull docker.io/securesystemsengineering/testimage:signed
       - name: Check other signed test image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

* currently the `dockerhub-check` job only pulls the most recent Connaisseur image
* this PR makes sure all Connaisseur image versions remain available

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

