### PR TITLE
Release v2.6.3

### DIFF
--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -32,12 +32,12 @@ jobs:
       - uses: ./.github/actions/safety
       - name: Print report
         if: ${{ success() || failure() }}
-        run: cat safety-report.txt
+        run: cat safety-report.json
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: safety-report
-          path: safety-report.txt
+          path: safety-report.json
 
   trivy-dockerhub-image-scan:
     name: trivy scan (latest public image)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAMESPACE = connaisseur
 IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
-COSIGN_VERSION = 1.10.0
+COSIGN_VERSION = 1.11.0
 
 .PHONY: all docker install uninstall upgrade annihilate
 

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,2 +1,2 @@
-mkdocs-material~=8.3.9
+mkdocs-material~=8.4.0
 mike~=1.1.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.4.2
-appVersion: 2.6.2
+version: 1.4.3
+appVersion: 2.6.3
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.6.2
+  image: securesystemsengineering/connaisseur:v2.6.3
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp~=3.8.1
 cheroot~=8.6.0
 ecdsa~=0.18
-Flask~=2.2.1
+Flask~=2.2.2
 Jinja2~=3.1.2
 jsonschema~=4.9.1
 parsedatetime~=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp~=3.8.1
 cheroot~=8.6.0
 ecdsa~=0.18
-Flask~=2.1.3
+Flask~=2.2.1
 Jinja2~=3.1.2
 jsonschema~=4.9.1
 parsedatetime~=2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jsonschema~=4.9.1
 parsedatetime~=2.6
 prometheus-flask-exporter==0.20.3
 python-dateutil~=2.8.2
-pytz~=2022.1
+pytz~=2022.2
 PyYAML~=6.0
 requests~=2.28.1
 rfc3339-validator~=0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cheroot~=8.6.0
 ecdsa~=0.18
 Flask~=2.1.3
 Jinja2~=3.1.2
-jsonschema~=4.8.0
+jsonschema~=4.9.0
 parsedatetime~=2.6
 prometheus-flask-exporter==0.20.2
 python-dateutil~=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask~=2.1.3
 Jinja2~=3.1.2
 jsonschema~=4.9.1
 parsedatetime~=2.6
-prometheus-flask-exporter==0.20.2
+prometheus-flask-exporter==0.20.3
 python-dateutil~=2.8.2
 pytz~=2022.1
 PyYAML~=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cheroot~=8.6.0
 ecdsa~=0.18
 Flask~=2.2.2
 Jinja2~=3.1.2
-jsonschema~=4.9.1
+jsonschema~=4.12.1
 parsedatetime~=2.6
 prometheus-flask-exporter==0.20.3
 python-dateutil~=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cheroot~=8.6.0
 ecdsa~=0.18
 Flask~=2.1.3
 Jinja2~=3.1.2
-jsonschema~=4.9.0
+jsonschema~=4.9.1
 parsedatetime~=2.6
 prometheus-flask-exporter==0.20.2
 python-dateutil~=2.8.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 aioresponses~=0.7.3
 parsedatetime~=2.6
 pylint~=2.14.5
-pytest-asyncio~=0.18.3
+pytest-asyncio~=0.19.0
 pytest-cov~=3.0.0
 pytest-mock~=3.8.2
 pytest-subprocess~=1.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pytest-cov~=3.0.0
 pytest-mock~=3.8.2
 pytest-subprocess~=1.4.1
 requests-mock~=1.9.3
-setuptools~=63.2.0
+setuptools~=63.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pytest-cov~=3.0.0
 pytest-mock~=3.8.2
 pytest-subprocess~=1.4.1
 requests-mock~=1.9.3
-setuptools~=64.0.1
+setuptools~=65.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pytest-cov~=3.0.0
 pytest-mock~=3.8.2
 pytest-subprocess~=1.4.1
 requests-mock~=1.9.3
-setuptools~=63.4.1
+setuptools~=64.0.1


### PR DESCRIPTION
# v2.6.3
## Major Scope

just fixes and updates.

## Changelog
### Ci
- Fix safety for nightly scan https://github.com/sse-secure-systems/connaisseur/pull/732

### Update
- Update jsonschema requirement from ~=4.9.1 to ~=4.12.1 https://github.com/sse-secure-systems/connaisseur/pull/756
- Cosign v1.10.0 to v1.11.0 https://github.com/sse-secure-systems/connaisseur/pull/757
- Update mkdocs-material requirement from ~=8.3.9 to ~=8.4.0 https://github.com/sse-secure-systems/connaisseur/pull/750
- Update setuptools requirement from ~=64.0.1 to ~=65.1.0 https://github.com/sse-secure-systems/connaisseur/pull/755
- Update setuptools requirement from ~=63.4.1 to ~=64.0.1 https://github.com/sse-secure-systems/connaisseur/pull/747
- Update pytz requirement from ~=2022.1 to ~=2022.2 https://github.com/sse-secure-systems/connaisseur/pull/748
- Update flask requirement from ~=2.2.1 to ~=2.2.2 https://github.com/sse-secure-systems/connaisseur/pull/745
- Update flask requirement from ~=2.1.3 to ~=2.2.1 https://github.com/sse-secure-systems/connaisseur/pull/741
- Bump prometheus-flask-exporter from 0.20.2 to 0.20.3 https://github.com/sse-secure-systems/connaisseur/pull/738
- Update setuptools requirement from ~=63.2.0 to ~=63.4.1 https://github.com/sse-secure-systems/connaisseur/pull/740
- Update pytest-asyncio requirement from ~=0.18.3 to ~=0.19.0 https://github.com/sse-secure-systems/connaisseur/pull/735
- Update jsonschema requirement from ~=4.9.0 to ~=4.9.1 https://github.com/sse-secure-systems/connaisseur/pull/739
- Update jsonschema requirement from ~=4.8.0 to ~=4.9.0 https://github.com/sse-secure-systems/connaisseur/pull/734

