### PR TITLE
feat: explicitly specify containerPort in helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.1.0
+version: 2.2.0
 appVersion: 3.1.1
 keywords:
   - container image

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kubernetes.deployment.image.repository }}:{{ default (print "v" .Chart.AppVersion) .Values.kubernetes.deployment.image.tag }}"
           imagePullPolicy: {{ .Values.kubernetes.deployment.imagePullPolicy }}
+          ports:
+            - containerPort: 5000
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Fixes #1305

## Description

Currently, the deployment from the connaisseur helm chart does not explicitly specify the containerPort. This is usually not a problem, because the port can still be used, even if it is not explicitly named. 

Explicitly specifying the port has two benefits:
* It documents the available ports for a user  of the chart.
* It enables to configure automatic scraping of metrics by prometheus using a `PodMonitor` from the prometheus operator (which requires the port to be explicitly specified). This helps in working around the issue described in #709, to scrape metrics even when they are provided via https only.

In principle, one could also name the port, but since there is only one exposed port and I did not want to use a generic name like `thePort`, I did not add a port name.

## Checklist

- [ x] PR is rebased to/aimed at branch `develop`
- [ x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ x] Added tests (if necessary)
- [ x] Extended README/Documentation (if necessary)
- [ x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

