### PR TITLE
Connaisseur release 3.2.0

### DIFF
--- a/.github/workflows/.reusable-build.yml
+++ b/.github/workflows/.reusable-build.yml
@@ -70,7 +70,7 @@ jobs:
       build_labels: ${{ steps.get_context.outputs.build_labels }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Get context
         id: get_context
         uses: ./.github/actions/context
@@ -85,7 +85,7 @@ jobs:
       cosign_public_key: ${{ steps.build.outputs.cosign_public_key }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build Connaisseur
         id: build
         uses: ./.github/actions/build

--- a/.github/workflows/.reusable-compliance.yml
+++ b/.github/workflows/.reusable-compliance.yml
@@ -14,18 +14,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
       - name: Analyze
-        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif
           repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: ${{ github.ref_name == 'master' }}
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: results.sarif
 
@@ -37,7 +37,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Review
         uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
 
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }} # Only run on PRs
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Otherwise will checkout merge commit, which isn't conform
           fetch-depth: ${{ github.event.pull_request.commits }} # Fetch all commits of the MR, but only those

--- a/.github/workflows/.reusable-docs.yaml
+++ b/.github/workflows/.reusable-docs.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
             fetch-depth: 0
       - name: Set release env

--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -60,7 +60,7 @@ jobs:
           - 56243:56243
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Login with registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
@@ -126,7 +126,7 @@ jobs:
           - 56243:56243
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Login with registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
@@ -189,7 +189,7 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Login with registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:

--- a/.github/workflows/.reusable-integration-test.yml
+++ b/.github/workflows/.reusable-integration-test.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Display logs if integration test failed
         if: failure()
         run: |
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1
 
   optional-integration-test:
     name: optional
@@ -162,7 +162,7 @@ jobs:
       - name: Display logs if integration test failed
         if: failure()
         run: |
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1
 
   k8s-versions:
     name: k8s versions
@@ -211,4 +211,4 @@ jobs:
         run: |
           kubectl describe deployments.apps -n connaisseur -lapp.kubernetes.io/name=connaisseur
           kubectl describe pods -n connaisseur -lapp.kubernetes.io/name=connaisseur
-          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true
+          kubectl logs -n connaisseur -lapp.kubernetes.io/name=connaisseur --prefix=true --tail=-1

--- a/.github/workflows/.reusable-sast.yml
+++ b/.github/workflows/.reusable-sast.yml
@@ -13,19 +13,19 @@ jobs:
       pull-requests: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+      uses: github/codeql-action/init@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
       with:
         languages: 'python'
     - name: Analyze
-      uses: github/codeql-action/analyze@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+      uses: github/codeql-action/analyze@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
 
   black:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install packages
         run: |
           pip3 install setuptools wheel
@@ -40,7 +40,7 @@ jobs:
       image: python:3.11-slim
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install
         run: |
           pip3 install -r requirements_dev.txt
@@ -55,13 +55,13 @@ jobs:
       image: python:slim
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install Bandit
         run: pip3 install bandit bandit_sarif_formatter
       - name: Run Bandit
         run: bandit -r -f sarif -o bandit-results.sarif connaisseur/ --exit-zero
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: 'bandit-results.sarif'
 
@@ -71,7 +71,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Scan
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
@@ -80,7 +80,7 @@ jobs:
           format: sarif
           output-file: hadolint-results.sarif
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: 'hadolint-results.sarif'
 
@@ -90,7 +90,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Scan
         uses: stackrox/kube-linter-action@ca0d55b925470deb5b04b556e6c4276ea94d03c3 # v1.0.4
         with:
@@ -99,7 +99,7 @@ jobs:
           format: sarif
           output-file: kubelinter-results.sarif
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: 'kubelinter-results.sarif'
 
@@ -110,7 +110,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Trivy
         uses: ./.github/actions/trivy-config
 
@@ -120,7 +120,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Render Helm charts
         run: |
           rm -rf tests # remove 'tests' folder from scan
@@ -128,13 +128,13 @@ jobs:
           helm template helm > deployment/deployment.yaml
         shell: bash
       - name: Scan
-        uses: bridgecrewio/checkov-action@f6243e0bd0159652f2017c47743fbb7e36859d00 # v12.2526.0
+        uses: bridgecrewio/checkov-action@defe079fd0a03179471fdca95535610fc46d4f0e # v12.2549.0
         with:
           soft_fail: true
           output_format: cli,sarif
           output_file_path: console,checkov-results.sarif
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: checkov-results.sarif
 
@@ -147,10 +147,10 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Scan
         run: semgrep ci --config=auto --suppress-errors --sarif --output=semgrep-results.sarif || exit 0
       - name: Upload
-        uses: github/codeql-action/upload-sarif@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2.21.9
+        uses: github/codeql-action/upload-sarif@49abf0ba24d0b7953cb586944e918a0b92074c80 # v2.22.4
         with:
           sarif_file: semgrep-results.sarif

--- a/.github/workflows/.reusable-sast.yml
+++ b/.github/workflows/.reusable-sast.yml
@@ -128,7 +128,7 @@ jobs:
           helm template helm > deployment/deployment.yaml
         shell: bash
       - name: Scan
-        uses: bridgecrewio/checkov-action@defe079fd0a03179471fdca95535610fc46d4f0e # v12.2549.0
+        uses: bridgecrewio/checkov-action@d403349a9193cf87f58f18a0f09aab1e9e058bde # v12.2552.0
         with:
           soft_fail: true
           output_format: cli,sarif

--- a/.github/workflows/.reusable-sca.yml
+++ b/.github/workflows/.reusable-sca.yml
@@ -32,7 +32,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run
         uses: ./.github/actions/safety
         with:
@@ -51,7 +51,7 @@ jobs:
       image: docker:stable
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run
         uses: ./.github/actions/trivy-image
         with:
@@ -71,7 +71,7 @@ jobs:
       image: docker:stable
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run
         uses: ./.github/actions/grype
         with:

--- a/.github/workflows/.reusable-unit-test.yml
+++ b/.github/workflows/.reusable-unit-test.yml
@@ -12,7 +12,7 @@ jobs:
       image: python:3.11
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install
         run: |
           pip3 install -r requirements_dev.txt && pip3 install .

--- a/.github/workflows/dockerhub-check.yml
+++ b/.github/workflows/dockerhub-check.yml
@@ -10,7 +10,7 @@ jobs:
   dockerhub-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install yq
         run: sudo snap install yq
       - name: Check main image

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -60,7 +60,7 @@ jobs:
       image: docker:stable
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test get-root utility
         run: |
           docker build -t get-root-key -f docker/Dockerfile.getRoot .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Ensure version equality
         run: |
           IMAGE_TAG=${{ needs.build.outputs.original_tag }}
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install helm git
       - name: Checkout code
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - name: Lint Helm chart

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE = connaisseur
 IMAGE_REPOSITORY := $(shell yq e '.kubernetes.deployment.image.repository' helm/values.yaml)
 VERSION := $(shell yq e '.appVersion' helm/Chart.yaml)
-COSIGN_VERSION = 2.0.0
+COSIGN_VERSION = 2.2.0
 
 .PHONY: all docker install uninstall upgrade annihilate
 

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -190,7 +190,7 @@ class CosignValidator(ValidatorInterface):
                     logging.info("non-json signature data from Cosign: %s", sig)
                     pass
         elif (
-            "Error: no matching signatures:\ninvalid signature when validating ASN.1 encoded signature\n"
+            "Error: no matching signatures: invalid signature when validating ASN.1 encoded signature\n"
             in stderr
         ):
             msg = "Failed to verify signature of trust data."
@@ -202,7 +202,7 @@ class CosignValidator(ValidatorInterface):
                 trust_root=values["name"],
             )
         elif (
-            "Error: no matching signatures:\nsignature not found in transparency log"
+            "Error: no matching signatures: signature not found in transparency log\nmain.go:"
             in stderr
         ):
             msg = "Failed to find signature in transparency log."
@@ -214,7 +214,7 @@ class CosignValidator(ValidatorInterface):
                 trust_root=values["name"],
             )
         elif (
-            "Error: no matching signatures:\n\nmain.go:" in stderr
+            "Error: no matching signatures\nmain.go:" in stderr
             or "Error: no matching signatures:\ncrypto/rsa: verification error"
             in stderr
         ):

--- a/connaisseur/workload_object.py
+++ b/connaisseur/workload_object.py
@@ -99,7 +99,11 @@ class WorkloadObject:
     def containers(self):
         return {
             (container_type, index): Image(container["image"])
-            for container_type in ["containers", "initContainers"]
+            for container_type in [
+                "containers",
+                "initContainers",
+                "ephemeralContainers",
+            ]
             for index, container in enumerate(self.spec.get(container_type, []))
         }
 

--- a/docker/Dockerfile.getRoot
+++ b/docker/Dockerfile.getRoot
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.11-slim
 # Based on debian as alpine needs compilation of cryptography package, which bloats image and increases build time immensely
 
 WORKDIR /app

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,9 +74,9 @@ black <path-to-repository>/connaisseur
 Changes can also be tested locally.
 We recommend the following approach for running pytest in a container:
 ```
-docker run -it --rm -v <path-to-repository>:/data --entrypoint=ash python:alpine
+docker run -it --rm -v <path-to-repository>:/data --entrypoint=bash python:3.11
 cd data
-YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install -r requirements_dev.txt
+pip3 install -r requirements_dev.txt
 pytest --cov=connaisseur --cov-report=xml tests/
 ```
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-While all known vulnerabilities are listed below and we intent to fix vulnerabilities as soon as we become aware, both, Python and OS packages of the Connaisseur image may become vulnerable over time and we suggest to frequently update to the latest version of Connaisseur or rebuilding the image from source yourself.
+While all known vulnerabilities in the Connaisseur application are listed below and we intent to fix vulnerabilities as soon as we become aware, both, Python and OS packages of the Connaisseur image may become vulnerable over time and we suggest to frequently update to the latest version of Connaisseur or rebuilding the image from source yourself.
 At present, we only support the latest version.
 We stick to semantic versioning, so unless the major version changes, updating Conaisseur should never break your installation.
 
@@ -11,6 +11,7 @@ We stick to semantic versioning, so unless the major version changes, updating C
 | Title | Affected versions | Fixed version | Description |
 | - | - | - | - |
 | initContainers not validated | <span>&#8804;</span> 1.3.0 | 1.3.1 | Prior to version 1.3.1 Connaisseur did not validate initContainers which allowed deploying unverified images to the cluster. |
+| Ephemeral containers not validated | <span>&#8804;</span> 3.1.1 | 3.2.0 | Prior to version 3.2.0 Connaisseur did not validate ephemeral containers (introduced in k8s 1.25) which allowed deploying unverified images to the cluster. |
 
 ## Reporting a vulnerability
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -32,7 +32,7 @@ Using Connaisseur requires a [Kubernetes](https://kubernetes.io/) cluster, [Helm
 
 Download the Connaisseur resources required for installation either by cloning the source code via Git or directly add the chart repository via Helm.
 
-=== "Clone via Git"
+=== "Git repo"
 
     The Connaisseur source code can be cloned directly from GitHub and includes the application and Helm charts in a single repository:
 
@@ -40,7 +40,7 @@ Download the Connaisseur resources required for installation either by cloning t
     git clone https://github.com/sse-secure-systems/connaisseur.git
     ```
 
-=== "Add via Helm"
+=== "Helm chart"
 
     The Helm chart can be added by:
 
@@ -76,7 +76,7 @@ However, validating your own images requires additional configuration.
 
 Install Connaisseur via Helm:
 
-=== "Cloned via Git"
+=== "Git repo"
 
     Install Connaisseur by using the Helm template definition files in the `helm` directory:
 
@@ -84,7 +84,7 @@ Install Connaisseur via Helm:
     helm install connaisseur helm --atomic --create-namespace --namespace connaisseur
     ```
 
-=== "Added via Helm"
+=== "Helm chart"
 
     Install Connaisseur using the default configuration from the chart repository:
 
@@ -140,7 +140,7 @@ kubectl run hello-world --image=docker.io/hello-world
 
 A running Connaisseur instance can be updated by a Helm upgrade of the current release:
 
-=== "Cloned via Git"
+=== "Git repo"
 
     Adjust configuration in `helm/values.yaml` as required and upgrade via:
 
@@ -148,7 +148,7 @@ A running Connaisseur instance can be updated by a Helm upgrade of the current r
     helm upgrade connaisseur helm -n connaisseur --wait
     ```
 
-=== "Added via Helm"
+=== "Helm chart"
 
     Adjust your local configuration file (e.g. `values.yaml`) as required and upgrade via:
 

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,2 +1,2 @@
-mkdocs-material~=9.4.4
+mkdocs-material~=9.4.6
 mike~=1.1.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.1.0
-appVersion: 3.1.1
+version: 2.2.0
+appVersion: 3.2.0
 keywords:
   - container image
   - signature

--- a/helm/templates/certificate_webhook-conf.yaml
+++ b/helm/templates/certificate_webhook-conf.yaml
@@ -101,9 +101,9 @@ webhooks:
         apiGroups: ["*"]
         apiVersions: ["*"]
         {{- if .Values.application.features.automaticChildApproval }}
-        resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs"]
+        resources: ["pods", "deployments", "replicationcontrollers", "replicasets", "daemonsets", "statefulsets", "jobs", "cronjobs", "pods/ephemeralcontainers"]
         {{- else }}
-        resources: ["pods"]
+        resources: ["pods", "pods/ephemeralcontainers"]
         {{- end }}
     sideEffects: None
     {{- if gt ($k8sMinor | int) 13 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kubernetes.deployment.image.repository }}:{{ default (print "v" .Chart.AppVersion) .Values.kubernetes.deployment.image.tag }}"
           imagePullPolicy: {{ .Values.kubernetes.deployment.imagePullPolicy }}
+          ports:
+            - containerPort: 5000
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /health

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ theme:
   favicon: 'assets/favicon.svg'
   features:
     - navigation.top
+    - content.code.copy
+    - content.tabs.link
 
 # Extensions
 markdown_extensions:
@@ -39,8 +41,9 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
-  - pymdownx.tabbed
   - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
   - toc:
         permalink: ⚓︎
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp~=3.8.5
+aiohttp~=3.8.6
 cheroot~=10.0.0
 ecdsa~=0.18
 Flask~=3.0.0
@@ -6,7 +6,7 @@ Jinja2~=3.1.2
 jsonschema~=4.19.1
 nest_asyncio~=1.5.8
 parsedatetime~=2.6
-prometheus-flask-exporter==0.22.4
+prometheus-flask-exporter==0.23.0
 python-dateutil~=2.8.2
 python-json-logger~=2.0.7
 pytz~=2023.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,10 +2,10 @@
 aioresponses~=0.7.4
 freezegun~=1.2.2
 parsedatetime~=2.6
-pylint~=3.0.1
+pylint~=3.0.2
 pytest-asyncio~=0.21.1
 pytest-cov~=4.1.0
-pytest-mock~=3.11.1
+pytest-mock~=3.12.0
 pytest-subprocess~=1.5.0
 requests-mock~=1.11.0
 setuptools~=68.2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,6 +355,8 @@ def adm_req_samples(m_ad_schema_path):
             "replicaset_to_zero",
             "replicaset_from_zero",
             "replica_from_non_zero",
+            "ephemeral_container",
+            "ephemeral_container_unchanged",
         )
     ]
 

--- a/tests/data/cosign/no_data.txt
+++ b/tests/data/cosign/no_data.txt
@@ -1,3 +1,3 @@
-Error: no matching signatures:
-
-main.go:48: error during command execution: no matching signatures:
+Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Unexpected Cosign exception for image "docker.io/securesystemsengineering/testimage:co-unsigned": WARNING: Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the signature.
+Error: no matching signatures
+main.go:69: error during command execution: no matching signatures

--- a/tests/data/cosign/notfound_in_tl.txt
+++ b/tests/data/cosign/notfound_in_tl.txt
@@ -1,2 +1,2 @@
-Error: no matching signatures:
-signature not found in transparency log
+Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Unexpected Cosign exception for image "docker.io/securesystemsengineering/testimage:rekor-cosigned-notl": Error: no matching signatures: signature not found in transparency log
+main.go:69: error during command execution: no matching signatures: signature not found in transparency log

--- a/tests/data/cosign/wrong_key.txt
+++ b/tests/data/cosign/wrong_key.txt
@@ -1,2 +1,1 @@
-Error: no matching signatures:
-invalid signature when validating ASN.1 encoded signature
+Error: no matching signatures: invalid signature when validating ASN.1 encoded signature

--- a/tests/data/sample_admission_requests/ad_request_ephemeral_container.json
+++ b/tests/data/sample_admission_requests/ad_request_ephemeral_container.json
@@ -1,0 +1,159 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1",
+    "request": {
+        "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "name": "demo",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "system:node:kind-control-plane",
+            "groups": [
+                "system:nodes",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "busybox",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    },
+                    {
+                        "name": "debugger-nx875",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always",
+                        "stdin": true,
+                        "tty": true
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "oldObject": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "busybox",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "dryRun": false
+    }
+}

--- a/tests/data/sample_admission_requests/ad_request_ephemeral_container_unchanged.json
+++ b/tests/data/sample_admission_requests/ad_request_ephemeral_container_unchanged.json
@@ -1,0 +1,152 @@
+{
+    "kind": "AdmissionReview",
+    "apiVersion": "admission.k8s.io/v1",
+    "request": {
+        "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+        "kind": {
+            "group": "",
+            "version": "v1",
+            "kind": "Pod"
+        },
+        "name": "demo",
+        "namespace": "default",
+        "operation": "UPDATE",
+        "userInfo": {
+            "username": "system:node:kind-control-plane",
+            "groups": [
+                "system:nodes",
+                "system:authenticated"
+            ]
+        },
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo2"
+                }
+            },
+            "spec": {
+                "volumes": [
+                ],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "oldObject": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "demo",
+                "namespace": "default",
+                "uid": "40b771f3-6047-4c39-8d79-56648592d1a6",
+                "resourceVersion": "5170",
+                "creationTimestamp": "2023-10-13T13:23:07Z",
+                "labels": {
+                    "run": "demo"
+                }
+            },
+            "spec": {
+                "volumes": [],
+                "containers": [
+                    {
+                        "name": "demo",
+                        "image": "docker.io/securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b",
+                        "resources": {},
+                        "volumeMounts": [
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "ephemeralContainers": [
+                    {
+                        "name": "debugger-d5jt9",
+                        "image": "docker.io/test/deny-image",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "serviceAccountName": "default",
+                "serviceAccount": "default",
+                "nodeName": "kind-control-plane",
+                "securityContext": {},
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "priority": 0,
+                "enableServiceLinks": true,
+                "preemptionPolicy": "PreemptLowerPriority"
+            }
+        },
+        "dryRun": false
+    }
+}

--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -63,6 +63,20 @@ test_cases:
     namespace: default
     expected_msg: pod/pod-rstd-${RAND} created
     expected_result: VALID
+  - id: recu
+    txt: Testing ephemeral container with unsigned image...
+    type: debug
+    ref: securesystemsengineering/testimage:unsigned
+    namespace: default
+    expected_msg: Unable to find signed digest for image docker.io/securesystemsengineering/testimage:unsigned.
+    expected_result: INVALID
+  - id: recs
+    txt: Testing ephemeral container with signed image...
+    type: debug
+    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
+    namespace: default
+    expected_msg: Defaulting debug container name to debugger-
+    expected_result: VALID
   cosign:
   - id: cu
     txt: Testing unsigned cosign image...

--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -59,7 +59,7 @@ test_cases:
   - id: rstd
     txt: Testing signed image with tag and digest...
     type: deploy
-    ref: securesystemsengineering/testimage:signed@sha256:c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7
+    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
     namespace: default
     expected_msg: pod/pod-rstd-${RAND} created
     expected_result: VALID

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -59,7 +59,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 		echo -e ${FAILED}
 		echo "::group::Output"
 		cat output.log
-		kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur
+		kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur --tail=-1
 		echo "::endgroup::"
 		EXIT="1"
 	else
@@ -68,7 +68,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			echo -e ${FAILED}
 			echo "::group::Output"
 			cat output.log
-			kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur
+			kubectl logs -n connaisseur -lapp.kubernetes.io/instance=connaisseur --tail=-1
 			echo "::endgroup::"
 			EXIT="1"
 		else

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -49,7 +49,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			kubectl apply -f $4 >output.log 2>&1 || true
 		fi
 		# if the webhook couldn't be called, try again.
-		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt $RETRY ]] && echo "Failed calling webhook, retrying test deployments" || break
+		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt ${RETRY} ]] && echo "Failed calling webhook, retrying test deployments" || break
 	done
 	if [[ "$3" == "debug" ]]; then
 		# account for extra deployed pod for attaching ephemeral container to
@@ -90,7 +90,7 @@ multi_test() { # TEST_CASE: key in the `test_cases` dict in the cases.yaml
 	# converting to json, as yq processing is pretty slow
 	test_cases=$(yq e -o=json ".test_cases.$1" tests/integration/cases.yaml)
 	len=$(echo ${test_cases} | jq 'length')
-	for i in $(seq 0 $(($len - 1))); do
+	for i in $(seq 0 $((${len} - 1))); do
 		test_case=$(echo ${test_cases} | jq ".[$i]")
 		ID=$(echo ${test_case} | jq -r ".id")
 		TEST_CASE_TXT=$(echo ${test_case} | jq -r ".txt")
@@ -204,7 +204,7 @@ load_test() { #
 ### CREATE IMAGEPULLSECRET ####################################
 create_imagepullsecret_in_ns() { # NAMESPACE # CREATE
 	local CREATE=${2:-true}
-	if $CREATE; then
+	if ${CREATE}; then
 		echo -n "Creating Namespace '${1}'..."
 		kubectl create ns ${1} >/dev/null || {
 			echo -e "${FAILED}"
@@ -215,7 +215,7 @@ create_imagepullsecret_in_ns() { # NAMESPACE # CREATE
 	if [[ -n "${IMAGEPULLSECRET+x}" ]]; then
 		echo -n "Creating imagePullSecret '${IMAGEPULLSECRET}'..."
 		kubectl create secret generic ${IMAGEPULLSECRET} \
-			--from-file=.dockerconfigjson=$HOME/.docker/config.json \
+			--from-file=.dockerconfigjson=${HOME}/.docker/config.json \
 			--type=kubernetes.io/dockerconfigjson \
 			--namespace=${1} >/dev/null || {
 			echo -e "${FAILED}"
@@ -395,7 +395,7 @@ regular_int_test() {
   "successful_requests_to_opsgenie_endpoint": $REQUESTS_TO_OPSGENIE_ENDPOINT,
   "successful_requests_to_keybase_endpoint": $REQUESTS_TO_KEYBASE_ENDPOINT
   }')
-	diff <(echo "$ENDPOINT_HITS" | jq -S .) <(echo "$EXPECTED_ENDPOINT_HITS" | jq -S .) >diff.log 2>&1 || true
+	diff <(echo "${ENDPOINT_HITS}" | jq -S .) <(echo "${EXPECTED_ENDPOINT_HITS}" | jq -S .) >diff.log 2>&1 || true
 	if [[ -s diff.log ]]; then
 		echo -e "${FAILED}"
 		echo "::group::Alerting endpoint diff:"

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -477,7 +477,11 @@ case $1 in
 	enable_alerting
 	make_install
 	regular_int_test
-	make_uninstall
+	if [[ "${EXIT}" != "0" ]]; then
+		echo "Skipping uninstallation to preserve logs..."
+	else
+		make_uninstall
+	fi
 	;;
 "cosign")
 	update_via_env_vars
@@ -576,7 +580,11 @@ case $1 in
 	debug_values "helm/values.yaml"
 	helm_upgrade_namespace "connaisseur"
 	pre_config_int_test
-	helm_uninstall
+	if [[ "${EXIT}" != "0" ]]; then
+		echo "Skipping uninstallation to preserve logs..."
+	else
+		helm_uninstall
+	fi
 	;;
 *)
 	echo "Invalid test case. Exiting..."

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -49,7 +49,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
 			kubectl apply -f $4 >output.log 2>&1 || true
 		fi
 		# if the webhook couldn't be called, try again.
-		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt $RETRY ]] || break
+		[[ ("$(cat output.log)" =~ "failed calling webhook") && $i -lt $RETRY ]] && echo "Failed calling webhook, retrying test deployments" || break
 	done
 	if [[ "$3" == "debug" ]]; then
 		# account for extra deployed pod for attaching ephemeral container to

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -358,7 +358,7 @@ regular_int_test() {
 	echo -n "[edge1] Testing edge case of tag defined in both targets and release json file..."
 	POD=$(kubectl get pods -o name | grep "pod-rs-")
 	DEPLOYED_SHA=$(kubectl get "${POD}" -o yaml | yq e '.spec.containers[0].image' - | sed 's/.*sha256://')
-	if [[ "${DEPLOYED_SHA}" != 'c5327b291d702719a26c6cf8cc93f72e7902df46547106a9930feda2c002a4a7' ]]; then
+	if [[ "${DEPLOYED_SHA}" != 'fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b' ]]; then
 		echo -e "${FAILED}"
 		EXIT="1"
 	else

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -1,3 +1,6 @@
+kubernetes:
+  deployment:
+    replicasCount: 1
 application:
   validators:
   - name: allow

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -250,6 +250,26 @@ def test_readyz():
             },
             fix.no_exc(),
         ),
+        (
+            12,
+            True,
+            {},
+            pytest.raises(exc.ValidationError),
+        ),
+        (
+            13,
+            True,
+            {
+                "apiVersion": "admission.k8s.io/v1",
+                "kind": "AdmissionReview",
+                "response": {
+                    "uid": "32559dae-5ddd-4c51-843d-a833c0670f2c",
+                    "allowed": True,
+                    "status": {"code": 202},
+                },
+            },
+            fix.no_exc(),
+        ),
     ],
 )
 async def test_admit(

--- a/tests/test_workload_object.py
+++ b/tests/test_workload_object.py
@@ -53,6 +53,8 @@ def adm_req_sample_objects():
             "wrong_version",
             "deployments_multi_image",
             "pods_unknownparent",
+            "ephemeral_container",
+            "ephemeral_container_unchanged",
         )
     ]
 
@@ -141,6 +143,25 @@ def test_k8s_object_parent_containers(
                 ("containers", 0): Image("redis:alpine"),
                 ("containers", 1): Image("mysql:8"),
                 ("initContainers", 0): Image("busybox:1.32"),
+            },
+        ),
+        (
+            7,
+            {
+                ("containers", 0): Image(
+                    "securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b"
+                ),
+                ("ephemeralContainers", 0): Image("busybox"),
+                ("ephemeralContainers", 1): Image("docker.io/test/deny-image"),
+            },
+        ),
+        (
+            8,
+            {
+                ("containers", 0): Image(
+                    "securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b"
+                ),
+                ("ephemeralContainers", 0): Image("docker.io/test/deny-image"),
             },
         ),
     ],


### PR DESCRIPTION
# Connaisseur release 3.2.0

## v3.2.0
### Feat
- Validate ephemeral containers https://github.com/sse-secure-systems/connaisseur/pull/1311
- Explicitly specify containerport in helm chart https://github.com/sse-secure-systems/connaisseur/pull/1308

### Fix
- Getroot base image https://github.com/sse-secure-systems/connaisseur/pull/1295
- Fix regular integration test https://github.com/sse-secure-systems/connaisseur/pull/1309

### Refactor
- Add missing variable brackets https://github.com/sse-secure-systems/connaisseur/pull/1335

### Ci
- Show non-truncated logs on failure https://github.com/sse-secure-systems/connaisseur/pull/1335

### Test
- No uninstall on integration test failure https://github.com/sse-secure-systems/connaisseur/pull/1335
- Run most integration tests on a single replica https://github.com/sse-secure-systems/connaisseur/pull/1335
- Add message to retry of deployment during integration test https://github.com/sse-secure-systems/connaisseur/pull/1332

### Docs
- Update unittest recommendation https://github.com/sse-secure-systems/connaisseur/pull/1311
- Fix code blocks in basics https://github.com/sse-secure-systems/connaisseur/pull/1310
- Add copy code buttons and linked content tabs https://github.com/sse-secure-systems/connaisseur/pull/1302

### Update
- Bump the gh-actions-packages group with 1 update https://github.com/sse-secure-systems/connaisseur/pull/1336
- Bump the pip-packages group with 5 updates (#1338) https://github.com/sse-secure-systems/connaisseur/pull/1338
- Bump the gh-actions-packages group with 4 updates https://github.com/sse-secure-systems/connaisseur/pull/1333
- Cosign v2.2.0 https://github.com/sse-secure-systems/connaisseur/pull/1296
