### PR TITLE
Feat: Validate ephemeral containers

### DIFF
--- a/connaisseur/workload_object.py
+++ b/connaisseur/workload_object.py
@@ -99,7 +99,11 @@ class WorkloadObject:
     def containers(self):
         return {
             (container_type, index): Image(container["image"])
-            for container_type in ["containers", "initContainers"]
+            for container_type in [
+                "containers",
+                "initContainers",
+                "ephemeralContainers",
+            ]
             for index, container in enumerate(self.spec.get(container_type, []))
         }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,9 +74,9 @@ black <path-to-repository>/connaisseur
 Changes can also be tested locally.
 We recommend the following approach for running pytest in a container:
 ```
-docker run -it --rm -v <path-to-repository>:/data --entrypoint=ash python:alpine
+docker run -it --rm -v <path-to-repository>:/data --entrypoint=bash python:3.11
 cd data
-YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install -r requirements_dev.txt
+pip3 install -r requirements_dev.txt
 pytest --cov=connaisseur --cov-report=xml tests/
 ```
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-While all known vulnerabilities are listed below and we intent to fix vulnerabilities as soon as we become aware, both, Python and OS packages of the Connaisseur image may become vulnerable over time and we suggest to frequently update to the latest version of Connaisseur or rebuilding the image from source yourself.
+While all known vulnerabilities in the Connaisseur application are listed below and we intent to fix vulnerabilities as soon as we become aware, both, Python and OS packages of the Connaisseur image may become vulnerable over time and we suggest to frequently update to the latest version of Connaisseur or rebuilding the image from source yourself.
 At present, we only support the latest version.
 We stick to semantic versioning, so unless the major version changes, updating Conaisseur should never break your installation.
 
@@ -11,6 +11,7 @@ We stick to semantic versioning, so unless the major version changes, updating C
 | Title | Affected versions | Fixed version | Description |
 | - | - | - | - |
 | initContainers not validated | <span>&#8804;</span> 1.3.0 | 1.3.1 | Prior to version 1.3.1 Connaisseur did not validate initContainers which allowed deploying unverified images to the cluster. |
+| Ephemeral containers not validated | <span>&#8804;</span> 3.1.1 | 3.2.0 | Prior to version 3.2.0 Connaisseur did not validate ephemeral containers (introduced in k8s 1.25) which allowed deploying unverified images to the cluster. |
 
 ## Reporting a vulnerability
 

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -101,9 +101,9 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         {{- if .Values.application.features.automaticChildApproval }}
-        resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+        resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "pods/ephemeralcontainers"]
         {{- else }}
-        resources: ["pods"]
+        resources: ["pods", "pods/ephemeralcontainers"]
         {{- end }}
     sideEffects: None
     {{- if gt ($k8sMinor | int) 13 }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,6 +355,8 @@ def adm_req_samples(m_ad_schema_path):
             "replicaset_to_zero",
             "replicaset_from_zero",
             "replica_from_non_zero",
+            "ephemeral_container",
+            "ephemeral_container_unchanged",
         )
     ]
 

--- a/tests/data/sample_admission_requests/ad_request_ephemeral_container.json
+++ b/tests/data/sample_admission_requests/ad_request_ephemeral_container.json
@@ -1,0 +1,159 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1",
+    "request": {
+        "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "name": "demo",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "system:node:kind-control-plane",
+            "groups": [
+                "system:nodes",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "busybox",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    },
+                    {
+                        "name": "debugger-nx875",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always",
+                        "stdin": true,
+                        "tty": true
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "oldObject": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "busybox",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "dryRun": false
+    }
+}

--- a/tests/data/sample_admission_requests/ad_request_ephemeral_container_unchanged.json
+++ b/tests/data/sample_admission_requests/ad_request_ephemeral_container_unchanged.json
@@ -1,0 +1,152 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1",
+    "request": {
+        "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "name": "demo",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "system:node:kind-control-plane",
+            "groups": [
+                "system:nodes",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo2"
+                }
+            },
+            "spec": {
+                "volumes": [
+                ],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "oldObject": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "dryRun": false
+    }
+}

--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -63,6 +63,20 @@ test_cases:
     namespace: default
     expected_msg: pod/pod-rstd-${RAND} created
     expected_result: VALID
+  - id: recu
+    txt: Testing ephemeral container with unsigned image...
+    type: debug
+    ref: securesystemsengineering/testimage:unsigned
+    namespace: default
+    expected_msg: Unable to find signed digest for image docker.io/securesystemsengineering/testimage:unsigned.
+    expected_result: INVALID
+  - id: recs
+    txt: Testing ephemeral container with signed image...
+    type: debug
+    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
+    namespace: default
+    expected_msg: Defaulting debug container name to debugger-
+    expected_result: VALID
   cosign:
   - id: cu
     txt: Testing unsigned cosign image...

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -250,6 +250,26 @@ def test_readyz():
             },
             fix.no_exc(),
         ),
+        (
+            12,
+            True,
+            {},
+            pytest.raises(exc.ValidationError),
+        ),
+        (
+            13,
+            True,
+            {
+                "apiVersion": "admission.k8s.io/v1",
+                "kind": "AdmissionReview",
+                "response": {
+                    "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+                    "allowed": True,
+                    "status": {"code": 202},
+                },
+            },
+            fix.no_exc(),
+        ),
     ],
 )
 async def test_admit(

--- a/tests/test_workload_object.py
+++ b/tests/test_workload_object.py
@@ -53,6 +53,8 @@ def adm_req_sample_objects():
             "wrong_version",
             "deployments_multi_image",
             "pods_unknownparent",
+            "ephemeral_container",
+            "ephemeral_container_unchanged",
         )
     ]
 
@@ -141,6 +143,25 @@ def test_k8s_object_parent_containers(
                 ("containers", 0): Image("redis:alpine"),
                 ("containers", 1): Image("mysql:8"),
                 ("initContainers", 0): Image("busybox:1.32"),
+            },
+        ),
+        (
+            7,
+            {
+                ("containers", 0): Image(
+                    "securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b"
+                ),
+                ("ephemeralContainers", 0): Image("busybox"),
+                ("ephemeralContainers", 1): Image("docker.io/test/deny-image"),
+            },
+        ),
+        (
+            8,
+            {
+                ("containers", 0): Image(
+                    "securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b"
+                ),
+                ("ephemeralContainers", 0): Image("docker.io/test/deny-image"),
             },
         ),
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When ephemeral containers got introduced, we missed including them in admission reviews. This would've allowed an attacker to circumvent Connaisseur's signature verification if they could spawn ephemeral containers in the cluster. This PR remedies the issue.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

