### PR TITLE
fix: digest confusion at high load

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.3.1
-appVersion: 2.5.1
+version: 1.3.2
+appVersion: 2.5.2
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.5.1
+  image: securesystemsengineering/connaisseur:v2.5.2
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/tests/validators/cosign/test_cosign_validator.py
+++ b/tests/validators/cosign/test_cosign_validator.py
@@ -146,7 +146,6 @@ def test_init(index: int, kchain: bool):
     assert val.name == static_cosigns[index]["name"]
     assert val.trust_roots == static_cosigns[index]["trust_roots"]
     assert val.k8s_keychain == kchain
-    assert val.vals == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Reference respective issue if it exists -->
Fixes #583

## Description

* it seems that as of v2.5.0 digest confusion can occur
  * a referenced image gets the digest of another image assigned and admission request is patched accordingly
  * causes deployments potentially falsely allowed, but failing due to broken request patching
* the root issue appears to be unexpectatly related to updating a class variable inside concurrent futures / asyncio
* the class variable is removed and inputs are passed into the concurrent tasks, results returned and then used to update the resuts


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

