### PR TITLE
fix: fix regular integration test

### DIFF
--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -59,7 +59,7 @@ test_cases:
   - id: rstd
     txt: Testing signed image with tag and digest...
     type: deploy
-    ref: securesystemsengineering/testimage:signed@sha256:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7
+    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
     namespace: default
     expected_msg: pod/pod-rstd-${RAND} created
     expected_result: VALID

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -358,7 +358,7 @@ regular_int_test() {
 	echo -n "[edge1] Testing edge case of tag defined in both targets and release json file..."
 	POD=$(kubectl get pods -o name | grep "pod-rs-")
 	DEPLOYED_SHA=$(kubectl get "${POD}" -o yaml | yq e '.spec.containers[0].image' - | sed 's/.*sha256://')
-	if [[ "${DEPLOYED_SHA}" != 'c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7' ]]; then
+	if [[ "${DEPLOYED_SHA}" != 'fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b' ]]; then
 		echo -e "${FAILED}"
 		EXIT="1"
 	else


### PR DESCRIPTION
With #1282 new test images were pushed, thus changing the signed digests. The previous digest was pinned inside the regular integration test. This has been updated.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

