### PR TITLE
ci: temporarily removed old k8s versions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -238,7 +238,7 @@ jobs:
       - uses: ./.github/actions/k8s-version-config
         name: Setup k8s cluster
         with:
-          k8s-version: v1.22
+          k8s-version: v1.25
       - name: Set environment variables for alerting listener
         run: |
           CONTAINER=$(docker container ls --no-trunc --format "{{json . }}" | jq ' . | select(.Image|match("alerting-endpoint"))')
@@ -270,12 +270,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version:
-          [
-            "v1.16",
-            "v1.17",
-            "v1.18",
-            "v1.19",
+        k8s-version: [
+            # "v1.16",
+            # "v1.17",
+            # "v1.18",
+            # "v1.19",
             "v1.20",
             "v1.21",
             "v1.22",
@@ -332,7 +331,7 @@ jobs:
       - uses: ./.github/actions/k8s-version-config
         name: Setup k8s cluster
         with:
-          k8s-version: v1.22
+          k8s-version: v1.25
       - uses: actions/checkout@v3
         with:
           ref: "master"

--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -2,7 +2,7 @@ name: nightly-scans
 
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 # Reduce default permission of GITHUB_TOKEN to nothing
 # Repository can still be checked out during these jobs
@@ -53,8 +53,7 @@ jobs:
         run: |
           sudo snap install yq
       - name: Get latest public image
-        run:
-          echo "LATEST-IMAGE=docker.io/$(yq e '.deployment.image' helm/values.yaml)" >> $GITHUB_ENV
+        run: echo "LATEST-IMAGE=docker.io/$(yq e '.deployment.image' helm/values.yaml)" >> $GITHUB_ENV
       - name: Run Trivy
         uses: aquasecurity/trivy-action@master
         with:
@@ -82,8 +81,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-           name: trivy-reports
-           path: trivy-reports
+          name: trivy-reports
+          path: trivy-reports
 
   get-root:
     runs-on: ubuntu-latest
@@ -103,7 +102,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        integration-test-arg: ["regular", "cosign", "deployment", "pre-config", "helm-repo"]
+        integration-test-arg:
+          ["regular", "cosign", "deployment", "pre-config", "helm-repo"]
     services:
       alerting-endpoint:
         image: securesystemsengineering/alerting-endpoint
@@ -119,7 +119,7 @@ jobs:
       - uses: ./.github/actions/k3s-cluster
         name: Setup K8s cluster
         with:
-          k3s-channel: v1.22
+          k3s-channel: v1.25
       - name: Set environment variables for alerting listener
         run: |
           CONTAINER=$(docker container ls --no-trunc --format "{{json . }}" | jq ' . | select(.Image|match("alerting-endpoint"))')
@@ -150,8 +150,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version:
-          ["v1.16", "v1.17", "v1.18", "v1.19", "v1.20", "v1.21", "v1.22", "v1.23", "v1.24", "v1.25"]
+        k8s-version: [
+            # "v1.16",
+            # "v1.17",
+            # "v1.18",
+            # "v1.19",
+            "v1.20",
+            "v1.21",
+            "v1.22",
+            "v1.23",
+            "v1.24",
+            "v1.25",
+          ]
     steps:
       - uses: actions/checkout@v3
       - name: Install yq

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./.github/actions/k8s-version-config
         name: Setup k8s cluster
         with:
-          k8s-version: v1.22
+          k8s-version: v1.25
           load-local-image: false
       - name: Set environment variables for alerting listener
         run: |

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -355,7 +355,7 @@ case $1 in
   kubectl create clusterrolebinding ${NAME} --clusterrole=auxillary --serviceaccount=${NS}:${NAME}
 
   # Use that service account's config to run the Connaisseur deployment to see no other namespace is touched
-  TOKEN=$(kubectl describe secrets -n ${NS} "$(kubectl describe serviceaccount ${NAME} -n ${NS} | grep Tokens | awk '{print $2}')" | grep token: | awk '{print $2}')
+  TOKEN=$(kubectl create token ${NAME} --namespace=${NS})
   kubectl config set-credentials ${CTX} --token=${TOKEN}
   kubectl config set-context ${CTX} --cluster=${CLUSTER_NAME} --user=${CTX}
   kubectl config use-context ${CTX}


### PR DESCRIPTION
## Description

The older k8 versions (v1.16 - v1.19) are failing the pipeline. Since they reached their end of life anyways, they have been removed temporarily until we find a fix.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

