### PR TITLE
fix: exclude k8s CRDs from parent resource check

### DIFF
--- a/tests/data/sample_admission_requests/ad_request_pods_unknownparent.json
+++ b/tests/data/sample_admission_requests/ad_request_pods_unknownparent.json
@@ -1,0 +1,112 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1beta1",
+    "request": {
+        "uid": "0c3331b6-1812-11ea-b3fc-02897404852e",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "resource": {
+            "group": "",
+            "version": "v1",
+            "resource": "pods"
+        },
+        "namespace": "test-connaisseur",
+        "operation": "CREATE",
+        "userInfo": {
+            "username": "system:serviceaccount:kube-system:replicaset-controller",
+            "uid": "13076e42-1513-11ea-b3fc-02897404852e",
+            "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:kube-system",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "generateName": "charlie-deployment-76fbf58b7d-",
+                "creationTimestamp": "",
+                "labels": {
+                    "app": "test-connaisseur",
+                    "pod-template-hash": "76fbf58b7d"
+                },
+                "annotations": {
+                    "kubernetes.io/psp": "eks.privileged"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "Unknownparent",
+                        "name": "charlie-deployment-76fbf58b7d",
+                        "uid": "090d26f8-1812-11ea-b3fc-02897404852e",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "default-token-hn7nn",
+                        "secret": {
+                            "secretName": "default-token-hn7nn"
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "test-connaisseur",
+                        "image": "securesystemsengineering/charlie-image@sha256:91ac9b26df583762234c1cdb2fc930364754ccc59bc752a2bfe298d2ea68f9ff",
+                        "ports": [
+                            {
+                                "containerPort": 5000,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "default-token-hn7nn",
+                                "readOnly": true,
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true
+            },
+            "status": {}
+        },
+        "oldObject": {}
+    },
+    "dryRun": false
+}

--- a/tests/test_workload_object.py
+++ b/tests/test_workload_object.py
@@ -51,6 +51,7 @@ def adm_req_sample_objects():
             "cronjob",
             "wrong_version",
             "deployments_multi_image",
+            "pods_unknownparent",
         )
     ]
 
@@ -107,6 +108,7 @@ def test_k8s_object_init(adm_req_sample_objects, index, exception):
         ),
         (2, {}, pytest.raises(exc.ParentNotFoundError)),
         (3, {}, fix.no_exc()),
+        (6, {}, fix.no_exc()),
     ],
 )
 def test_k8s_object_parent_containers(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #582

## Description

* Per default, Connaisseur checks the parent resource of a k8s object as part of automatic child approval.
* This fails when creating a workload object from custom resource definitions (CRDs) as the API group and thus the structure is not known.
* This is fixed by excluding the parent check for unknown API groups.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

