### PR TITLE
feat: Add pod securityContext to helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.0.0
 keywords:
   - container image

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -106,6 +106,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.kubernetes.deployment.podSecurityContext }}
+      {{- with .Values.kubernetes.deployment.podSecurityContext }}
+      securityContext:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
       volumes:
         - name: {{ .Chart.Name }}-certs
           secret:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,6 +36,7 @@ kubernetes:
             weight: 100
     #annotations:  # uncomment when using Kubernetes prior v1.19
     #  seccomp.security.alpha.kubernetes.io/pod: runtime/default  # uncomment when using Kubernetes prior v1.19
+    # container wide security context
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -48,6 +49,8 @@ kubernetes:
       runAsGroup: 20001 # remove when using openshift or OKD 4
       seccompProfile: # remove when using Kubernetes prior v1.19, openshift or OKD 4
         type: RuntimeDefault # remove when using Kubernetes prior v1.19, openshift or OKD 4
+    # pod wide security context
+    podSecurityContext: {}
     # PodSecurityPolicy is deprecated as of Kubernetes v1.21, and will be removed in v1.25
     podSecurityPolicy:
       enabled: false


### PR DESCRIPTION
The current helm chart does not permit to add a pod-level security context, only a container-level security context. The helm chart is extended with an optional pod-level security context.

Fix #1240

duplicate of #1242

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

