### PR TITLE
fix: less verbose logging for cosign

### DIFF
--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -134,7 +134,7 @@ class CosignValidator(ValidatorInterface):
             values["digest"] = await self.__get_cosign_validated_digests(image, values)
         except Exception as err:
             values["error"] = err
-            logging.info(err)
+            logging.debug(err)
 
         return {trust_root: values}
 
@@ -147,7 +147,7 @@ class CosignValidator(ValidatorInterface):
         returncode, stdout, stderr = await self.__validate_using_trust_root(
             image, values["trust_root"], values["verify_tlog"]
         )
-        logging.info(
+        logging.debug(
             "COSIGN output of trust root '%s' for image'%s': RETURNCODE: %s; STDOUT: %s; STDERR: %s",
             values["name"],
             str(image),


### PR DESCRIPTION
With the functionality for cosign validators to validate multiple signatures with different keys and meeting certain thresholds, the logging output for these can be confusing. It is expected that certain keys do not match a signature and that an error is logged, even though the overall verification is successfull. To reduce confusion here and to make it clear the verification was actually sucessfull, the error logging was set to debug instead of info.

fixes #977

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)

