### PR TITLE
Fix integration test failures

### DIFF
--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -42,6 +42,8 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			kubectl run pod-$1-${RAND} --image="$4" --namespace="$5" -luse="connaisseur-integration-test" >output.log 2>&1 || true
 		elif [[ "$3" == "debug" ]]; then
 			kubectl run $1-base-pod-${RAND} --image="securesystemsengineering/testimage:signed" --namespace="$5" -luse="connaisseur-integration-test" >/dev/null 2>&1 || true
+			# Await base pod readiness as otherwise there may be multiple admission requests during the deployment of the ephemeral container
+			kubectl wait --for=condition=Ready pod $1-base-pod-${RAND} --namespace="$5" || true
 			kubectl debug $1-base-pod-${RAND} --image="$4" --namespace="$5" >output.log 2>&1 || true
 		elif [[ "$3" == "workload" ]]; then
 			envsubst <tests/integration/workload-objects/$4.yaml | kubectl apply -f - >output.log 2>&1 || true


### PR DESCRIPTION
## Description
Before this commit the integration testing of ephemeral containers failed sporadically in the sense that more admissions than anticipated happened. This PR awaits the base pod that is to be debugged by the ephemeral container as the unreadiness of the base pod led to another admission request being sent once the base pod got ready.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

