### PR TITLE
Fix release docs

### DIFF
--- a/.github/actions/context/action.yaml
+++ b/.github/actions/context/action.yaml
@@ -101,6 +101,8 @@ runs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ steps.get_context.outputs.BUILD_REGISTRY }}/${{ steps.get_context.outputs.BUILD_REPO }}
+        flavor: |
+          latest=false
     - name: Show context
       id: show_context
       run: |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,7 +56,7 @@ If not already (you can check with `docker trust inspect securesystemsengineerin
 ## Merge PR
 
 Run `git checkout master` to switch to the `master` branch and then run `git merge develop` to merge `develop` in.
-Then run `git push` and `git push --tags` to publish all changes and the new tag.
+Then run `git push origin master --tags` to publish all changes and the new tag.
 
 ## Create release page
 


### PR DESCRIPTION
This commit ammends the release documentation to allow publishing both the master branch and the release tag at the same time.