### PR TITLE
Fix mutate timeout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ connaisseur/coverage.xml
 connaisseur/coverage.txt
 # ignore pycache
 connaisseur/__pycache__/
+# ignore venv folder
+venv/

--- a/connaisseur/config.py
+++ b/connaisseur/config.py
@@ -16,7 +16,7 @@ from connaisseur.validators.validator import Validator
 
 class Config:
     """
-    Config Object that contains all notary configurations.
+    Config Object that contains all runtime configurations.
     """
 
     __PATH = "/app/connaisseur-config/config.yaml"
@@ -28,7 +28,7 @@ class Config:
 
     def __init__(self):
         """
-        Create a Config object, containing all validator configurations.
+        Create a Config object, containing all runtime configurations.
         Read a config file, validate its contents and then create Validator objects,
         storing them.
 

--- a/connaisseur/constants.py
+++ b/connaisseur/constants.py
@@ -1,1 +1,8 @@
+# We use aiohttp to connect to external sources. Webhooks time out after 30s,
+# so we need to respond before that or the Connaisseur webhook will fail with a
+# generic error message, see https://github.com/sse-secure-systems/connaisseur/issues/448
+# Since the timeouts in aiohttp are ceiled to full seconds
+# (https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts),
+# we can't get closer to 30 than 29 without failing to respond within 30 a lot more often
+AIO_TIMEOUT_SECONDS = 29
 SHA256 = "sha256"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,8 +76,6 @@ We recommend the following approach for running pytest in a container:
 ```
 docker run -it --rm -v <path-to-repository>:/data --entrypoint=ash python:alpine
 cd data
-pip3 install --upgrade pip
-apk add libc-dev gcc
 YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install -r requirements_dev.txt
 pytest --cov=connaisseur --cov-report=xml tests/
 ```


### PR DESCRIPTION
<!--- Reference respective issue if it exists -->

Admission control is capped to 30s. As such Connaisseur must finish within these 30s or it will fail generically. To add information to this failure, this MR adds a 29s timeout to all validation activities and fails with a dedicated error message if the timeout is surpassed
The MR also contains minor fixes to docs and build I noticed when touching it

Fixes #448 

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

