### PR TITLE
build: Default to appVersion

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@ Fixes #
 - [ ] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
 - [ ] Added tests (if necessary)
 - [ ] Extended README/Documentation (if necessary)
-- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)
+- [ ] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -112,7 +112,7 @@ runs:
         path: build/cosign.pub
     - name: Show build and signature information
       run: |
-        CONFIGURE="yq '. *+ load(\"tests/integration/var-img.yaml\")' tests/integration/ghcr-values.yaml > ghcr.yaml &&\n\t IMAGE=\"${{ inputs.image_registry }}/${{ inputs.image_repo }}:${{ inputs.image_tag }}\" IMAGEPULLSECRET=\"<ImagePullSecret name>\" envsubst < ghcr.yaml > update &&\n\t yq '. *+ load(\"update\")' -i helm/values.yaml &&\n\t rm ghcr.yaml update"
+        CONFIGURE="yq '. *+ load(\"tests/integration/var-img.yaml\")' tests/integration/ghcr-values.yaml > ghcr.yaml &&\n\t IMAGE=\"${{ inputs.image_registry }}/${{ inputs.image_repo }}\" TAG=\"${{ inputs.image_tag }}\" IMAGEPULLSECRET=\"<ImagePullSecret name>\" envsubst < ghcr.yaml > update &&\n\t yq '. *+ load(\"update\")' -i helm/values.yaml &&\n\t rm ghcr.yaml update"
         CONFIGURE=$(printf -- "${CONFIGURE}")
         PUBLIC_KEY="${{ steps.verify.outputs.public_key }}"
         PUBLIC_KEY="$(printf -- "${PUBLIC_KEY//'<br>'/'\n'}")"

--- a/.github/actions/context/action.yaml
+++ b/.github/actions/context/action.yaml
@@ -54,11 +54,16 @@ runs:
       uses: mikefarah/yq@47f4f8c7939f887e851b35f14def6741b8f5396e # v4.31.2
       with:
         cmd: yq '.version' helm/Chart.yaml
-    - name: Get original image
-      id: get_original_image
+    - name: Get app version
+      id: get_app_version
       uses: mikefarah/yq@47f4f8c7939f887e851b35f14def6741b8f5396e # v4.31.2
       with:
-        cmd: yq '.deployment.image' helm/values.yaml
+        cmd: yq '.appVersion' helm/Chart.yaml
+    - name: Get original image
+      id: get_original_image_repository
+      uses: mikefarah/yq@47f4f8c7939f887e851b35f14def6741b8f5396e # v4.31.2
+      with:
+        cmd: yq '.deployment.image.repository' helm/values.yaml
     - name: Get context
       id: get_context
       run: |
@@ -66,10 +71,10 @@ runs:
         echo "github.ref is: ${GHREF}"
         CHART_VERSION=${{ steps.get_chart_version.outputs.result }}
         COSIGN_VERSION=$(grep -Eo '^COSIGN_VERSION = .*' Makefile | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-        ORIGINAL_IMAGE=${{ steps.get_original_image.outputs.result }}
-        ORIGINAL_REGISTRY=$(echo "${ORIGINAL_IMAGE}" | cut -d "/" -f 1)
-        ORIGINAL_REPO=$(echo "${ORIGINAL_IMAGE}" | cut -d "/" -f 2- | cut -d ":" -f 1)
-        ORIGINAL_TAG=$(echo "${ORIGINAL_IMAGE}" | cut -d "/" -f 2- | cut -d ':' -f 2)
+        CONFIGURED_IMAGE_REPO=${{ steps.get_original_image_repository.outputs.result }}
+        ORIGINAL_REGISTRY=$(echo "${CONFIGURED_IMAGE_REPO}" | cut -d "/" -f 1)
+        ORIGINAL_REPO=$(echo "${CONFIGURED_IMAGE_REPO}" | cut -d "/" -f 2- | cut -d ":" -f 1)
+        ORIGINAL_TAG=v${{ steps.get_app_version.outputs.result }}
         BUILD_REGISTRY=${{ inputs.build_registry }}
         BUILD_REPO=${{ inputs.build_repo }}
         if [[ "${GHREF}" != "refs/heads/master" &&
@@ -84,7 +89,7 @@ runs:
         echo ORIGINAL_REGISTRY=${ORIGINAL_REGISTRY} >> ${GITHUB_OUTPUT}
         echo ORIGINAL_REPO=${ORIGINAL_REPO} >> ${GITHUB_OUTPUT}
         echo ORIGINAL_TAG=${ORIGINAL_TAG} >> ${GITHUB_OUTPUT}
-        echo ORIGINAL_IMAGE=${ORIGINAL_IMAGE} >> ${GITHUB_OUTPUT}
+        echo ORIGINAL_IMAGE=${CONFIGURED_IMAGE_REPO}:${ORIGINAL_TAG} >> ${GITHUB_OUTPUT}
         echo BUILD_REGISTRY=${BUILD_REGISTRY} >> ${GITHUB_OUTPUT}
         echo BUILD_REPO=${BUILD_REPO} >> ${GITHUB_OUTPUT}
       shell: bash

--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -90,9 +90,11 @@ jobs:
           echo "::group::values.yaml"
           yq e '.' helm/values.yaml
           echo "::endgroup::"
-      - name: Display k8s logs if integration test failed
+      - name: Display k8s state and logs if integration test failed
         if: failure()
         run: |
+          kubectl describe deployments.apps -n connaisseur -lapp.kubernetes.io/name=connaisseur
+          kubectl describe pods -n connaisseur -lapp.kubernetes.io/name=connaisseur
           kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
 
   k8s-versions:
@@ -134,9 +136,11 @@ jobs:
       - name: Run pre-config and workload integration tests
         run: |
           bash tests/integration/integration-test.sh "pre-and-workload"
-      - name: Display k8s logs if integration test failed
+      - name: Display k8s state and logs if integration test failed
         if: failure()
         run: |
+          kubectl describe deployments.apps -n connaisseur -lapp.kubernetes.io/name=connaisseur
+          kubectl describe pods -n connaisseur -lapp.kubernetes.io/name=connaisseur
           kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
 
   k8s-legacy-versions:
@@ -177,7 +181,9 @@ jobs:
       - name: Run pre-config and workload integration tests
         run: |
           bash tests/integration/integration-test.sh "pre-and-workload"
-      - name: Display k8s logs if integration test failed
+      - name: Display k8s state and logs if integration test failed
         if: failure()
         run: |
+          kubectl describe deployments.apps -n connaisseur -lapp.kubernetes.io/name=connaisseur
+          kubectl describe pods -n connaisseur -lapp.kubernetes.io/name=connaisseur
           kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true

--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -9,8 +9,11 @@ on:
       repo_owner:
         description: 'Name of repository owner, e.g. "inputs.repo_owner" for ghcr.io'
         type: string
-      build_image:
-        description: "Workflow build image used for testing, i.e. registry + repository + tag"
+      build_image_repository:
+        description: "Workflow build image used for testing, excluding the tag i.e. registry + repository"
+        type: string
+      build_tag:
+        description: "Tag of build image used for testing"
         type: string
       skip_integration_tests:
         description: "Want to skip running certain integration tests 'none', 'non-required', 'all'?"
@@ -31,7 +34,8 @@ jobs:
     permissions:
       packages: read
     env:
-      IMAGE: ${{ inputs.build_image }}
+      IMAGE: ${{ inputs.build_image_repository }}
+      TAG: ${{ inputs.build_tag }}
       COSIGN_PUBLIC_KEY: ${{ inputs.cosign_public_key }}
     strategy:
       fail-fast: false
@@ -96,7 +100,8 @@ jobs:
     permissions:
       packages: read
     env:
-      IMAGE: ${{ inputs.build_image }}
+      IMAGE: ${{ inputs.build_image_repository }}
+      TAG: ${{ inputs.build_tag }}
       COSIGN_PUBLIC_KEY: ${{ inputs.cosign_public_key }}
     strategy:
       fail-fast: false
@@ -141,7 +146,8 @@ jobs:
     permissions:
       packages: read
     env:
-      IMAGE: ${{ inputs.build_image }}
+      IMAGE: ${{ inputs.build_image_repository }}
+      TAG: ${{ inputs.build_tag }}
       COSIGN_PUBLIC_KEY: ${{ inputs.cosign_public_key }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+      - connaisseur-3 # for testing
 
 permissions: {}
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -92,6 +92,7 @@ jobs:
     with:
       build_registry: ${{ needs.build.outputs.build_registry }}
       repo_owner: ${{ github.repository_owner }}
-      build_image: ${{ needs.build.outputs.build_image }}
+      build_image_repository: ${{ needs.build.outputs.build_registry }}/${{ needs.build.outputs.build_repo }}
+      build_tag: ${{ needs.build.outputs.build_tag }}
       skip_integration_tests: ${{ needs.conditionals.outputs.skip_integration_tests }}
       cosign_public_key: ${{ needs.build.outputs.cosign_public_key }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -53,6 +53,7 @@ jobs:
     with:
       build_registry: ${{ needs.build.outputs.build_registry }}
       repo_owner: ${{ github.repository_owner }}
-      build_image: ${{ needs.build.outputs.build_image }}
+      build_image_repository: ${{ needs.build.outputs.build_registry }}/${{ needs.build.outputs.build_repo }}
+      build_tag: ${{ needs.build.outputs.build_tag }}
       skip_integration_tests: ${{ needs.conditionals.outputs.skip_integration_tests }}
       cosign_public_key: ${{ needs.build.outputs.cosign_public_key }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,8 @@ jobs:
     with:
       build_registry: ${{ needs.build.outputs.build_registry }}
       repo_owner: ${{ github.repository_owner }}
-      build_image: ${{ needs.build.outputs.original_image }}
+      build_image_repository: ${{ needs.build.outputs.build_registry }}/${{ needs.build.outputs.build_repo }}
+      build_tag: ${{ needs.build.outputs.build_tag }}
       skip_integration_tests: ${{ needs.conditionals.outputs.skip_integration_tests }}
       cosign_public_key: ${{ needs.build.outputs.cosign_public_key }}
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAMESPACE = connaisseur
-IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
+IMAGE_REPOSITORY := $(shell yq e '.deployment.image.repository' helm/values.yaml)
+VERSION := $(shell yq e '.appVersion' helm/Chart.yaml)
 COSIGN_VERSION = 1.13.1
 
 .PHONY: all docker install uninstall upgrade annihilate
@@ -7,7 +8,7 @@ COSIGN_VERSION = 1.13.1
 all: docker install
 
 docker:
-	docker build --pull --build-arg COSIGN_VERSION=$(COSIGN_VERSION) -f docker/Dockerfile -t $(IMAGE) .
+	docker build --pull --build-arg COSIGN_VERSION=$(COSIGN_VERSION) -f docker/Dockerfile -t $(IMAGE_REPOSITORY):v$(VERSION) .
 
 install:
 	#

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,8 +17,7 @@ Before starting the release, make sure everything is ready and in order:
 
 - See that all tests are running smoothly.
 - Check that documentation changes show up correctly [here](https://sse-secure-systems.github.io/connaisseur/develop/).
-- Make sure the Connaisseur version is incremented correctly according to the changes.
-- Make sure Connaisseur version in `helm/values.yaml` is matched to the appVersion in `helm/Chart.yaml` and the (chart) version in `helm/Chart.yaml` is increased according to semantic versioning if Helm templates have been touched.
+- Make sure the Connaisseur appVersion in `helm/Chart.yaml` is incremented correctly according to the changes and the (chart) version is increased according to semantic versioning if Helm templates have been touched.
 - See if the docs announcements should be adjusted [here](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/overrides/main.html).
 - Consider making a [GitHub Discussions *announcement*](https://github.com/sse-secure-systems/connaisseur/discussions).
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 1.6.1
-appVersion: 2.8.1
+version: 2.0.0
+appVersion: 3.0.0
 keywords:
   - container image
   - signature

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.deployment.image }}"
+          image: "{{ .Values.deployment.image.repository }}:{{ default (print "v" .Chart.AppVersion) .Values.deployment.image.tag }}"
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,12 @@
 # configure Connaisseur deployment
 deployment:
   replicasCount: 3
-  image: docker.io/securesystemsengineering/connaisseur:v2.8.1
+  image:
+    repository: docker.io/securesystemsengineering/connaisseur
+    # Running a different version than the version in the Chart.yaml may not work as the
+    # Connaisseur application version depends on the layout of the Helm deployment
+    # Thus, if unset, we default to the appVersion of the Chart.yaml
+    # tag: v1.2.3
   imagePullPolicy: IfNotPresent
   # imagePullSecrets contains an optional list of Kubernetes Secrets, in Connaisseur namespace,
   # that are needed to access the registry containing Connaisseur image.

--- a/tests/integration/ghcr-values.yaml
+++ b/tests/integration/ghcr-values.yaml
@@ -9,5 +9,5 @@ validators:
       secret_name: ${IMAGEPULLSECRET}
 
 policy:
-  - pattern: "${IMAGE}"
+  - pattern: "${IMAGE}:${TAG}"
     validator: connaisseur-ghcr

--- a/tests/integration/var-img.yaml
+++ b/tests/integration/var-img.yaml
@@ -1,4 +1,6 @@
 deployment:
-  image: ${IMAGE}
+  image:
+    repository: ${IMAGE}
+    tag: ${TAG}
   imagePullSecrets:
   - name: ${IMAGEPULLSECRET}


### PR DESCRIPTION
## Description

To get less hassle and generally improve the config, we default to the current Helm appVersion instead of having an additional configuration toggle in the values.yaml. While the toggle exists, it is discouraged and not enabled by default.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

