### PR TITLE
 refactor: Minimize software footprint of Dockerfiles

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,3 +1,3 @@
-FROM python:3.7-alpine
+FROM alpine:3.18@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 RUN echo "while true; do echo 'Hello World of signing ;)'; sleep 3; done" >> hello.sh
 CMD ["sh", "hello.sh"]

--- a/tests/Dockerfile.unsigned
+++ b/tests/Dockerfile.unsigned
@@ -1,3 +1,3 @@
-FROM python:3.7-alpine
+FROM alpine:3.18@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 RUN echo "while true; do echo 'Hello World of untrusted images :('; sleep 3; done" >> hello.sh
 CMD ["sh", "hello.sh"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I noticed that the base image contains too many dependencies for the use cases.

## Description

<!--- Provide a short description of the PR: why? how? -->

I used the alpine image as it contains all necessary dependencies and is far smaller.
1. alpine:3.19 -> 7.45MB
2. python:3.7-alpine -> 46.6MB

## Checklist

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

