### PR TITLE
Fix/pin and update prometheus dependencies

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.3.2
-appVersion: 2.5.2
+version: 1.3.3
+appVersion: 2.5.3
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.5.2
+  image: securesystemsengineering/connaisseur:v2.5.3
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ Flask~=2.1.1
 Jinja2~=3.1.1
 jsonschema~=4.4.0
 parsedatetime~=2.6
-prometheus-flask-exporter~=0.19.0
+prometheus-client==0.14.0
+prometheus-flask-exporter==0.20.1
 python-dateutil~=2.8.2
 pytz~=2022.1
 PyYAML~=6.0


### PR DESCRIPTION
## Description

Fixes break of Connaisseur by incompatible versions of prometheus-flask-exporter and prometheus-client (indirect dependency, not pinned by prometheus-flask-exporter)

Match is exact on purpose, as the change may be reverted https://github.com/rycus86/prometheus_flask_exporter/pull/129#issuecomment-1092382980 breaking installations again if the change is breaking without being marked as such and prometheus-flask-exporter doesn't implement version pinning since then (and we update to it for all releases we do in the meantime)

If they introduce pinning, we can remove the indirect dependency again.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

