### PR TITLE
Small change to make connoisseur running under OpenShift / OKD 4

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -85,8 +85,10 @@ spec:
                   fieldPath: metadata.name
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
+          {{- if .Values.deployment.securityContext.enabled }}
           securityContext:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
+          {{- end }}
         {{- if .Values.deployment.extraContainers }}
         {{ tpl (toYaml .Values.deployment.extraContainers) . | nindent 8}}
         {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,7 @@ deployment:
   #annotations:  # uncomment when using Kubernetes prior v1.19
   #  seccomp.security.alpha.kubernetes.io/pod: runtime/default  # uncomment when using Kubernetes prior v1.19
   securityContext:
+    enabled: true # enable if you want to use it, disable this for OKD / OpenShift 4
     allowPrivilegeEscalation: false
     capabilities:
       drop:
@@ -45,10 +46,10 @@ deployment:
     privileged: false
     readOnlyRootFilesystem: true
     runAsNonRoot: true
-    runAsUser: 10001  # remove when using openshift or OKD 4
-    runAsGroup: 20001  # remove when using openshift or OKD 4
-    seccompProfile:  # remove when using Kubernetes prior v1.19, openshift or OKD 4
-      type: RuntimeDefault  # remove when using Kubernetes prior v1.19, openshift or OKD 4
+    runAsUser: 10001
+    runAsGroup: 20001
+    seccompProfile:  # remove when using Kubernetes prior v1.19
+      type: RuntimeDefault  # remove when using Kubernetes prior v1.19
   # PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25
   podSecurityPolicy:
     enabled: false


### PR DESCRIPTION
This is needed for OpenShift / OKD 4

If we want to make connoisseur runnable under OpenShift / OKD 4, the easiest way is:
- disable securityContext in deployments completely.

Fixes #

## Description

Create a variable, which can disable securityContexts.

## Checklist

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [X ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

