### PR TITLE
fix: ignore secret scanning config rules for trivy config scanner

### DIFF
--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -3,16 +3,18 @@ description: 'action that runs trivy '
 runs:
   using: "composite"
   steps:
-    - name: Install trivy
+    - name: Setup reports folder
       run: |
-        apk update
-        apk add curl
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
         mkdir trivy-reports
       shell: sh
-    - name: Scan Image
-      run: trivy image --input ${GITHUB_SHA}_image.tar
-              -o trivy-reports/image.txt
-              --exit-code 1
-              --severity="UNKNOWN,MEDIUM,HIGH,CRITICAL"
-      shell: sh
+    - name: Run Trivy on Image
+      uses: aquasecurity/trivy-action@master
+      with:
+        input: ${{ github.sha }}_image.tar
+        scan-type: "image"
+        hide-progress: false
+        format: "table"
+        output: 'trivy-reports/image.txt'
+        exit-code: "1"
+        ignore-unfixed: false
+        severity: "UNKNOWN,MEDIUM,HIGH,CRITICAL"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,14 @@
+# no fix yet, no actual risk, risk accepted
 CVE-2022-32149
+
+# no fix yet, no actual risk, risk accepted
 CVE-2022-41717
+
+# no fix yet, no actual risk, risk accepted
 CVE-2022-41721
+
+# noise rule "Storing sensitive content in configMaps is unsafe", dropped
+AVD-KSV-0109
+
+# noisy rule "Storing secrets in configMaps is unsafe", dropped
+AVD-KSV-0110

--- a/connaisseur/alert.py
+++ b/connaisseur/alert.py
@@ -18,7 +18,6 @@ from connaisseur.util import safe_json_open, validate_schema
 
 
 class AlertingConfiguration:
-
     __PATH = "/app/config/alertconfig.json"
     __SCHEMA_PATH = "/app/connaisseur/res/alertconfig_schema.json"
 

--- a/connaisseur/exceptions.py
+++ b/connaisseur/exceptions.py
@@ -116,7 +116,6 @@ class UnreachableError(BaseConnaisseurException):
 
 
 class AlertingException(Exception):
-
     message: str
 
     def __init__(self, message: str):

--- a/connaisseur/flask_application.py
+++ b/connaisseur/flask_application.py
@@ -80,12 +80,7 @@ def mutate():
         logging.error(err_log)
         uid = admission_request.uid if admission_request else ""
         return jsonify(
-            get_admission_review(
-                uid,
-                False,
-                msg=msg,
-                detection_mode=DETECTION_MODE,
-            )
+            get_admission_review(uid, False, msg=msg, detection_mode=DETECTION_MODE)
         )
 
     send_alerts(admission_request, True)

--- a/connaisseur/image.py
+++ b/connaisseur/image.py
@@ -30,7 +30,6 @@ class Image:
     digest_algo: Optional[str]
 
     def __init__(self, image: str):  # pylint: disable=too-many-locals
-
         # implements https://github.com/distribution/distribution/blob/main/reference/regexp.go
         digest_hex = r"[0-9a-fA-F]{32,}"
         digest_algorithm_component = r"[A-Za-z][A-Za-z0-9]*"

--- a/connaisseur/util.py
+++ b/connaisseur/util.py
@@ -112,9 +112,7 @@ def validate_schema(data: dict, schema_path: str, kind: str, exception):
     except ValidationError as err:
         msg = "{validation_kind} has an invalid format: {validation_err}."
         raise exception(
-            message=msg,
-            validation_kind=kind,
-            validation_err=str(err),
+            message=msg, validation_kind=kind, validation_err=str(err)
         ) from err
 
 

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -101,9 +101,7 @@ class CosignValidator(ValidatorInterface):
         if missing_trs:
             msg = 'Trust roots "{tr_names}" not configured for validator "{validator_name}".'
             raise NotFoundException(
-                message=msg,
-                tr_names=", ".join(missing_trs),
-                validator_name=self.name,
+                message=msg, tr_names=", ".join(missing_trs), validator_name=self.name
             )
 
         # construct key validation dictionary for pinned keys
@@ -270,11 +268,7 @@ class CosignValidator(ValidatorInterface):
             )
         elif isinstance(trust_root, KMSKey):
             return self.__invoke_cosign(
-                image,
-                {
-                    "option_kword": "--key",
-                    "inline_tr": trust_root.value,
-                },
+                image, {"option_kword": "--key", "inline_tr": trust_root.value}
             )
         msg = (
             "The trust_root type {tr_type} is unsupported for a validator of type"
@@ -322,7 +316,7 @@ class CosignValidator(ValidatorInterface):
                     message=msg, trust_data_type="dev.cosignproject.cosign/signature"
                 ) from err
 
-        return process.returncode, stdout.decode("utf-8"), stderr.decode("utf-8")
+        return (process.returncode, stdout.decode("utf-8"), stderr.decode("utf-8"))
 
     def __get_envs(self):
         """

--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -20,7 +20,6 @@ from connaisseur.validators.notaryv1.tuf_role import TUFRole
 
 
 class Notary:
-
     name: str
     host: str
     root_keys: list

--- a/connaisseur/validators/notaryv1/notaryv1_validator.py
+++ b/connaisseur/validators/notaryv1/notaryv1_validator.py
@@ -19,15 +19,10 @@ from connaisseur.validators.notaryv1.tuf_role import TUFRole
 
 
 class NotaryV1Validator(ValidatorInterface):
-
     name: str
     notary: Notary
 
-    def __init__(
-        self,
-        name: str,
-        **kwargs,
-    ):
+    def __init__(self, name: str, **kwargs):
         super().__init__(name, **kwargs)
         self.notary = Notary(name, **kwargs)
 

--- a/connaisseur/validators/static/static_validator.py
+++ b/connaisseur/validators/static/static_validator.py
@@ -4,7 +4,6 @@ from connaisseur.validators.interface import ValidatorInterface
 
 
 class StaticValidator(ValidatorInterface):
-
     name: str
     approve: bool
 

--- a/scripts/changelogger.py
+++ b/scripts/changelogger.py
@@ -16,7 +16,6 @@ bo = "BODY:%b"
 
 
 class Commit:
-
     hash_: str
     subject_: str
     categories_: list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,6 @@ def get_cosign_err_msg(path):
 
 @pytest.fixture
 def m_request(monkeypatch):
-
     monkeypatch.setattr(requests, "get", mock_get_request)
     monkeypatch.setattr(requests, "post", mock_post_request)
     monkeypatch.setattr(connaisseur.kube_api, "__get_token", kube_token)

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -160,12 +160,7 @@ def test_alert_config_init(
     ],
 )
 def test_alerting_required(
-    m_alerting,
-    m_ad_schema_path,
-    alerting_path,
-    admission_request,
-    event_category,
-    out,
+    m_alerting, m_ad_schema_path, alerting_path, admission_request, event_category, out
 ):
     alert.AlertingConfiguration._AlertingConfiguration__PATH = alerting_path
     assert alert.AlertingConfiguration().alerting_required(event_category) is out
@@ -275,20 +270,8 @@ def test_alert_init(
             },
             fix.no_exc(),
         ),
-        (
-            opsgenie_receiver_config,
-            "",
-            401,
-            {},
-            fix.no_exc(),
-        ),
-        (
-            opsgenie_receiver_config_throw,
-            "",
-            401,
-            {},
-            pytest.raises(AlertSendingError),
-        ),
+        (opsgenie_receiver_config, "", 401, {}, fix.no_exc()),
+        (opsgenie_receiver_config_throw, "", 401, {}, pytest.raises(AlertSendingError)),
     ],
 )
 def test_alert_send_alert(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,14 +26,8 @@ static = vals.static.static_validator.StaticValidator
 cosign = vals.cosign.cosign_validator.CosignValidator
 static_config = {
     "validators": [
-        {
-            "name": "default",
-            "type": nv1,
-        },
-        {
-            "name": "harbor",
-            "type": nv1,
-        },
+        {"name": "default", "type": nv1},
+        {"name": "harbor", "type": nv1},
         {"name": "allow", "type": static},
         {"name": "deny", "type": static},
         {"name": "cosign-example", "type": cosign},

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -96,11 +96,7 @@ def test_mutate(
 
 
 def test_mutate_calls_send_alert_for_invalid_admission_request(
-    monkeypatch,
-    adm_req_samples,
-    m_request,
-    m_trust_data,
-    m_alerting_without_send,
+    monkeypatch, adm_req_samples, m_request, m_trust_data, m_alerting_without_send
 ):
     with aioresponses() as aio:
         aio.get(re.compile(r".*"), callback=fix.async_callback, repeat=True)
@@ -248,14 +244,7 @@ async def test_admit(
         ),
     ],
 )
-def test_error_handler(
-    mocker,
-    m_ad_schema_path,
-    m_alerting,
-    function,
-    err,
-):
-
+def test_error_handler(mocker, m_ad_schema_path, m_alerting, function, err):
     mocker.patch("connaisseur.flask_application.__admit", return_value=True)
     mock_function = mocker.patch(**function)
     with pytest.fa.APP.test_request_context():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,11 +23,7 @@ def test_safe_path_func(path, exception):
 admission_review_plain = {
     "apiVersion": "admission.k8s.io/v1",
     "kind": "AdmissionReview",
-    "response": {
-        "uid": 1,
-        "allowed": True,
-        "status": {"code": 202},
-    },
+    "response": {"uid": 1, "allowed": True, "status": {"code": 202}},
 }
 admission_review_msg = {
     "apiVersion": "admission.k8s.io/v1",
@@ -106,13 +102,7 @@ admission_review_msg_patch = {
 def test_get_admission_review(monkeypatch, uid, allowed, patch, msg, dm, review):
     monkeypatch.setenv("KUBE_VERSION", "v1.20.0")
     assert (
-        ut.get_admission_review(
-            uid,
-            allowed,
-            patch=patch,
-            msg=msg,
-            detection_mode=dm,
-        )
+        ut.get_admission_review(uid, allowed, patch=patch, msg=msg, detection_mode=dm)
         == review
     )
 

--- a/tests/test_workload_object.py
+++ b/tests/test_workload_object.py
@@ -103,7 +103,7 @@ def test_k8s_object_init(adm_req_sample_objects, index, exception):
                     "securesystemsengineering/charlie-image@sha256"
                     ":91ac9b26df583762234c1cdb2fc930364754ccc59bc7"
                     "52a2bfe298d2ea68f9ff"
-                ),
+                )
             },
             fix.no_exc(),
         ),
@@ -133,10 +133,7 @@ def test_k8s_object_parent_containers(
                 )
             },
         ),
-        (
-            2,
-            {("containers", 0): Image("securesystemsengineering/sample-san-sama:hai")},
-        ),
+        (2, {("containers", 0): Image("securesystemsengineering/sample-san-sama:hai")}),
         (3, {("containers", 0): Image("busybox")}),
         (
             5,

--- a/tests/validators/cosign/test_cosign_validator.py
+++ b/tests/validators/cosign/test_cosign_validator.py
@@ -25,22 +25,14 @@ static_cosigns = [
         "name": "cosign1",
         "type": "cosign",
         "trust_roots": [
-            {
-                "name": "default",
-                "key": example_key,
-            },
+            {"name": "default", "key": example_key},
             {"name": "test", "key": example_key2},
         ],
     },
     {
         "name": "cosign2",
         "type": "cosign",
-        "trust_roots": [
-            {
-                "name": "test",
-                "key": "...",
-            },
-        ],
+        "trust_roots": [{"name": "test", "key": "..."}],
         "auth": {"k8s_keychain": True},
         "host": "https://rekor.instance.com",
     },
@@ -65,10 +57,7 @@ static_cosigns = [
         "name": "cosign1",
         "type": "cosign",
         "trust_roots": [
-            {
-                "name": "test1",
-                "key": example_key,
-            },
+            {"name": "test1", "key": example_key},
             {"name": "test2", "key": example_key2},
             {"name": "test3", "key": example_key2},
         ],
@@ -77,12 +66,7 @@ static_cosigns = [
         "name": "cosign1",
         "type": "cosign",
         "host": "rekor.sigstore.dev",
-        "trust_roots": [
-            {
-                "name": "default",
-                "key": example_key,
-            }
-        ],
+        "trust_roots": [{"name": "default", "key": example_key}],
     },
 ]
 
@@ -177,22 +161,8 @@ def test_init(index: int, kchain: bool, host: str):
 @pytest.mark.parametrize(
     "index, key_name, required, threshold, key, exception",
     [
-        (
-            0,
-            None,
-            [],
-            1,
-            gen_vals(static_cosigns[0], [0]),
-            fix.no_exc(),
-        ),
-        (
-            0,
-            "test",
-            [],
-            1,
-            gen_vals(static_cosigns[0], [1]),
-            fix.no_exc(),
-        ),
+        (0, None, [], 1, gen_vals(static_cosigns[0], [0]), fix.no_exc()),
+        (0, "test", [], 1, gen_vals(static_cosigns[0], [1]), fix.no_exc()),
         (
             0,
             "non_existing",
@@ -446,10 +416,7 @@ def test_get_cosign_validated_digests(
         (
             "testimage:v1",
             "k8s://example_ns/example_key",
-            {
-                "option_kword": "--key",
-                "inline_tr": "k8s://example_ns/example_key",
-            },
+            {"option_kword": "--key", "inline_tr": "k8s://example_ns/example_key"},
             fix.no_exc(),
         ),
         (
@@ -525,19 +492,13 @@ def test_validate_using_key(fake_process, image, key, process_input, exception):
         ),
         (
             "testimage:v1",
-            {
-                "option_kword": "--key",
-                "inline_tr": "k8s://connaisseur/test_key",
-            },
+            {"option_kword": "--key", "inline_tr": "k8s://connaisseur/test_key"},
             False,
             None,
         ),
         (
             "testimage:v1",
-            {
-                "option_kword": "--key",
-                "inline_tr": "k8s://connaisseur/test_key",
-            },
+            {"option_kword": "--key", "inline_tr": "k8s://connaisseur/test_key"},
             False,
             "https://rekor.sigstore.dev",
         ),
@@ -586,12 +547,7 @@ def test_invoke_cosign(fake_process, image, process_input, k8s_keychain, host):
     )
 
 
-@pytest.mark.parametrize(
-    "image",
-    [
-        "testimage:v1",
-    ],
-)
+@pytest.mark.parametrize("image", ["testimage:v1"])
 def test_invoke_cosign_timeout_expired(
     mocker, mock_add_kill_fake_process, fake_process, image
 ):
@@ -629,13 +585,7 @@ def test_invoke_cosign_timeout_expired(
     assert "Cosign timed out." in str(err.value)
 
 
-@pytest.mark.parametrize(
-    "index, COSIGN_EXPERIMENTAL",
-    [
-        (0, 0),
-        (5, 1),
-    ],
-)
+@pytest.mark.parametrize("index, COSIGN_EXPERIMENTAL", [(0, 0), (5, 1)])
 def test_get_envs(monkeypatch, index, COSIGN_EXPERIMENTAL):
     env = co.CosignValidator(**static_cosigns[index])._CosignValidator__get_envs()
     assert env["DOCKER_CONFIG"] == "/app/connaisseur-config/cosign1/.docker/"

--- a/tests/validators/notaryv1/test_keystore.py
+++ b/tests/validators/notaryv1/test_keystore.py
@@ -19,19 +19,19 @@ pub_root_keys = {
         (
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErIGdt5pelfWOSjmY7k+/TypV0IFF"
             "9XLA+K4swhclLJb79cLoeBBDqkkUrkfhN5gxRnA//wA3amL4WXkaGsb9zQ=="
-        ),
+        )
     ),
     "7dbacd611d5933ca3f0fad581ed233881c501229343613f63f2d4b5771ee4299": TrustRoot(
         (
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzRo/rFtBEAJLvEFU7xem34GpEsw"
             "xsw6nW9YiBqbAcba6LWZuem7slTp+List+NKAVK3EzJCjUixooO5ss4Erug=="
-        ),
+        )
     ),
     "f1997e14be3d33c5677282b6a73060d8124f4020f464644e27ab76f703eb6f7e": TrustRoot(
         (
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMza1L1+e8vfZ1q7+GA5E0st13g7j"
             "WR7fdQSsxkdrpJ6IkUq9D6f9BUopD83YvLBMEMy20MBvsICJnXMu8IZlYA=="
-        ),
+        )
     ),
 }
 
@@ -40,13 +40,13 @@ target_keys = {
         (
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEchQNiJJt4PTaEeAzaztL+TQZqTa"
             "0iM0YSf+w0LjSElobVsYgnqIbCWe6pGX3UvcCngNw7N4uGkdVNVMS2Tslg=="
-        ),
+        )
     ),
     "70aa109003a93131c63499c70dcfc8db3ba33ca81bdd1abcd52c067a8acc0492": TrustRoot(
         (
             "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0xl8F5nwIV3IAru1Pf85WCo4cfT"
             "OQ91jhxVaQ3xHMeW430q7R4H/tJmAXUZBe+nOTX8pgtmrLpT+Hu/H7pUhw=="
-        ),
+        )
     ),
 }
 
@@ -58,9 +58,7 @@ snapshot_hashes = {
     "targets/releases": ("pNjHgtwOrSZB5l0bzHZt9u3dUdFpKsPBhWPiVrIMm88=", 712),
 }
 
-timestamp_hashes = {
-    "snapshot": ("cNXm5R+rJsc3WNQVH8M1G/cTwkO1doq5n8fQmYpQcfQ=", 1286),
-}
+timestamp_hashes = {"snapshot": ("cNXm5R+rJsc3WNQVH8M1G/cTwkO1doq5n8fQmYpQcfQ=", 1286)}
 
 
 @pytest.mark.parametrize(

--- a/tests/validators/notaryv1/test_notary.py
+++ b/tests/validators/notaryv1/test_notary.py
@@ -67,13 +67,7 @@ static_notaries = [
 ]
 
 
-@pytest.mark.parametrize(
-    "index, exception",
-    [
-        (0, fix.no_exc()),
-        (1, fix.no_exc()),
-    ],
-)
+@pytest.mark.parametrize("index, exception", [(0, fix.no_exc()), (1, fix.no_exc())])
 def test_notary(sample_notaries, index, exception):
     with exception:
         no = notary.Notary(**sample_notaries[index])
@@ -152,14 +146,7 @@ def test_healthy(sample_notaries, m_request, index, host, health):
     ],
 )
 async def test_get_trust_data(
-    sample_notaries,
-    m_request,
-    m_trust_data,
-    index,
-    image,
-    role,
-    output,
-    exception,
+    sample_notaries, m_request, m_trust_data, index, image, role, output, exception
 ):
     with exception:
         with aioresponses() as aio:

--- a/tests/validators/notaryv1/test_notaryv1_validator.py
+++ b/tests/validators/notaryv1/test_notaryv1_validator.py
@@ -407,12 +407,7 @@ def test_search_image_targets_for_digest(sample_nv1, image: str, digest: str):
     ],
 )
 async def test_update_with_delegation_trust_data(
-    m_request,
-    m_trust_data,
-    m_expiry,
-    alice_key_store,
-    sample_nv1,
-    delegations,
+    m_request, m_trust_data, m_expiry, alice_key_store, sample_nv1, delegations
 ):
     assert (
         await sample_nv1._NotaryV1Validator__update_with_delegation_trust_data(

--- a/tests/validators/notaryv1/test_trust_data.py
+++ b/tests/validators/notaryv1/test_trust_data.py
@@ -301,12 +301,7 @@ def test_validate_signature(
             ),
             fix.no_exc(),
         ),
-        (
-            "",
-            "",
-            TrustRoot("mail@example.com"),
-            pytest.raises(exc.WrongKeyError),
-        ),
+        ("", "", TrustRoot("mail@example.com"), pytest.raises(exc.WrongKeyError)),
     ],
 )
 def test_validate_signature_with_key(
@@ -446,10 +441,7 @@ def test_get_hashes(m_trust_data, data: dict, role: str, hashes: dict):
 
 @pytest.mark.parametrize(
     "data, out",
-    [
-        (fix.get_td("sample_targets"), True),
-        (fix.get_td("sample2_targets"), False),
-    ],
+    [(fix.get_td("sample_targets"), True), (fix.get_td("sample2_targets"), False)],
 )
 def test_has_delegation(m_trust_data, data: dict, out: bool):
     trust_data_ = td.TrustData(data, "targets")
@@ -476,10 +468,7 @@ def test_get_delegations(m_trust_data, data: dict, out: list):
     [
         (fix.get_td("sample_targets"), []),
         (fix.get_td("sample2_targets"), ["hai"]),
-        (
-            fix.get_td("sample3_targets"),
-            ["v1.0.9", "v1.0.9-slim-fat_image", "v382"],
-        ),
+        (fix.get_td("sample3_targets"), ["v1.0.9", "v1.0.9-slim-fat_image", "v382"]),
     ],
 )
 def test_get_tags(m_trust_data, data: dict, out: list):

--- a/tests/validators/static/test_static_validator.py
+++ b/tests/validators/static/test_static_validator.py
@@ -17,14 +17,7 @@ def test_init(name, approve):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "approve, out, exception",
-    [
-        (True, None, fix.no_exc()),
-        (
-            False,
-            None,
-            pytest.raises(exc.ValidationError),
-        ),
-    ],
+    [(True, None, fix.no_exc()), (False, None, pytest.raises(exc.ValidationError))],
 )
 async def test_validate(approve, out, exception):
     with exception:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes no issue

## Description

- ignore trivy config rules for secrets
- switch all trivy scans to aquasecurity gh action
- fix black

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

