### PR TITLE
Only deploy ConfigMaps and Secrets if needed

### DIFF
--- a/connaisseur/config.py
+++ b/connaisseur/config.py
@@ -32,7 +32,7 @@ class Config:
         Read a config file, validate its contents and then create Validator objects,
         storing them.
 
-        Raise `NotFoundException` if the configuration file is not found.
+        Raise `FileNotFoundError` or `NotFoundException` if the configuration file is not found.
 
         Raise `InvalidFormatException` if the configuration file has an invalid format.
         """
@@ -43,8 +43,11 @@ class Config:
             msg = "Error loading connaisseur config file."
             raise NotFoundException(message=msg)
 
-        with open(self.__SECRETS_PATH, "r", encoding="utf-8") as secrets_configfile:
-            secrets_config_content = yaml.safe_load(secrets_configfile)
+        try:
+            with open(self.__SECRETS_PATH, "r", encoding="utf-8") as secrets_configfile:
+                secrets_config_content = yaml.safe_load(secrets_configfile)
+        except FileNotFoundError:  # If empty, secrets config doesn't produce a resource
+            secrets_config_content = {}
 
         config = self.__merge_configs(config_content, secrets_config_content)
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.6.0
-appVersion: 2.8.0
+version: 1.6.1
+appVersion: 2.8.1
 keywords:
   - container image
   - signature

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -71,6 +71,18 @@ Extract Kubernetes Minor Version.
 {{- end -}}
 
 
+{{- define "hasConfigSecrets" -}}
+{{- range .Values.validators -}}
+    {{- if and (and (eq .type "notaryv1") (hasKey . "auth") not (hasKey . "auth.secret_name" )) -}}
+        1
+    {{- end -}}
+    {{- if and (eq .type "cosign") (hasKey . "cert") -}}
+        1
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
 {{- define "external-secrets-vol" -}}
 {{- $external_secret := dict -}}
 {{- range .Values.validators -}}
@@ -172,7 +184,7 @@ Extract Kubernetes Minor Version.
 
 
 {{- define "hasCosignCerts" -}}  
-{{- range .Values.validators     -}}
+{{- range .Values.validators -}}
     {{- if and (eq .type "cosign") (hasKey . "cert") -}}
         1
     {{- end -}}
@@ -181,7 +193,7 @@ Extract Kubernetes Minor Version.
 
 
 {{- define "getCosignCerts" -}}
-{{- range .Values.validators     -}}
+{{- range .Values.validators -}}
     {{- if and (eq .type "cosign") (hasKey . "cert") }}
     {{ .name }}.crt: {{ .cert | b64enc -}}
     {{- end -}}

--- a/helm/templates/alertconfig.yaml
+++ b/helm/templates/alertconfig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alerting}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -29,3 +30,4 @@ stringData:
   alertconfig.json: |
     {{ mustToJson .Values.alerting | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/helm/templates/config-secrets.yaml
+++ b/helm/templates/config-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if (include "hasConfigSecrets" .) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,7 @@ type: Opaque
 data:
   config-secrets.yaml: {{ include "config-secrets" . | b64enc }}
 ---
+{{- end -}}
 {{- if (include "hasCosignCerts" .) -}}
 apiVersion: v1
 kind: Secret

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -63,10 +63,12 @@ spec:
               mountPath: /app/connaisseur-config/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{- if (include "hasConfigSecrets" .) -}}
             - name: {{ .Chart.Name }}-config-secrets
               mountPath: /app/connaisseur-config/config-secrets.yaml
               subPath: config-secrets.yaml
               readOnly: true
+            {{- end }}
             - name: {{ .Chart.Name }}-config-sigstore
               mountPath: /app/.sigstore
               readOnly: false
@@ -119,9 +121,11 @@ spec:
         - name: {{ .Chart.Name }}-config
           configMap:
             name: {{ .Chart.Name }}-config
+        {{- if (include "hasConfigSecrets" .) -}}
         - name: {{ .Chart.Name }}-config-secrets
           secret:
             secretName: {{ .Chart.Name }}-config-secrets
+        {{- end }}
         - name: {{ .Chart.Name }}-config-sigstore
           emptyDir: {}
         {{ include "external-secrets-vol" . | nindent 8}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -51,12 +51,14 @@ spec:
             - name: {{ .Chart.Name }}-certs
               mountPath: /app/certs
               readOnly: true
+            {{- if .Values.alerting}}
             - name: {{ .Chart.Name }}-alert-templates
               mountPath: "/app/config/templates"
               readOnly: true
             - name: {{ .Chart.Name }}-alertconfig
               mountPath: "/app/config"
               readOnly: true
+            {{- end }}
             - name: {{ .Chart.Name }}-config
               mountPath: /app/connaisseur-config/config.yaml
               subPath: config.yaml
@@ -106,12 +108,14 @@ spec:
         - name: {{ .Chart.Name }}-certs
           secret:
             secretName: {{ .Chart.Name }}-tls
+        {{- if .Values.alerting}}
         - name: {{ .Chart.Name }}-alertconfig
           secret:
             secretName: {{ .Chart.Name }}-alertconfig
         - name: {{ .Chart.Name }}-alert-templates
           configMap:
             name: {{ .Chart.Name }}-alert-templates
+        {{- end }}
         - name: {{ .Chart.Name }}-config
           configMap:
             name: {{ .Chart.Name }}-config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: docker.io/securesystemsengineering/connaisseur:v2.8.0
+  image: docker.io/securesystemsengineering/connaisseur:v2.8.1
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -287,7 +287,7 @@ make_upgrade() {
 
 helm_upgrade_namespace() { # NS
 	echo -n 'Upgrading Connaisseur...'
-	helm upgrade connaisseur helm -n ${1} --wait >/dev/null || {
+	helm upgrade connaisseur helm -n ${1} --values "helm/values.yaml" --wait >/dev/null || {
 		echo -e ${FAILED}
 		exit 1
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Only deploy alerting ConfigMap and Secret if defined

## Description
Previously, we deployed some resources even if they weren't used in the deployment. This reduces the number of instances where that happens

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

