### PR TITLE
Fix installation in other namespace

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -211,6 +211,7 @@ jobs:
             "namespace-val",
             "deployment",
             "pre-config",
+            "other-ns",
           ]
     services:
       alerting-endpoint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
             "multi-cosigned",
             "deployment",
             "pre-config",
+            "other-ns",
           ]
     services:
       alerting-endpoint:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ upgrade:
 	helm upgrade connaisseur helm  -n $(NAMESPACE) --wait
 
 annihilate:
-	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,configmaps,secrets,serviceaccounts,crds -lapp.kubernetes.io/instance=connaisseur
-	kubectl delete imagepolicies -lapp.kubernetes.io/instance=connaisseur || true
+	kubectl delete all,mutatingwebhookconfigurations,clusterroles,clusterrolebindings,configmaps,secrets,serviceaccounts,crds -lapp.kubernetes.io/instance=connaisseur -n $(NAMESPACE)
+	kubectl delete imagepolicies -lapp.kubernetes.io/instance=connaisseur -n $(NAMESPACE) || true
 	kubectl delete ns $(NAMESPACE)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.4.1
-appVersion: 2.6.1
+version: 1.4.2
+appVersion: 2.6.2
 keywords:
   - container image
   - signature

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -127,7 +127,7 @@ Extract Kubernetes Minor Version.
 
 
 {{- define "getInstalledTLSCert" -}}
-{{- $data := (lookup "v1" "Secret" "connaisseur" (printf "%s-tls" .Chart.Name)).data -}}
+{{- $data := (lookup "v1" "Secret" .Release.Namespace (printf "%s-tls" .Chart.Name)).data -}}
 {{- if $data -}}
     {{ get $data "tls.crt" }}
 {{- end -}}
@@ -135,7 +135,7 @@ Extract Kubernetes Minor Version.
 
 
 {{- define "getInstalledTLSKey" -}}
-{{- $data := (lookup "v1" "Secret" "connaisseur" (printf "%s-tls" .Chart.Name)).data -}}
+{{- $data := (lookup "v1" "Secret" .Release.Namespace (printf "%s-tls" .Chart.Name)).data -}}
 {{- if $data -}}
     {{ get $data "tls.key" }}
 {{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.6.1
+  image: securesystemsengineering/connaisseur:v2.6.2
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.


### PR DESCRIPTION
<!--- Reference respective issue if it exists -->
Fixes #724 

## Description

As noted in #724 the installation in a different namespace fails as the TLS certificate certificate is looked up in the wrong namespace. This merge request fixes this and adds a test case to the integration test to check we don't run into this again in the future.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

