### PR TITLE
Don't clear image tag

### DIFF
--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -69,7 +69,6 @@ class Image:
         Set the digest to the given `digest`.
         """
         self.digest = digest
-        self.tag = None
 
     def has_digest(self) -> bool:
         """

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -128,13 +128,20 @@ def test_image(
 
 
 @pytest.mark.parametrize(
-    "image, digest",
-    [("image:tag", "859b5aada817b3eb53410222e8fc232cf126c9e598390ae61895eb96f52ae46d")],
+    "image, tag, digest",
+    [
+        (
+            "image:tag",
+            "tag",
+            "859b5aada817b3eb53410222e8fc232cf126c9e598390ae61895eb96f52ae46d",
+        )
+    ],
 )
-def test_set_digest(image: str, digest: str):
+def test_set_digest(image: str, tag: str, digest: str):
     i = img.Image(image)
     i.set_digest(digest)
     assert i.digest == digest
+    assert i.tag == tag
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Just because you've augmented an image with a new property ("digest") doesn't mean you get to clear a different value ("tag") in the setter.

Fixes: N/A (or, more correctly: future pain when tag preservation in patch is implemented)

## Description

Image tags are valid properties of the image.  You shouldn't arbitrarily throw the tag away once you've set a digest.
I intend for you to preserve this image tag in the patch based on a config setting in a subsequent PR, but first I need to test your willingness to adapt here with this change.

I can't keep using your solution if we can't take these steps together to preserve my image tags.

## Checklist

- [X] PR is rebased to/aimed at branch `develop`
- [X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [X] Added tests (if necessary)
- [X] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

