### PR TITLE
Make failures visible via metrics in detection mode

### DIFF
--- a/connaisseur/flask_application.py
+++ b/connaisseur/flask_application.py
@@ -56,6 +56,7 @@ def handle_alert_config_error(err):
     labels={
         "allowed": lambda r: metrics_label(r, "allowed"),
         "status_code": lambda r: metrics_label(r, "status_code"),
+        "warnings": lambda r: metrics_label(r, "warnings"),
     },
 )
 def mutate():
@@ -73,6 +74,8 @@ def metrics_label(response, label):
             return json_response["response"]["allowed"]
         elif label == "status_code":
             return json_response["response"]["status"]["code"]
+        elif label == "warnings":
+            return "warnings" in json_response["response"]
     return json_response
 
 

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -70,8 +70,8 @@ http_request_created{method="POST",status="200"} 1.6436681947581613e+09
 # TYPE http_request_exceptions_total counter
 # HELP mutate_requests_total Total number of mutate requests
 # TYPE mutate_requests_total counter
-mutate_requests_total{allowed="False",status_code="403"} 4.0
-mutate_requests_total{allowed="True",status_code="202"} 5.0
+mutate_requests_total{allowed="False",status_code="403",warnings="False"} 4.0
+mutate_requests_total{allowed="True",status_code="202",warnings="False"} 5.0
 # HELP mutate_requests_created Total number of mutate requests
 # TYPE mutate_requests_created gauge
 mutate_requests_created{allowed="False",status_code="403"} 1.643760946491879e+09


### PR DESCRIPTION
When monitoring Connaissuer via the prometheus metrics endpoint, there was previously no way to detect failures when detection mode was turned on, as it changed the status code and 'allowed' field to True (as designed). This change adds a boolean label to the metric that indicates whether warnings are present - and warnings are only present when the operation would have failed but detection mode is on.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

