### PR TITLE
Fix: Repair script for getting root key

### DIFF
--- a/scripts/get_root_key.py
+++ b/scripts/get_root_key.py
@@ -2,6 +2,8 @@ import argparse
 import asyncio
 import base64
 
+import aiohttp
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
@@ -13,7 +15,8 @@ from connaisseur.validators.notaryv1.tuf_role import TUFRole
 
 async def get_pub_root_key(host: str, image: Image):
     notary = Notary("no", host, ["not_empty"])
-    root_td = await notary.get_trust_data(image, TUFRole("root"))
+    async with (aiohttp.ClientSession()) as session:
+        root_td = await notary.get_trust_data(session, image, TUFRole("root"))
 
     root_key_id = root_td.signatures[0].get("keyid")
     root_cert_base64 = (


### PR DESCRIPTION
## Description

The root key script was broken with https://github.com/sse-secure-systems/connaisseur/pull/873 due to a new argument added to an internal function, which the root key script uses. This commit adds that missing argument to the call inside the root key script

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

