### PR TITLE
build: Remove transitive dependency pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Flask~=2.1.1
 Jinja2~=3.1.1
 jsonschema~=4.4.0
 parsedatetime~=2.6
-prometheus-client==0.14.1
 prometheus-flask-exporter==0.20.1
 python-dateutil~=2.8.2
 pytz~=2022.1


### PR DESCRIPTION
## Description

In light of #620 we pinned a transitive dependency to fix incompatibility introduced by a breaking change in said transitive dependency. While being a reasonable quick fix at the time, it imposes undue limits on our dependency. Thus this commit removes the pinning of the transitive dependency and should they again break (the transitive dependency took notice and the dependency took steps to mitigate), we may need to reeavluate the dependency as a whole instead of pinning dependencies that are not ours to pin.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

