### PR TITLE
docs: fix create image pull secret command

### DIFF
--- a/docs/validators/sigstore_cosign.md
+++ b/docs/validators/sigstore_cosign.md
@@ -144,6 +144,7 @@ The secret can for example be created directly from your local `config.json` (fo
 ```bash
 kubectl create secret generic my-secret \
   --from-file=.dockerconfigjson=path/to/config.json \
+  --type=kubernetes.io/dockerconfigjson \
   -n connaisseur
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

- while current docs work for connaisseur, secret cannot be used as imagePullSecret

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

