### PR TITLE
ci: add k8s v1.27 integration test

### DIFF
--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -119,6 +119,7 @@ jobs:
             "v1.24",
             "v1.25",
             "v1.26",
+            "v1.27",
           ]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Extend ci tests

## Description

- add latest k8s version to integration tests

## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)