### PR TITLE
feat: auto update approval

### DIFF
--- a/connaisseur/admission_request.py
+++ b/connaisseur/admission_request.py
@@ -12,6 +12,7 @@ class AdmissionRequest:
         )
 
         request = ad_request["request"]
+        self.__request = request
         self.uid = request["uid"]
         self.kind = request["kind"]["kind"]
         self.namespace = request["namespace"]
@@ -28,3 +29,7 @@ class AdmissionRequest:
             "name": self.wl_object.name,
             "namespace": self.namespace,
         }
+
+    @property
+    def old_wl_object(self):
+        return WorkloadObject(self.__request.get("oldObject"), self.namespace)

--- a/connaisseur/admission_request.py
+++ b/connaisseur/admission_request.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from connaisseur.exceptions import InvalidFormatException
 from connaisseur.util import validate_schema
 from connaisseur.workload_object import WorkloadObject
@@ -30,6 +32,6 @@ class AdmissionRequest:
             "namespace": self.namespace,
         }
 
-    @property
+    @cached_property
     def old_wl_object(self):
         return WorkloadObject(self.__request.get("oldObject"), self.namespace)

--- a/connaisseur/workload_object.py
+++ b/connaisseur/workload_object.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import connaisseur.kube_api as k_api
 from connaisseur.exceptions import ParentNotFoundError, UnknownAPIVersionError
 from connaisseur.image import Image
@@ -48,7 +50,7 @@ class WorkloadObject:
                 wl_obj_name=self.name,
             )
 
-    @property
+    @cached_property
     def parent_containers(self):
         parent_containers = {}
         for owner in self._owner:
@@ -91,7 +93,7 @@ class WorkloadObject:
     def spec(self):
         return self._spec["template"]["spec"]
 
-    @property
+    @cached_property
     def containers(self):
         return {
             (container_type, index): Image(container["image"])

--- a/docs/features/automatic_update_approval.md
+++ b/docs/features/automatic_update_approval.md
@@ -1,0 +1,34 @@
+# Automatic Unchanged Approval
+
+With the feature *automatic unchanged approval* enabled, Connaisseur automatically approves any resource that is updated and doesn't change its image references.
+This is especially useful when handling long living resources, with potentially out-of-sync signature data, that still need to be scaled up and down.
+
+An example: When dealing with a deployment that has an image reference `image:tag`, this reference is updated by Connaisseur during signature validation to `image@sha256:123...`, to ensure the correct image is used by the deployment.
+When scaling up or down the deployment, the image reference `image@sha256:123...` is presented to Connaisseur, due to the updated definition.
+Over time the signature of the original `image:tag` may change and a new "correct" image is available at `image@sha256:456...`.
+If afterwards the deployment in scaled up or down, Connaisseur will try to validate the image reference `image@sha256:123...`, by looking for it inside the signature data it receives.
+Unfortunately this reference may no longer be present, due to signature updates and thus the whole scaling will be denied.
+
+With automatic unchanged approval enabled, this is no longer the case.
+The validation of `image@sha256:123...` will be skipped, as no different image is used.
+
+This obviously has security implications, since it's no longer guaranteed that resources that are updated, have fresh and up-to-date signatures.
+So use it with caution.
+For that reason the feature is also disabled by default.
+The creation of resources on the other hand remains unchanged and will enforce validation.
+
+## Configuration options
+
+`automaticUnchangedApproval` in `helm/value.yaml` supports the following keys:
+
+| Key | Default | Required | Description |
+| - | - | - | - |
+| `automaticUnchangedApproval` | false |  | `true` or `false` ; when `true`, Connaisseur will enable automatic unchanged approval |
+
+## Example
+
+In `helm/values.yaml`:
+
+```yaml
+automaticUnchangedApproval: true
+```

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.5.0
-appVersion: 2.7.0
+version: 1.6.0
+appVersion: 2.8.0
 keywords:
   - container image
   - signature

--- a/helm/templates/env.yaml
+++ b/helm/templates/env.yaml
@@ -27,6 +27,9 @@ data:
   {{- if .Values.alerting }}
   CLUSTER_NAME: {{ default "not specified" .Values.alerting.cluster_identifier }}
   {{- end }}
+  {{- if .Values.automaticUnchangedApproval  }}
+  AUTOMATIC_UNCHANGED_APPROVAL: "1"
+  {{- end }}
   KUBE_VERSION: {{ .Capabilities.KubeVersion }}
 ---
 apiVersion: v1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: securesystemsengineering/connaisseur:v2.7.0
+  image: securesystemsengineering/connaisseur:v2.8.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.
@@ -175,6 +175,13 @@ namespacedValidation:
 # NOTE: configuration of automatic child approval is in EXPERIMENTAL state.
 automaticChildApproval:
   enabled: true
+
+# automatic unchanged approval determines how certain updates of Kubernetes resources are handled
+# by Connaisseur. when disabled (default), Connaisseur validates and mutates resources whenever they 
+# are created or updated. when enabled, Connaisseur will skip validation on any update request that
+# does not change the image references used by the resource. check the docs for more
+# information.
+automaticUnchangedApproval: false
 
 # debug: true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,6 +352,7 @@ def adm_req_samples(m_ad_schema_path):
             "invalid_image",
             "auto_approval",
             "invalid",
+            "auto_update_approval",
         )
     ]
 

--- a/tests/data/sample_admission_requests/ad_request_auto_update_approval.json
+++ b/tests/data/sample_admission_requests/ad_request_auto_update_approval.json
@@ -1,0 +1,220 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1",
+    "request": {
+        "uid": "6418f614-b7f1-4c57-94bf-14fc30b2d791",
+        "kind": {
+            "group": "apps",
+            "version": "v1",
+            "kind": "ReplicaSet"
+        },
+        "resource": {
+            "group": "apps",
+            "version": "v1",
+            "resource": "replicasets"
+        },
+        "requestKind": {
+            "group": "apps",
+            "version": "v1",
+            "kind": "ReplicaSet"
+        },
+        "requestResource": {
+            "group": "apps",
+            "version": "v1",
+            "resource": "replicasets"
+        },
+        "name": "test-58d59c69bf",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "system:serviceaccount:kube-system:deployment-controller",
+            "uid": "ad2a0c14-9ed4-4ef4-8b28-1e66978a7e6c",
+            "groups": [
+                "system:serviceaccounts",
+                "system:serviceaccounts:kube-system",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "ReplicaSet",
+            "apiVersion": "apps/v1",
+            "metadata": {
+                "name": "test-58d59c69bf",
+                "namespace": "default",
+                "uid": "5a112af8-ccc7-4e00-b1bc-f81adc8acffe",
+                "resourceVersion": "8916",
+                "generation": 3,
+                "creationTimestamp": "2023-01-26T10:39:15Z",
+                "labels": {
+                    "app": "test",
+                    "pod-template-hash": "58d59c69bf"
+                },
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "2",
+                    "deployment.kubernetes.io/max-replicas": "3",
+                    "deployment.kubernetes.io/revision": "2"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "Deployment",
+                        "name": "test",
+                        "uid": "8d8adb16-b1fc-487d-a778-3b6f556a9050",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ],
+                "managedFields": []
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {
+                    "matchLabels": {
+                        "app": "test",
+                        "pod-template-hash": "58d59c69bf"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "test",
+                            "pod-template-hash": "58d59c69bf"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "nginx",
+                                "image": "docker.io/library/redis:latest@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 30,
+                        "dnsPolicy": "ClusterFirst",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "replicas": 2,
+                "fullyLabeledReplicas": 2,
+                "readyReplicas": 2,
+                "availableReplicas": 2,
+                "observedGeneration": 2
+            }
+        },
+        "oldObject": {
+            "kind": "ReplicaSet",
+            "apiVersion": "apps/v1",
+            "metadata": {
+                "name": "test-58d59c69bf",
+                "namespace": "default",
+                "uid": "5a112af8-ccc7-4e00-b1bc-f81adc8acffe",
+                "resourceVersion": "8916",
+                "generation": 3,
+                "creationTimestamp": "2023-01-26T10:39:15Z",
+                "labels": {
+                    "app": "test",
+                    "pod-template-hash": "58d59c69bf"
+                },
+                "annotations": {
+                    "deployment.kubernetes.io/desired-replicas": "2",
+                    "deployment.kubernetes.io/max-replicas": "3",
+                    "deployment.kubernetes.io/revision": "2"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "kind": "Deployment",
+                        "name": "test",
+                        "uid": "8d8adb16-b1fc-487d-a778-3b6f556a9050",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ],
+                "managedFields": [
+                    {
+                        "manager": "kubectl",
+                        "operation": "Update",
+                        "apiVersion": "apps/v1",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {
+                            "f:spec": {
+                                "f:replicas": {}
+                            }
+                        },
+                        "subresource": "scale"
+                    },
+                    {
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "apiVersion": "apps/v1",
+                        "time": "2023-01-26T10:39:24Z",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {}
+                    },
+                    {
+                        "manager": "kube-controller-manager",
+                        "operation": "Update",
+                        "apiVersion": "apps/v1",
+                        "time": "2023-01-26T10:39:25Z",
+                        "fieldsType": "FieldsV1",
+                        "fieldsV1": {},
+                        "subresource": "status"
+                    }
+                ]
+            },
+            "spec": {
+                "replicas": 4,
+                "selector": {
+                    "matchLabels": {
+                        "app": "test",
+                        "pod-template-hash": "58d59c69bf"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "test",
+                            "pod-template-hash": "58d59c69bf"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "nginx",
+                                "image": "docker.io/library/redis:latest@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 30,
+                        "dnsPolicy": "ClusterFirst",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "replicas": 2,
+                "fullyLabeledReplicas": 2,
+                "readyReplicas": 2,
+                "availableReplicas": 2,
+                "observedGeneration": 2
+            }
+        },
+        "dryRun": false,
+        "options": {
+            "kind": "UpdateOptions",
+            "apiVersion": "meta.k8s.io/v1"
+        }
+    }
+}

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -195,12 +195,34 @@ def test_create_logging_msg(msg, kwargs, out):
             },
             fix.no_exc(),
         ),
+        (
+            8,
+            {
+                "apiVersion": "admission.k8s.io/v1",
+                "kind": "AdmissionReview",
+                "response": {
+                    "uid": "6418f614-b7f1-4c57-94bf-14fc30b2d791",
+                    "allowed": True,
+                    "status": {"code": 202},
+                },
+            },
+            fix.no_exc(),
+        ),
     ],
 )
 async def test_admit(
-    adm_req_samples, index, m_request, m_expiry, m_trust_data, out, exception
+    monkeypatch,
+    adm_req_samples,
+    index,
+    m_request,
+    m_expiry,
+    m_trust_data,
+    out,
+    exception,
 ):
     with exception:
+        if index == 8:
+            monkeypatch.setenv("AUTOMATIC_UNCHANGED_APPROVAL", "1")
         with aioresponses() as aio:
             aio.get(re.compile(r".*"), callback=fix.async_callback, repeat=True)
             response = await pytest.fa.__admit(AdmissionRequest(adm_req_samples[index]))

--- a/tests/validators/notaryv1/test_trust_data.py
+++ b/tests/validators/notaryv1/test_trust_data.py
@@ -1,9 +1,9 @@
 import datetime as dt
-from freezegun import freeze_time
 import json
 
 import pytest
 import pytz
+from freezegun import freeze_time
 
 import connaisseur.exceptions as exc
 import connaisseur.validators.notaryv1.trust_data as td


### PR DESCRIPTION
Added a feature flag that enables auto update approval. When active, Connaisseur automatically allows updates to resources in which no changes to image references were made.

fixes  #820

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

