### PR TITLE
ci: use some cosigned images for ci to speedup complexity

### DIFF
--- a/tests/integration/deployments/complexity.yaml
+++ b/tests/integration/deployments/complexity.yaml
@@ -32,9 +32,9 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: mongo
+      image: gcr.io/distroless/java11-debian11
     - name: container4
-      image: nginx
+      image: gcr.io/distroless/static-debian11
     - name: container5
       image: rabbitmq
     - name: container6
@@ -60,11 +60,11 @@ spec:
     - name: container4
       image: nginx
     - name: container5
-      image: rabbitmq
+      image: gcr.io/distroless/static-debian11
     - name: container6
-      image: elasticsearch
+      image: gcr.io/distroless/java11-debian11
     - name: container7
-      image: sonarqube
+      image: gcr.io/distroless/nodejs:14
   initContainers:
     - name: init2
       image: maven
@@ -85,7 +85,7 @@ spec:
       image: busybox
       command: ['sh', '-c', 'sleep 3600']
     - name: container2
-      image: redis
+      image: gcr.io/distroless/nodejs:14
     - name: container3
       image: mongo
     - name: container4
@@ -112,12 +112,12 @@ spec:
     - name: container2
       image: redis
     - name: container3
-      image: mongo
+      image: gcr.io/distroless/nodejs:14
   initContainers:
     - name: init1
       image: busybox
       command: ['sh', '-c', 'sleep 3600']
     - name: init2
-      image: redis
+      image: gcr.io/distroless/java11-debian11
     - name: init3
       image: mongo

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -343,6 +343,7 @@ case $1 in
   pre_config_int_test
   ;;
 "complexity")
+  update_via_env_vars
   update_values '.deployment.imagePullPolicy="Never"' '.deployment.replicasCount=3' '.deployment.resources= {"limits": {"cpu":"1000m", "memory":"512Mi"},"requests": {"cpu":"500m", "memory":"512Mi"}}'
   make_install
   complexity_test

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -27,6 +27,15 @@ validators:
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
       d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
       -----END PUBLIC KEY-----
+- name: distroless-official
+  type: cosign
+  trust_roots:
+  - name: default
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
+      OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
+      -----END PUBLIC KEY-----
 - name: cosign
   type: cosign
   trust_roots:
@@ -74,6 +83,8 @@ policy:
     trust_root: securesystemsengineering-official
 - pattern: "k8s.gcr.io/*:*"
   validator: allow
+- pattern: "gcr.io/distroless/*:*"
+  validator: distroless-official
 - pattern: docker.io/securesystemsengineering/connaisseur:*
   validator: allow
 - pattern: docker.io/securesystemsengineering/testimage:co-*

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -30,7 +30,7 @@ validators:
 - name: distroless-official
   type: cosign
   trust_roots:
-  - name: default
+  - name: distroless
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
@@ -85,6 +85,8 @@ policy:
   validator: allow
 - pattern: "gcr.io/distroless/*:*"
   validator: distroless-official
+  with:
+    trust_root: distroless
 - pattern: docker.io/securesystemsengineering/connaisseur:*
   validator: allow
 - pattern: docker.io/securesystemsengineering/testimage:co-*

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -87,6 +87,10 @@ policy:
   validator: distroless-official
   with:
     trust_root: distroless
+- pattern: "docker.io/library/*:*"
+  validator: dockerhub-basics
+  with:
+    trust_root: docker-official
 - pattern: docker.io/securesystemsengineering/connaisseur:*
   validator: allow
 - pattern: docker.io/securesystemsengineering/testimage:co-*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

- attempting to minimize complexity test failing due to slow notary validation by using more cosigned images

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

