### PR TITLE
feat: validation only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It provides several additional features:
 - [Metrics](docs/features/metrics.md): *get prometheus metrics at `/metrics`*
 - [Alerting](docs/features/alerting.md): *send alerts based on verification result*
 - [Detection Mode](docs/features/detection_mode.md): *warn but do not block invalid images*
+- [Validation Mode](docs/features/validation_mode.md): *configure whether or not to mutate images*
 - [Namespaced Validation](docs/features/namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Automatic Child Approval](docs/features/automatic_child_approval.md): *configure approval of Kubernetes child resources*
 

--- a/connaisseur/flask_application.py
+++ b/connaisseur/flask_application.py
@@ -24,7 +24,7 @@ sends its response back.
 """
 CONFIG = Config()
 DETECTION_MODE = os.environ.get("DETECTION_MODE", "0") == "1"
-VALIDATION_MODE_MUTATE = os.environ.get("VALIDATION_MODE_MUTATE", "true") == "true"
+VALIDATION_MODE_MUTATE = os.environ.get("VALIDATION_MODE_MUTATE", "true") != "false"
 
 metrics = PrometheusMetrics(
     APP,

--- a/connaisseur/flask_application.py
+++ b/connaisseur/flask_application.py
@@ -24,6 +24,7 @@ sends its response back.
 """
 CONFIG = Config()
 DETECTION_MODE = os.environ.get("DETECTION_MODE", "0") == "1"
+VALIDATION_MODE_MUTATE = os.environ.get("VALIDATION_MODE_MUTATE", "true") == "true"
 
 metrics = PrometheusMetrics(
     APP,
@@ -144,7 +145,9 @@ async def __admit(admission_request: AdmissionRequest):
     return get_admission_review(
         admission_request.uid,
         True,
-        patch=[patch for patch in patches.result() if patch],
+        patch=[patch for patch in patches.result() if patch]
+        if VALIDATION_MODE_MUTATE
+        else None,
     )
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ It provides several additional features:
 - [Metrics](features/metrics.md): *get prometheus metrics at `/metrics`*
 - [Alerting](features/alerting.md): *send alerts based on verification result*
 - [Detection Mode](features/detection_mode.md): *warn but do not block invalid images*
+- [Validation Mode](features/validation_mode.md): *configure whether or not to mutate images*
 - [Namespaced Validation](features/namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Automatic Child Approval](features/automatic_child_approval.md): *configure approval of Kubernetes child resources*
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -2,9 +2,11 @@
 
 Besides Connaisseur's central functionality, several additional features are available:
 
-- [Detection Mode](./detection_mode.md): *warn but do not block invalid images*
-- [Namespaced Validation](./namespaced_validation.md): *restrict validation to dedicated namespaces*
+- [Metrics](./metrics.md): *get prometheus metrics at `/metrics`*
 - [Alerting](./alerting.md): *send alerts based on verification result*
+- [Detection Mode](./detection_mode.md): *warn but do not block invalid images*
+- [Validation Mode](./validation_mode.md): *configure whether or not to mutate images*
+- [Namespaced Validation](./namespaced_validation.md): *restrict validation to dedicated namespaces*
 - [Automatic Child Approval](automatic_child_approval.md): *configure approval of Kubernetes child resources*
 
 In combination, these features help to improve usability and might better support the DevOps workflow.

--- a/docs/features/validation_mode.md
+++ b/docs/features/validation_mode.md
@@ -1,0 +1,32 @@
+# Validation Mode
+
+Validation mode allows configuration whether Connaisseur mutates image references (tags to trusted digests).
+
+In default behavior during validation, Connaisseur uses the image reference (tag or digest) from the admission request to identify a trusted digest (digest with valid signature from a configured trust root) and modifies the reference to the trusted digest if one exists or denies the request otherwise.
+This ensures that the container runtime pulls and spins up a container of a validated image, as the digest is an immutable inherent property of the image.
+
+However, some closed-loop deployment technologies such as [Argo CD](https://argo-cd.readthedocs.io/) verify that the created resources correspond to the requested resources, essentially synchronizing the state from a reference repository.
+In consequence, a mutated image reference causes an error for such tools, as actual and requested resource differ.
+To resolve this, it is possible to configure Connaisseur to only validate but not mutate image references by which the original image reference (tag or digest) remains unchanged and successful admission only indicates that a trusted digest exists.
+However, image tag and digest are only loosly associated which introduces a [*time-of-check to time-of-use* vulnerability](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use): an attacker slips in a malicious image after Connaisseur validated that a given tag exhibits a signed digest but before the runtime resolves the tag for pulling the image.
+This supposedly small time window might be significantly larger if images are re-pulled by the container runtime at a later time for some reason.
+
+To disable image mutation, set the `validationMode.mutateImage` flag to `false` in `helm/values.yaml`.
+
+## Configuration options
+
+`validationMode` in `helm/values.yaml` supports the following keys:
+
+| Key | Default | Required | Description |
+| - | - | - | - |
+| `mutateImage` | true | | `true` or `false`; mutate image reference to trusted digest (`true`) or keep original reference (`false`) |
+
+## Example
+
+In `helm/values.yaml`:
+
+```
+validationMode:
+  mutateImage: true
+```
+

--- a/docs/features/validation_mode.md
+++ b/docs/features/validation_mode.md
@@ -1,5 +1,8 @@
 # Validation Mode
 
+> :warning: Be aware that disabling image reference mutation has significant impact on the security guarantees of signature verification.
+> Carefully consider the notes below.
+
 Validation mode allows configuration whether Connaisseur mutates image references (tags to trusted digests).
 
 In default behavior during validation, Connaisseur uses the image reference (tag or digest) from the admission request to identify a trusted digest (digest with valid signature from a configured trust root) and modifies the reference to the trusted digest if one exists or denies the request otherwise.
@@ -10,6 +13,8 @@ In consequence, a mutated image reference causes an error for such tools, as act
 To resolve this, it is possible to configure Connaisseur to only validate but not mutate image references by which the original image reference (tag or digest) remains unchanged and successful admission only indicates that a trusted digest exists.
 However, image tag and digest are only loosly associated which introduces a [*time-of-check to time-of-use* vulnerability](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use): an attacker slips in a malicious image after Connaisseur validated that a given tag exhibits a signed digest but before the runtime resolves the tag for pulling the image.
 This supposedly small time window might be significantly larger if images are re-pulled by the container runtime at a later time for some reason.
+
+As disabling image reference mutation considerably lowers the security guarantees of image signatures for the above reasons, it is generally advised to reference images by (signed) digests instead of tags in which case no mutation takes place even if mutation remains activated.
 
 To disable image mutation, set the `validationMode.mutateImage` flag to `false` in `helm/values.yaml`.
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.4.3
-appVersion: 2.6.3
+version: 1.5.0
+appVersion: 2.7.0
 keywords:
   - container image
   - signature

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -24,6 +24,9 @@ data:
   AUTOMATIC_CHILD_APPROVAL_ENABLED: "0"
   {{- end }}
   {{- end }}
+  {{- if .Values.validationMode }}
+  VALIDATION_MODE_MUTATE: {{ quote .Values.validationMode.mutateImage | default "true"}}
+  {{- end }}
   {{- if .Values.alerting }}
   CLUSTER_NAME: {{ default "not specified" .Values.alerting.cluster_identifier }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -144,7 +144,7 @@ detectionMode: false
 
 # validation mode allows advanced configuration of image validation such as whether to mutate image references
 validationMode:
-  mutateImage: false  # mutate image references to signed digests ('true', default) or keep original reference ('false', less secure)
+  mutateImage: true  # mutate image references to signed digests ('true', default) or keep original reference ('false', less secure)
 
 # namespaced validation allows to restrict the namespaces that will be subject to Connaisseur verification.
 # when enabled, based on namespaced validation mode ('ignore' or 'validate')

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -144,7 +144,7 @@ detectionMode: false
 
 # validation mode allows advanced configuration of image validation such as whether to mutate image references
 validationMode:
-  mutateImage: true  # mutate image references to signed digests ('true', default) or keep original reference ('false')
+  mutateImage: false  # mutate image references to signed digests ('true', default) or keep original reference ('false', less secure)
 
 # namespaced validation allows to restrict the namespaces that will be subject to Connaisseur verification.
 # when enabled, based on namespaced validation mode ('ignore' or 'validate')

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.6.3
+  image: securesystemsengineering/connaisseur:v2.7.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.
@@ -141,6 +141,10 @@ policy:
 # and logged. this allows testing the functionality without
 # interrupting operation.
 detectionMode: false
+
+# validation mode allows advanced configuration of image validation such as whether to mutate image references
+validationMode:
+  mutateImage: true  # mutate image references to signed digests ('true', default) or keep original reference ('false')
 
 # namespaced validation allows to restrict the namespaces that will be subject to Connaisseur verification.
 # when enabled, based on namespaced validation mode ('ignore' or 'validate')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - features/metrics.md
       - features/alerting.md
       - features/detection_mode.md
+      - features/validation_mode.md
       - features/namespaced_validation.md
       - features/automatic_child_approval.md
   - Security:


### PR DESCRIPTION
relates to #712 

## Description

allow configuration to not mutate image references but simply validate whether signed digest exists

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

