### PR TITLE
ci: Change deprecated set-output to GITHUB_OUTPUT variable and re-enable legacy k8s tests

### DIFF
--- a/.github/actions/k3s-cluster/action.yaml
+++ b/.github/actions/k3s-cluster/action.yaml
@@ -13,16 +13,16 @@ inputs:
 outputs:
   kubeconfig:
     description: Path to kubeconfig file
-    value: ${{ steps.set-output.outputs.kubeconfig }}
+    value: ${{ steps.set-versions.outputs.kubeconfig }}
   k3s-version:
     description: "Installed k3s version, such as v1.20.0+k3s2"
-    value: "${{ steps.set-output.outputs.k3s-version }}"
+    value: "${{ steps.set-versions.outputs.k3s-version }}"
   k8s-version:
     description: "Installed k8s version, such as v1.20.0"
-    value: "${{ steps.set-output.outputs.k8s-version }}"
+    value: "${{ steps.set-versions.outputs.k8s-version }}"
   helm-version:
     description: "Installed helm version, such as v3.4.2"
-    value: "${{ steps.set-output.outputs.helm-version }}"
+    value: "${{ steps.set-versions.outputs.helm-version }}"
 
 runs:
   using: "composite"
@@ -49,12 +49,12 @@ runs:
       shell: bash
 
     - name: Set version output
-      id: set-output
+      id: set-versions
       run: |
         echo "::group::Set version output"
-        echo "::set-output name=kubeconfig::$HOME/.kube/config"
-        echo "::set-output name=k3s-version::$(k3s --version | sed 's/.*\(v[0-9][^ ]*\).*/\1/')"
-        echo "::set-output name=k8s-version::$(k3s --version | sed 's/.*\(v[0-9][^+]*\).*/\1/')"
+        echo "kubeconfig=$HOME/.kube/config" >> $GITHUB_OUTPUT
+        echo "k3s-version=$(k3s --version | grep 'k3s' | sed 's/.*\(v[0-9][^ ]*\).*/\1/')" >> $GITHUB_OUTPUT
+        echo "k8s-version=$(k3s --version | grep 'k3s' | sed 's/.*\(v[0-9][^+]*\).*/\1/')" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -271,16 +271,53 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [
-            # "v1.16",
-            # "v1.17",
-            # "v1.18",
-            # "v1.19",
             "v1.20",
             "v1.21",
             "v1.22",
             "v1.23",
             "v1.24",
             "v1.25",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - uses: actions/download-artifact@v3
+        with:
+          name: images
+      - uses: ./.github/actions/k8s-version-config
+        name: Setup k8s cluster
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+      - name: Configure Connaisseur
+        run: |
+          yq e '.deployment.imagePullPolicy = "Never"' -i helm/values.yaml
+          yq e '.policy +={"pattern": "docker.io/securesystemsengineering/connaisseur:v*"} | .policy[4].pattern style="double"' -i helm/values.yaml
+          yq e '.policy[4].validator = "allow"' -i helm/values.yaml
+          yq e '.deployment.replicasCount = "1"' -i helm/values.yaml
+      - name: Run pre-config and workload integration tests
+        run: |
+          bash tests/integration/integration-test.sh "pre-and-workload"
+        shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+        shell: bash
+
+  k8s-legacy-versions:
+    # k3s with older versions doesn't play with newer kernel, so we're running those on deprecated hosts, yay...
+    runs-on: ubuntu-18.04
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [
+            "v1.16",
+            "v1.17",
+            "v1.18",
+            "v1.19",
           ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-scans.yaml
+++ b/.github/workflows/nightly-scans.yaml
@@ -151,16 +151,48 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version: [
-            # "v1.16",
-            # "v1.17",
-            # "v1.18",
-            # "v1.19",
             "v1.20",
             "v1.21",
             "v1.22",
             "v1.23",
             "v1.24",
             "v1.25",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yq
+        run: |
+          sudo snap install yq
+      - uses: ./.github/actions/k8s-version-config
+        name: Setup k8s cluster
+        with:
+          k8s-version: ${{ matrix.k8s-version }}
+          load-local-image: false
+      - name: Configure Connaisseur
+        run: |
+          yq e '.deployment.replicasCount = "1"' -i helm/values.yaml
+      - name: Run pre-config and workload integration tests
+        run: |
+          bash tests/integration/integration-test.sh "nightly-pre-and-workload"
+        shell: bash
+      - name: Display k8s logs if integration test failed
+        if: failure()
+        run: |
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+        shell: bash
+
+
+  k8s-legacy-versions:
+    # k3s with older versions doesn't play with newer kernel, so we're running those on deprecated hosts, yay...
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version: [
+            "v1.16",
+            "v1.17",
+            "v1.18",
+            "v1.19",
           ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

- Changes the deprecated set-output command in the CI
- Fixes tests for older k8s versions

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

