### PR TITLE
feat: Add pod securityContext to helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.0.0
 keywords:
   - container image

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -106,6 +106,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.kubernetes.deployment.podSecurityContext }}
+      {{- with .Values.kubernetes.deployment.podSecurityContext }}
+      securityContext:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
       volumes:
         - name: {{ .Chart.Name }}-certs
           secret:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,6 +48,7 @@ kubernetes:
       runAsGroup: 20001 # remove when using openshift or OKD 4
       seccompProfile: # remove when using Kubernetes prior v1.19, openshift or OKD 4
         type: RuntimeDefault # remove when using Kubernetes prior v1.19, openshift or OKD 4
+    podSecurityContext: {}
     # PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25
     podSecurityPolicy:
       enabled: false


### PR DESCRIPTION
Fixes #1240

## Description

The current helm chart does not permit to add a pod-level security context, only a container-level security context. With this pull request, the helm chart is extended with an optional pod-level security context.

The change is such that pod-level and container-level security context can be specified separately. Why? Because there are configuration options in the pod-level security context that do not apply to the container-level security context and vice versa (examples are given in the fixed ticket #1240).

The new key in the values.yaml file for the pod-level security context is `podSecurityContext` (to distinguish it from the existing `securityContext`, which applies to the container). Renaming `securityContext` to `containerSecurityContext` to make things more explicit sounds nice, but would be breaking, which is why it is not changed. (But maybe it should be changed? Not sure.)

The default value for the `podSecurityContext` is empty, in which case the generated `Deployment` yaml will not contain a pod-level security context.

I have increased the chart version from 2.0.0 to 2.0.1 with the change -  I a not sure if this is the correct version bump, if not I would be happy about advice.

## Checklist

- [ X] PR is rebased to/aimed at branch `develop`
- [ X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ X] Added tests (if necessary)
- [ X] Extended README/Documentation (if necessary)
- [ X] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

