### PR TITLE
Fix: add tag labels to patch output

### DIFF
--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -80,7 +80,7 @@ class Image:
         repo_reg = "".join(
             f"{item}/" for item in [self.registry, self.repository] if item
         )
-        tag = f":{self.tag}" if not self.digest else f":{self.tag}@sha256:{self.digest}"
+        tag = f":{self.tag}" if not self.digest else f"@sha256:{self.digest}" if not self.tag else f":{self.tag}@sha256:{self.digest}"
         return f"{repo_reg}{self.name}{tag}"
 
     def __eq__(self, other):

--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -80,7 +80,7 @@ class Image:
         repo_reg = "".join(
             f"{item}/" for item in [self.registry, self.repository] if item
         )
-        tag = f":{self.tag}" if not self.digest else f"@sha256:{self.digest}"
+        tag = f":{self.tag}" if not self.digest else f":{self.tag}@sha256:{self.digest}"
         return f"{repo_reg}{self.name}{tag}"
 
     def __eq__(self, other):

--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -80,7 +80,9 @@ class Image:
         repo_reg = "".join(
             f"{item}/" for item in [self.registry, self.repository] if item
         )
-        tag = f":{self.tag}" if not self.digest else f"@sha256:{self.digest}" if not self.tag else f":{self.tag}@sha256:{self.digest}"
+        tag = (
+            f":{self.tag}" if not self.digest else f"@sha256:{self.digest}" 
+            if not self.tag else f":{self.tag}@sha256:{self.digest}")
         return f"{repo_reg}{self.name}{tag}"
 
     def __eq__(self, other):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -183,6 +183,16 @@ def test_has_digest(image: str, digest: bool):
             ),
         ),
         ("path/image", "docker.io/path/image:latest"),
+        (
+            (
+                "image:tag@sha256:859b5aada817b3eb53410222"
+                "e8fc232cf126c9e598390ae61895eb96f52ae46d"
+            ),
+            (
+                "docker.io/library/image:tag@sha256:859b5aada817b3eb"
+                "53410222e8fc232cf126c9e598390ae61895eb96f52ae46d"
+            ),
+        ),
     ],
 )
 def test_str(image: str, str_image: str):


### PR DESCRIPTION
Fixes # n/a
Extends: #800

## Description

The mutating controller is stripping the human-readable element from the patch, and therefore the deployment artifacts that are mutated.
This results in pain and frustration for humans and tools that are relying on the human-readable element.  This includes `kubectl` output, metrics tools like `grafana` dashboards that have suddenly lost tag elements, security monitoring tools that can no longer see the deployed version by parsing a tag, and many more.
Essentially, we will have to select a different tool and move away from `connaisseur` if the image tags can not be preserved.
`Chainguard` allegedly handles tags the way that I desire.

## Checklist


- [X] PR is rebased to/aimed at branch `develop`
- [X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [X] Added tests (if necessary)
- [X] Extended README/Documentation (if necessary)
- [X] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

