### PR TITLE
ci: grouping of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       prefix: "update"
     insecure-external-code-execution: "deny"
     target-branch: "develop"
+    groups:
+      pip-packages:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
@@ -15,6 +19,10 @@ updates:
     commit-message:
       prefix: "update"
     target-branch: "develop"
+    groups:
+      docker-packages:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -22,4 +30,8 @@ updates:
     commit-message:
       prefix: "update"
     target-branch: "develop"
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"
 


### PR DESCRIPTION
Groups all dependabot PRs into single one's per package type. [Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

