### PR TITLE
ci: Limit Github Actions token scope

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,6 +9,10 @@ on:
       - master
       - develop
 
+# Reduce default permission of GITHUB_TOKEN to nothing
+# Repository can still be checked out during these jobs
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '40 6 * * 3'
 
+# Reduce default permission of GITHUB_TOKEN to nothing
+# Repository can still be checked out during these jobs
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '37 6 * * 3'
 
+# No permissions needed
+permissions: {}
+
 jobs:
   dockerhub-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-dev.yaml
+++ b/.github/workflows/docs-dev.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+# Needs write on repo contents as it pushes to gh-pages branch
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*.*.*'
 
+# Needs write on repo contents as it pushes to gh-pages branch
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+# Reduce default permission of GITHUB_TOKEN to nothing
+# Repository can still be checked out during these jobs
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,10 @@ on:
   push:
     tags: "v*"
 
+# Reduce default permission of GITHUB_TOKEN to nothing
+# Repository can still be checked out during these jobs
+permissions: {}
+
 jobs:
   version-match:
     runs-on: ubuntu-latest
@@ -76,6 +80,8 @@ jobs:
   publish_chart:
     runs-on: ubuntu-latest
     needs: [version-match, integration-test]
+    permissions:
+      contents: write
     steps:
       - name: Install Helm and Git
         run: |


### PR DESCRIPTION
## Description
Previously any action and job ran with full read/write privileges as some jobs (docs) need write access. This commit limits the scope with which most jobs are running and only allows broader scope where necessary

## Checklist


- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

