### PR TITLE
feat: explicitly specify containerPort in helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.1.0
-appVersion: 3.1.1
+version: 2.2.0
+appVersion: 3.2.0
 keywords:
   - container image
   - signature

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kubernetes.deployment.image.repository }}:{{ default (print "v" .Chart.AppVersion) .Values.kubernetes.deployment.image.tag }}"
           imagePullPolicy: {{ .Values.kubernetes.deployment.imagePullPolicy }}
+          ports:
+            - containerPort: 5000
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Specifying the containerPort, on the one hand, has a documentary purpose, by making explicit which ports are exposed by the container. On the other hand, it permits the usage of other tools that rely on the containerPort, like PodMonitors from the prometheus operator.

Fix #1305

duplicated from #1306 because of pipeline issue with external PRs

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

