### PR TITLE
Community Attestation Service integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is built to be extendable and currently aims to support the following signing
 - [Notary V1](https://github.com/theupdateframework/notary) / [Docker Content Trust](https://docs.docker.com/engine/security/trust/)
 - [Sigstore](https://sigstore.dev/) / [Cosign](https://github.com/sigstore/cosign)
 - [Notary V2](https://github.com/notaryproject/nv2) (PLANNED)
+- [CAS](https://cas.codenotary.com/) 
 
 It provides several additional features:
 

--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -222,6 +222,9 @@
                             "properties": {
                                 "signerId": {
                                     "type": "string"
+                                },
+                                "serviceUrl": {
+                                    "type": "string"
                                 }
                             },
                             "required": [

--- a/connaisseur/res/config_schema.json
+++ b/connaisseur/res/config_schema.json
@@ -16,7 +16,8 @@
                             "notaryv1",
                             "notaryv2",
                             "cosign",
-                            "static"
+                            "static",
+                            "cas"
                         ]
                     }
                 },
@@ -206,6 +207,25 @@
                             },
                             "required": [
                                 "approve"
+                            ]
+                        }
+                    },
+                    {
+                        "if": {
+                            "properties": {
+                                "type": {
+                                    "const": "cas"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "signerId": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "signerId"
                             ]
                         }
                     }

--- a/connaisseur/validators/cas/cas_validator.py
+++ b/connaisseur/validators/cas/cas_validator.py
@@ -11,11 +11,13 @@ class CASValidator(ValidatorInterface):
         self,
         name: str,
         signerId: str = None,
+        serviceUrl: str = "cas.codenotary.com",
         **kwargs,
     ):
         super().__init__(name, **kwargs)
         self.signerId = signerId
-        self.client = CASClient(signerId=self.signerId)
+        self.serviceUrl = serviceUrl
+        self.client = CASClient(signerId=self.signerId, casUrl = self.serviceUrl)
 
     async def validate(
         self, image: Image, **kwargs

--- a/connaisseur/validators/cas/cas_validator.py
+++ b/connaisseur/validators/cas/cas_validator.py
@@ -21,8 +21,8 @@ class CASValidator(ValidatorInterface):
         self, image: Image, **kwargs
     ):  # pylint: disable=arguments-differ
         if(image.has_digest()):
-            package_name, status = self.client.authenticateHash(image.digest)
-            if(status and status == ArtifactStatus.TRUSTED):
+            package_name, status = await self.client.authenticateHash(image.digest, image.name)
+            if(status and status.status == ArtifactStatus.TRUSTED):
                 return True
             raise ValidationError(message="Artifact is not trusted.")
         raise ValidationError(message="Deployment has no digest")

--- a/connaisseur/validators/cas/cas_validator.py
+++ b/connaisseur/validators/cas/cas_validator.py
@@ -1,0 +1,28 @@
+# import asyncio
+from cas_pip.casclient.casclient import CASClient, ArtifactStatus
+from connaisseur.exceptions import ValidationError
+from connaisseur.image import Image
+from connaisseur.validators.interface import ValidatorInterface
+
+
+class CASValidator(ValidatorInterface):
+
+    def __init__(
+        self,
+        name: str,
+        signerId: str = None,
+        **kwargs,
+    ):
+        super().__init__(name, **kwargs)
+        self.signerId = signerId
+        self.client = CASClient(signerId=self.signerId)
+
+    async def validate(
+        self, image: Image, **kwargs
+    ):  # pylint: disable=arguments-differ
+        if(image.has_digest()):
+            package_name, status = self.client.authenticateHash(image.digest)
+            if(status and status == ArtifactStatus.TRUSTED):
+                return True
+            raise ValidationError(message="Artifact is not trusted.")
+        raise ValidationError(message="Deployment has no digest")

--- a/connaisseur/validators/cas/cas_validator.py
+++ b/connaisseur/validators/cas/cas_validator.py
@@ -25,6 +25,6 @@ class CASValidator(ValidatorInterface):
         if(image.has_digest()):
             package_name, status = await self.client.authenticateHash(image.digest, image.name)
             if(status and status.status == ArtifactStatus.TRUSTED):
-                return True
+                return image.digest
             raise ValidationError(message="Artifact is not trusted.")
         raise ValidationError(message="Deployment has no digest")

--- a/connaisseur/validators/validator.py
+++ b/connaisseur/validators/validator.py
@@ -3,6 +3,7 @@ from connaisseur.validators.cosign.cosign_validator import CosignValidator
 from connaisseur.validators.notaryv1.notaryv1_validator import NotaryV1Validator
 from connaisseur.validators.notaryv2.notaryv2_validator import NotaryV2Validator
 from connaisseur.validators.static.static_validator import StaticValidator
+from connaisseur.validators.cas.cas_validator import CASValidator
 
 
 class Validator:
@@ -11,6 +12,7 @@ class Validator:
         "notaryv2": NotaryV2Validator,
         "cosign": CosignValidator,
         "static": StaticValidator,
+        "cas": CASValidator
     }
 
     def __new__(cls, **kwargs):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3-alpine as base
 
 # Build dependencies
 FROM base as builder
+RUN apk add git
 
 RUN mkdir /install
 WORKDIR /install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3-alpine as base
 
 # Build dependencies
 FROM base as builder
-RUN apk add git
 
 RUN mkdir /install
 WORKDIR /install

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.6.0
+  image: razikus/validd:v1.0.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: razikus/validd:v1.0.0
+  image: securesystemsengineering/connaisseur:v2.6.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ PyYAML~=6.0
 requests~=2.27.1
 rfc3339-validator~=0.1.4
 rsa~=4.8
-
-git+https://github.com/Razikus/cas_pip.git
+cas_pip==0.1.0
 Click>=8.1.3
 grpcio>=1.44.0
 pydantic>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,10 +13,3 @@ requests~=2.27.1
 rfc3339-validator~=0.1.4
 rsa~=4.8
 cas_pip==0.1.0
-Click>=8.1.3
-grpcio>=1.44.0
-pydantic>=1.9.0
-aiofiles>=0.8.0
-pytz>=2022.1
-googleapis-common-protos==1.56.1
-google-api==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyYAML~=6.0
 requests~=2.27.1
 rfc3339-validator~=0.1.4
 rsa~=4.8
+git+https://github.com/Razikus/cas_pip.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,12 @@ PyYAML~=6.0
 requests~=2.27.1
 rfc3339-validator~=0.1.4
 rsa~=4.8
+
 git+https://github.com/Razikus/cas_pip.git
+Click>=8.1.3
+grpcio>=1.44.0
+pydantic>=1.9.0
+aiofiles>=0.8.0
+pytz>=2022.1
+googleapis-common-protos==1.56.1
+google-api==0.1.12


### PR DESCRIPTION
Community Attestation Service integration

## Description

Adds possibility to run CAS as signing solution.

Currently works with images that have SHA256 digest


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)  - extended README with link to CAS
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)


Please point me what should i change/extend in order to make this PR mergeable