### PR TITLE
fix: revert frozenlist changes

### DIFF
--- a/.github/actions/safety/action.yaml
+++ b/.github/actions/safety/action.yaml
@@ -5,7 +5,6 @@ runs:
   steps:
     - name: Install packages
       run: |
-        apt update && apt install gcc build-essential -y
         pip3 install --upgrade pip
         pip3 install -r requirements_dev.txt
       shell: sh

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -73,7 +73,6 @@ jobs:
       - name: Install packages
         # Since we run inside an alpine based container, we cannot compile yarl and multidic
         run: |
-          apk add gcc libc-dev
           pip3 install --upgrade pip
           YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install -r requirements_dev.txt
       - name: Lint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY requirements.txt /requirements.txt
 
 # Have to upgrade pip and install extra packages due to error when installing frozenlist
 # Since we run inside an alpine based container, we cannot compile yarl and multidict
-RUN apk add --no-cache gcc~=11.2.1_git20220219-r2 libc-dev~=0.7.2-r3 \
+RUN apk add --no-cache \
  && pip install --no-cache-dir --upgrade pip~=22.3 \
  && YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip install --no-cache-dir --prefix=/install -r /requirements.txt
 


### PR DESCRIPTION
There was a problem with the frozenlist package, which didn't had its packages added to wheels (https://github.com/aio-libs/frozenlist/issues/342). The packages are now added, so the fix for this can be reverted, except for the pytest job which is the only one building on a debian image (faster runtime). Here the yarl and multidict packages still have the same problem as frozenlist had. Waiting fo a fix here.

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)

