### PR TITLE
Add optional objectValidation to webhook

### DIFF
--- a/docs/features/namespaced_validation.md
+++ b/docs/features/namespaced_validation.md
@@ -1,6 +1,6 @@
 # Namespaced Validation
 
-Namespaced validation allows restricting validation to specific namespaces.
+Namespaced validation allows restricting validation to specific namespaces, and can operate alongside [object validation](./object_validation.md).
 Connaisseur will only verify trust of images deployed to the configured namespaces.
 This can greatly support initial rollout by stepwise extending the validated namespaces or excluding specific namespaces for which signatures are unfeasible.
 

--- a/docs/features/object_validation.md
+++ b/docs/features/object_validation.md
@@ -1,0 +1,46 @@
+# Object Validation
+
+Object validation allows restricting validation to specific objects, and can operate alongside [namespace validation](./namespaced_validation.md).
+Connaisseur can optionally include/exclude the verification trust of images based on pod labels.
+This can allow for careful exception to a cluster/namespace-wide policy, when altering the image value for particular pods (*potentially self-referential containers which use their tags to determine application version*) can be problematic.
+
+> :warning: Enabling object validation, allows roles with edit permissions on objects to disable validation for those namespaces. :warning:
+
+Object validation offers two modes:
+
+- `ignore`: ignore all objects with label `securesystemsengineering.connaisseur/webhook: ignore`
+- `validate`: only validate objects with label `securesystemsengineering.connaisseur/webhook: validate`
+
+The desired objects must be labelled accordingly, using the `.spec.template.metadata.labels` field of whichever controller (*deployment, statefulset, etc*) creates them.
+
+Configure object validation via the `objectValidation` in `helm/values.yaml`.
+
+## Configuration options
+
+`objectValidation` in `helm/values.yaml` supports the following keys:
+
+| Key | Default | Required | Description |
+| - | - | - | - |
+| `enabled` | false | | `true` or `false`; enable object validation otherwise images in all objects will be validated. |
+| `mode` | ignore | | `ignore` or `validate`; configure mode of exclusion to either ignore all objecst with label `securesystemsengineering.connaisseur/webhook` set to `ignore` or only validate objects with the label set to `validate`. |
+
+## Example
+
+In `helm/values.yaml`:
+
+```
+objectValidation:
+  enabled: true
+  mode: ignore
+```
+
+Labelling target object to be excluded from validation:
+
+```
+spec:
+  template:
+    metadata:
+      labels:
+        securesystemsengineering.connaisseur/webhook: ignore
+```
+

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: 2.5.2
 keywords:
   - container image

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -109,6 +109,26 @@ webhooks:
         operator: In
         values:
           - validate
-   {{- end }}
-   {{- end }}
-   {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.objectValidation }}
+    {{- if .Values.objectValidation.enabled }}
+    objectSelector:
+      matchExpressions:
+      - key: securesystemsengineering.connaisseur/webhook
+    {{- if not .Values.objectValidation.mode}}
+        operator: NotIn
+        values:
+          - ignore
+    {{- else if eq .Values.objectValidation.mode "ignore"}}
+        operator: NotIn
+        values:
+          - ignore
+    {{- else if eq .Values.objectValidation.mode "validate"}}
+        operator: In
+        values:
+          - validate
+    {{- end }}
+    {{- end }}
+    {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -152,6 +152,16 @@ namespacedValidation:
   enabled: false
   mode: ignore  # 'ignore' or 'validate'
 
+# object validation allows to restrict the individual objects that will be subject to Connaisseur verification.
+# when enabled, based on object validation mode ('ignore' or 'validate')
+# - either all objects with label "securesystemsengineering.connaisseur/webhook=ignore" are ignored
+# - or only objects with label "securesystemsengineering.connaisseur/webhook=validate" are validated.
+# warning: enabling object validation, allows roles with edit permission on an object to disable
+# validation for that object
+objectValidation:
+  enabled: false
+  mode: ignore  # 'ignore' or 'validate'
+
 # automatic child approval determines how admission of Kubernetes child resources is handled by Connaisseur.
 # per default, Connaisseur validates and mutates all resources, e.g. deployments, replicaSets, pods, and
 # automatically approves child resources of those to avoid duplicate validation and inconsistencies with the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - features/alerting.md
       - features/detection_mode.md
       - features/namespaced_validation.md
+      - features/object_validation.md
       - features/automatic_child_approval.md
   - Security:
     - threat_model.md


### PR DESCRIPTION
Hey guys,

Here's a PR which implements "objectValidation", much the same way that "namespacedValidation" is implemented. It allows the user to optionally include/ignore specific objects by attaching the `securesystemsengineering.connaisseur/webhook` to them via their parent controller/objects (_deployment, statefulset, etc_).

## Description

Why do we need this? There may be many more edge cases, but in my case I use FoundationDB Operator to manage multiple database clusters. The operator deploys sidecars to database pods. When performing a version upgrade, the operator identifies targets for upgrade by finding pods running the not-latest version of the sidecar, and attempts to update them.

With Connaisseur in the mix, all database pods get mutated, and don't have the expected image tag, so I get stuck in a perpetual loop of "lets-upgrade-the-non-latest-images", with the operator "battling" Connaisseur for how the sidecar image should be specified!

An easy fix (_which I'm now using locally_) has been to add the `objectSelector` field to the webhook, so that these particularly tricky pods can be excluded altogether from connaisseur validation and mutation.

I've updated the chart version, docs, and templates, but I might need assistance updating any necessary tests!

Cheers!
D

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [X] PR is rebased to/aimed at branch `develop`
- [X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [X] Extended README/Documentation (if necessary)
- [X] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

