### PR TITLE
add serviceaccount annotations to allow IRSA in the helm chart

### DIFF
--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -5,3 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceaccount.annotations | nindent 4 }}
+  {{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "helm.labels" . | nindent 4 }}
+  {{- if .Values.serviceaccount.annotations }}
   annotations:
     {{- toYaml .Values.serviceaccount.annotations | nindent 4 }}
   {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -78,6 +78,11 @@ kubernetes:
     type: ClusterIP
     port: 443
 
+  # configure Connaisseur serviceaccount (so you can do IRSA, for example)
+  serviceaccount:
+    annotations:
+      # eks.amazonaws.com/role-arn: arn:aws:iam::XXX:role/myrole
+
   webhook:
     failurePolicy: Fail  # use 'Ignore' to fail open if Connaisseur becomes unavailable
     # Use 'reinvocationPolicy: IfNeeded' to be called again as part of the admission evaluation if the object


### PR DESCRIPTION
## Description

This allows us to add annotations to the serviceaccount in the helm chart, which will allow people to enable IRSA for EKS, which will let things like cosign be able to access ECR or use KMS keys or other activities that require IAM permissions.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

