### PR TITLE
Fix RuntimeError

### DIFF
--- a/connaisseur/__main__.py
+++ b/connaisseur/__main__.py
@@ -13,6 +13,9 @@ from connaisseur.flask_application import APP
 from connaisseur.logging import ConnaisseurLoggingWrapper
 
 if __name__ == "__main__":
+    # allow nested asyncio loops
+    nest_asyncio.apply()
+
     LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 
     dictConfig(
@@ -35,9 +38,6 @@ if __name__ == "__main__":
     HTTPServer.ssl_adapter = BuiltinSSLAdapter(
         certificate="/app/certs/tls.crt", private_key="/app/certs/tls.key"
     )
-
-    # allow nested asyncio loops
-    nest_asyncio.apply()
 
     # wrap Connaisseur with a layer that logs HTTP requests
     app = ConnaisseurLoggingWrapper(APP, LOG_LEVEL)

--- a/connaisseur/flask_application.py
+++ b/connaisseur/flask_application.py
@@ -24,12 +24,6 @@ sends its response back.
 """
 CONFIG = Config()
 
-"""
-Initiating and setting an event loop,
-"""
-loop = asyncio.new_event_loop()
-asyncio.set_event_loop(loop)
-
 metrics = PrometheusMetrics(
     APP,
     defaults_prefix=NO_PREFIX,
@@ -70,7 +64,7 @@ def mutate():
     Handle the '/mutate' path and accept CREATE and UPDATE requests.
     Send a response back, which either denies or allows the request.
     """
-    result = loop.run_until_complete(__async_mutate())
+    result = asyncio.get_event_loop().run_until_complete(__async_mutate())
     return result
 
 

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -14,7 +14,7 @@ TIMEOUT=30
 RETRY=3
 
 ## Backup helm/values.yaml
-cp helm/values.yaml values.yaml.Backup
+cp helm/values.yaml values.yaml.backup
 
 ## LOAD PUBLIC KEY
 COSIGN_PUBLIC_KEY="$(printf -- "${COSIGN_PUBLIC_KEY//<br>/\\n            }")"
@@ -607,5 +607,6 @@ fi
 echo 'Cleaning up installation and test resources...'
 make uninstall >/dev/null 2>&1 || true
 kubectl delete all,cronjobs,daemonsets,jobs,replicationcontrollers,statefulsets,namespaces -luse="connaisseur-integration-test" -A >/dev/null
+rm ghcr-values ghcr-validator
 mv values.yaml.backup helm/values.yaml
 echo 'Finished cleanup.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We fail sometimes like [here](https://github.com/sse-secure-systems/connaisseur/actions/runs/6655707388/job/18086653425) with `RuntimeError: Timeout context manager should be used inside a task`, which this PR fixes.


## Description

Using the default initialization of the event loop (i.e. not doing it ourselves) seems to fix the problem (locally ran into RuntimeErrors 5/20 complexity integration tests before and 0/20 after fix)

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

