### PR TITLE
fix cosign self-signed certificate registry bug

### DIFF
--- a/helm/templates/config-secrets.yaml
+++ b/helm/templates/config-secrets.yaml
@@ -10,7 +10,7 @@ type: Opaque
 data:
   config-secrets.yaml: {{ include "config-secrets" . | b64enc }}
 ---
-{{- end -}}
+{{ end }}
 {{- if (include "hasCosignCerts" .) -}}
 apiVersion: v1
 kind: Secret

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
               mountPath: /app/connaisseur-config/config.yaml
               subPath: config.yaml
               readOnly: true
-            {{- if (include "hasConfigSecrets" .) -}}
+            {{ if (include "hasConfigSecrets" .) -}}
             - name: {{ .Chart.Name }}-config-secrets
               mountPath: /app/connaisseur-config/config-secrets.yaml
               subPath: config-secrets.yaml
@@ -121,7 +121,7 @@ spec:
         - name: {{ .Chart.Name }}-config
           configMap:
             name: {{ .Chart.Name }}-config
-        {{- if (include "hasConfigSecrets" .) -}}
+        {{ if (include "hasConfigSecrets" .) -}}
         - name: {{ .Chart.Name }}-config-secrets
           secret:
             secretName: {{ .Chart.Name }}-config-secrets


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When using cosign and self-signed certificate registry, helm rendering error will appear
error converting YAML to JSON: yaml: line 53: mapping values are not allowed in this context
<!--- Reference respective issue if it exists -->
Fixes #
https://github.com/sse-secure-systems/connaisseur/issues/1114


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

