### PR TITLE
Multiple improvements to the integration test setup

### DIFF
--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Display logs if integration test failed
         if: failure()
         run: |
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1
 
   optional-integration-test:
     name: optional
@@ -162,7 +162,7 @@ jobs:
       - name: Display logs if integration test failed
         if: failure()
         run: |
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1
 
   k8s-versions:
     name: k8s versions
@@ -211,4 +211,4 @@ jobs:
         run: |
           kubectl describe deployments.apps -n connaisseur -lapp.kubernetes.io/name=connaisseur
           kubectl describe pods -n connaisseur -lapp.kubernetes.io/name=connaisseur
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -59,7 +59,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 		echo -e ${FAILED}
 		echo "::group::Output"
 		cat output.log
-		kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur
+		kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur --tail=-1
 		echo "::endgroup::"
 		EXIT="1"
 	else
@@ -68,7 +68,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			echo -e ${FAILED}
 			echo "::group::Output"
 			cat output.log
-			kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur
+			kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur --tail=-1
 			echo "::endgroup::"
 			EXIT="1"
 		else

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -49,7 +49,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			kubectl apply -f $4 >output.log 2>&1 || true
 		fi
 		# if the webhook couldn't be called, try again.
-		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt $RETRY ]] && echo "Failed calling webhook, retrying test deployments" || break
+		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt ${RETRY} ]] && echo "Failed calling webhook, retrying test deployments" || break
 	done
 	if [[ "$3" == "debug" ]]; then
 		# account for extra deployed pod for attaching ephemeral container to
@@ -90,7 +90,7 @@ multi_test() { # TEST_CASE: key in the `test_cases` dict in the cases.yaml
 	# converting to json, as yq processing is pretty slow
 	test_cases=$(yq e -o=json ".test_cases.$1" tests/integration/cases.yaml)
 	len=$(echo ${test_cases} | jq 'length')
-	for i in $(seq 0 $(($len - 1))); do
+	for i in $(seq 0 $((${len} - 1))); do
 		test_case=$(echo ${test_cases} | jq ".[$i]")
 		ID=$(echo ${test_case} | jq -r ".id")
 		TEST_CASE_TXT=$(echo ${test_case} | jq -r ".txt")
@@ -204,7 +204,7 @@ load_test() { #
 ### CREATE IMAGEPULLSECRET ####################################
 create_imagepullsecret_in_ns() { # NAMESPACE # CREATE
 	local CREATE=${2:-true}
-	if $CREATE; then
+	if ${CREATE}; then
 		echo -n "Creating Namespace '${1}'..."
 		kubectl create ns ${1} >/dev/null || {
 			echo -e "${FAILED}"
@@ -215,7 +215,7 @@ create_imagepullsecret_in_ns() { # NAMESPACE # CREATE
 	if [[ -n "${IMAGEPULLSECRET+x}" ]]; then
 		echo -n "Creating imagePullSecret '${IMAGEPULLSECRET}'..."
 		kubectl create secret generic ${IMAGEPULLSECRET} \
-			--from-file=.dockerconfigjson=$HOME/.docker/config.json \
+			--from-file=.dockerconfigjson=${HOME}/.docker/config.json \
 			--type=kubernetes.io/dockerconfigjson \
 			--namespace=${1} >/dev/null || {
 			echo -e "${FAILED}"
@@ -395,7 +395,7 @@ regular_int_test() {
   "successful_requests_to_opsgenie_endpoint": $REQUESTS_TO_OPSGENIE_ENDPOINT,
   "successful_requests_to_keybase_endpoint": $REQUESTS_TO_KEYBASE_ENDPOINT
   }')
-	diff <(echo "$ENDPOINT_HITS" | jq -S .) <(echo "$EXPECTED_ENDPOINT_HITS" | jq -S .) >diff.log 2>&1 || true
+	diff <(echo "${ENDPOINT_HITS}" | jq -S .) <(echo "${EXPECTED_ENDPOINT_HITS}" | jq -S .) >diff.log 2>&1 || true
 	if [[ -s diff.log ]]; then
 		echo -e "${FAILED}"
 		echo "::group::Alerting endpoint diff:"

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -477,7 +477,11 @@ case $1 in
 	enable_alerting
 	make_install
 	regular_int_test
-	make_uninstall
+	if [[ "${EXIT}" != "0" ]]; then
+		echo "Skipping uninstallation to preserve logs..."
+	else
+		make_uninstall
+	fi
 	;;
 "cosign")
 	update_via_env_vars
@@ -576,7 +580,11 @@ case $1 in
 	debug_values "helm/values.yaml"
 	helm_upgrade_namespace "connaisseur"
 	pre_config_int_test
-	helm_uninstall
+	if [[ "${EXIT}" != "0" ]]; then
+		echo "Skipping uninstallation to preserve logs..."
+	else
+		helm_uninstall
+	fi
 	;;
 *)
 	echo "Invalid test case. Exiting..."

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -1,3 +1,6 @@
+kubernetes:
+  deployment:
+    replicasCount: 1
 application:
   validators:
   - name: allow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Multiple improvements to the integration test setup

## Description
This PR includes some improvements with respect to the integration test setup
- Most tests are run on a single Connaisseur replica for easier debugging should things go wrong
- If part of the main integration test fails, integration tests that include uninstallation of Connaisseur will not uninstall it such that the k8s logs are preserved
- In case a failure occurs, the whole set of logs (instead of the last 10 entries) are printed, giving way better debugging data

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

