### PR TITLE
fix: switch to python 3.11

### DIFF
--- a/.github/workflows/.reusable-sast.yml
+++ b/.github/workflows/.reusable-sast.yml
@@ -37,7 +37,7 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     container:
-      image: python:slim
+      image: python:3.11-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/.reusable-unit-test.yml
+++ b/.github/workflows/.reusable-unit-test.yml
@@ -9,7 +9,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     container:
-      image: python:3
+      image: python:3.11
     steps:
       - name: Checkout code
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine as base
+FROM python:3.11-alpine as base
 
 # Build dependencies
 FROM base as builder


### PR DESCRIPTION
Some packages currently do not work with python 3.12, so we explicitly use python 3.11.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

