### PR TITLE
feat: create microsoft teams alert template

### DIFF
--- a/docs/features/alerting.md
+++ b/docs/features/alerting.md
@@ -6,7 +6,7 @@ endpoint that accepts JSON payloads.
 
 ## Supported interfaces
 
-Slack, Opsgenie and Keybase have pre-configured payloads that are ready to use.
+Slack, Opsgenie, Keybase and Microsoft Teams have pre-configured payloads that are ready to use.
 However, you can use the existing payload templates as an example how to model your
 own custom one.
 It is also possible to configure multiple interfaces for receiving
@@ -16,15 +16,15 @@ alerts at the same time.
 
 Currently, Connaisseur supports alerting on either admittance of images, denial of images or both. These event categories can be configured independently of each other under the relevant category (i.e. `admit_request` or `reject_request`):
 
-| Key                                                |  Accepted values                                      | Default           | Required           | Description                                                                                        |
-| -------------------------------------------------- | ----------------------------------------------------  | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------- |
-| `alerting.cluster_identifier`                      | string                                                | `"not specified"` |                    | Cluster identifier used in alert payload to distinguish between alerts from different clusters.     |
-| `alerting.<category>.template`                     | `opsgenie`, `slack`, `keybase`, `ecs-1-12-0` or custom<sup>*</sup>  | -                 | :heavy_check_mark: | File in `helm/alert_payload_templates/` to be used as alert payload template.           |
-| `alerting.<category>.receiver_url`                 | string                                                | -                 | :heavy_check_mark: | URL of alert-receiving endpoint.                                                                    |
-| `alerting.<category>.priority`                     | int                                                   | `3`               |                    | Priority of alert (to enable fitting Connaisseur alerts into alerts from other sources).            |
-| `alerting.<category>.custom_headers`               | list[string]                                          | -                 |                    | Additional headers required by alert-receiving endpoint.                                            |
-| `alerting.<category>.payload_fields`               | subyaml                                               | -                 |                    | Additional (`yaml`) key-value pairs to be appended to alert payload (as `json`). |
-| `alerting.<category>.fail_if_alert_sending_fails`  | bool                                                  | `False`           |                    | Whether to make Connaisseur deny images if the corresponding alert cannot be successfully sent.    |
+| Key                                               | Accepted values                                                               | Default           | Required           | Description                                                                                     |
+|---------------------------------------------------|-------------------------------------------------------------------------------|-------------------|--------------------|-------------------------------------------------------------------------------------------------|
+| `alerting.cluster_identifier`                     | string                                                                        | `"not specified"` |                    | Cluster identifier used in alert payload to distinguish between alerts from different clusters. |
+| `alerting.<category>.template`                    | `opsgenie`, `slack`, `keybase`, `msteams`, `ecs-1-12-0` or custom<sup>*</sup> | -                 | :heavy_check_mark: | File in `helm/alert_payload_templates/` to be used as alert payload template.                   |
+| `alerting.<category>.receiver_url`                | string                                                                        | -                 | :heavy_check_mark: | URL of alert-receiving endpoint.                                                                |
+| `alerting.<category>.priority`                    | int                                                                           | `3`               |                    | Priority of alert (to enable fitting Connaisseur alerts into alerts from other sources).        |
+| `alerting.<category>.custom_headers`              | list[string]                                                                  | -                 |                    | Additional headers required by alert-receiving endpoint.                                        |
+| `alerting.<category>.payload_fields`              | subyaml                                                                       | -                 |                    | Additional (`yaml`) key-value pairs to be appended to alert payload (as `json`).                |
+| `alerting.<category>.fail_if_alert_sending_fails` | bool                                                                          | `False`           |                    | Whether to make Connaisseur deny images if the corresponding alert cannot be successfully sent. |
 
 <sup>*basename of the custom template file in `helm/alerting_payload_templates` without file extension </sup>
 
@@ -32,7 +32,7 @@ _Notes_:
 
 - The value for `template` needs to match an existing file of the pattern
 `helm/alert_payload_templates/<template>.json`; so if you want to use a predefined
-one it needs to be one of `slack`, `keybase`, `opsgenie` or `ecs-1-12-0`.
+one it needs to be one of `slack`, `keybase`, `opsgenie`, `msteams` or `ecs-1-12-0`.
 - For Opsgenie you need to configure an additional
   `["Authorization: GenieKey <Your-Genie-Key>"]` header.
 - For [Elastic Common Schema 1.12.0](https://www.elastic.co/guide/en/ecs/1.12/index.html) output, the `receiver_url` has to be an HTTP/S log ingester, such as [Fluentd HTTP input](https://docs.fluentd.org/input/http) or [Logstash HTTP input](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-http.html). Also `custom_headers` needs to be set to `["Content-Type: application/json"]` for Fluentd HTTP endpoints.
@@ -63,6 +63,7 @@ during runtime into the payload:
 - `alert_message`
 - `priority`
 - `connaisseur_pod_id`
+- `namespace`
 - `cluster`
 - `timestamp`
 - `request_id`

--- a/helm/alert_payload_templates/msteams.json
+++ b/helm/alert_payload_templates/msteams.json
@@ -1,0 +1,42 @@
+{
+  "@type": "MessageCard",
+  "@context": "http://schema.org/extensions",
+  "summary": "{{ alert_message }}",
+  "title": "Connaisseur Alert",
+  "sections": [
+    {
+      "activityTitle": "{{ alert_message }}",
+      "facts": [
+        {
+          "name": "cluster",
+          "value": "{{ cluster }}"
+        },
+        {
+          "name": "namespace",
+          "value": "{{ namespace }}"
+        },
+        {
+          "name": "connaisseur_pod_id",
+          "value": "{{ connaisseur_pod_id }}"
+        },
+        {
+          "name": "request_id",
+          "value": "{{ request_id }}"
+        },
+        {
+          "name": "timestamp",
+          "value": "{{ timestamp }}"
+        },
+        {
+          "name": "images",
+          "value": "{{ images }}"
+        },
+        {
+          "name": "priority",
+          "value": "{{ priority }}"
+        }
+      ],
+      "markdown": true
+    }
+  ]
+}


### PR DESCRIPTION
A Microsoft Teams alert template to allow Connaisseur to generate valid JSON payload that can be sent to a MS teams webhook.

The schema is described in the source below:
- https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL

<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->

## Description

The generated message looks something like that:

<img width="976" alt="image" src="https://github.com/sse-secure-systems/connaisseur/assets/17041950/b91e7248-6cc4-47cc-89db-fb10e058a75f">

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

