### PR TITLE
ci: trivy scan of latest public image

### DIFF
--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -39,7 +39,28 @@ jobs:
           name: safety-report
           path: safety-report.txt
 
+  trivy-dockerhub-image-scan:
+    name: trivy scan (latest public image)
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - name: Get latest public image
+        run:
+          echo "LATEST-IMAGE=docker.io/$(yq e '.deployment.image' helm/values.yaml)" >> $GITHUB_ENV
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.LATEST-IMAGE }}
+          hide-progress: false
+          format: "table"
+          exit-code: "1"
+
   trivy:
+    name: trivy scan (current build)
     runs-on: ubuntu-latest
     container:
       image: docker:stable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

- add trivy scan of the latest public connaisseur image to the nightly scans
- make sure vulnerabilities are detected early
- test run: https://github.com/sse-secure-systems/connaisseur/runs/7254449587?check_suite_focus=true


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

