### PR TITLE
Fix DoS vulnerability

### DIFF
--- a/.github/workflows/.reusable-compliance.yml
+++ b/.github/workflows/.reusable-compliance.yml
@@ -61,7 +61,7 @@ jobs:
           for commit in ${COMMITS}; do
               MSG=$(git log ${commit} -n1 --pretty=%s)
               TYPE=$(echo ${MSG} | awk '{{ print $1 }}')
-              if ! [[ "${TYPE}" =~ ^(build|ci|docs|feat|fix|refactor|test|update):$ ]]; then
+              if ! [[ "${TYPE}" =~ ^(build|ci|docs|feat|fix|refactor|sec|test|update):$ ]]; then
                 EXIT=1
                 echo "Commit message of commit ${commit} doesn't conform to 'type: msg' format:"
                 echo "${MSG}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,6 +81,8 @@ jobs:
           fetch-depth: 0
       - name: Lint Helm chart
         run: helm lint helm
+      - name: Add annotation if it's a security release
+        run: bash scripts/security_annotation.sh
       - name: Package and upload Helm chart
         run: |
           git config user.name "versioning_user"

--- a/connaisseur/constants.py
+++ b/connaisseur/constants.py
@@ -1,10 +1,6 @@
-# We use aiohttp to connect to external sources. Webhooks time out after 30s,
-# so we need to respond before that or the Connaisseur webhook will fail with a
-# generic error message, see https://github.com/sse-secure-systems/connaisseur/issues/448
-# Since the timeouts in aiohttp are ceiled to full seconds
-# (https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts),
-# we can't get closer to 30 than 29 without failing to respond within 30 a lot more often
-AIO_TIMEOUT_SECONDS = 29
+# Webhooks time out after 30s, so we need to respond before that or the Connaisseur webhook will fail
+# with a generic error message, see https://github.com/sse-secure-systems/connaisseur/issues/448
+MUTATE_TIMEOUT_SECONDS = 29
 SHA256 = "sha256"
 DETECTION_MODE = "DETECTION_MODE"
 AUTOMATIC_CHILD_APPROVAL = "AUTOMATIC_CHILD_APPROVAL"

--- a/connaisseur/res/targets_schema.json
+++ b/connaisseur/res/targets_schema.json
@@ -75,7 +75,7 @@
                                     },
                                     "name": {
                                         "type": "string",
-                                        "pattern": "^targets/([a-z\\d][a-z\\d_-]*)+$"
+                                        "pattern": "^targets/[a-z\\d][a-z\\d_-]*$"
                                     },
                                     "paths": {
                                         "type": "array",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -147,6 +147,7 @@ We want to use the following common types in the header:
 - _feat_: adding of new features
 - _fix_: fixing an issue or bug
 - _refactor_: adjustment of code base to improve code quality or performance but not adding a feature or fixing a bug
+- _sec_: change that fixes a security vulnerability
 - _test_: testing related changes
 - _update_: updating a dependency
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,6 +12,7 @@ We stick to semantic versioning, so unless the major version changes, updating C
 | - | - | - | - |
 | initContainers not validated | <span>&#8804;</span> 1.3.0 | 1.3.1 | Prior to version 1.3.1 Connaisseur did not validate initContainers which allowed deploying unverified images to the cluster. |
 | Ephemeral containers not validated | <span>&#8804;</span> 3.1.1 | 3.2.0 | Prior to version 3.2.0 Connaisseur did not validate ephemeral containers (introduced in k8s 1.25) which allowed deploying unverified images to the cluster. |
+| Regex Denial of Service for Notary delegations | <span>&#8804;</span> 3.3.0 | 3.3.1 | Prior to version 3.3.1 Connaisseur did input validation on the names of delegations in an unsafe manner: An adversary with the ability to alter Notary responses, in particular an evil Notary server, could have provided Connaisseur with an invalid delegation name that would lead to catastrophic backtracking during a regex matching. Only users of type `notaryv1` validators are affected as Connaisseur will only perform this kind of input validation in the context of a Notary validation. If you mistrust the Docker Notary server, the default configuration is vulnerable as it contains a `notaryv1` validator with the root keys of both Connaisseur and the library of official Docker images. |
 
 ## Reporting a vulnerability
 

--- a/scripts/changelogger.py
+++ b/scripts/changelogger.py
@@ -83,7 +83,17 @@ def git_latest_two_tags():
 def create_changelog(version, change_dict):
     body = ""
 
-    known_keys = ["feat", "fix", "refactor", "build", "ci", "test", "docs", "update"]
+    known_keys = [
+        "sec",
+        "feat",
+        "fix",
+        "refactor",
+        "build",
+        "ci",
+        "test",
+        "docs",
+        "update",
+    ]
 
     # order by importance
     for key in known_keys:

--- a/scripts/security_annotation.sh
+++ b/scripts/security_annotation.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+# Running as Shell such that we don't need to install dependencies in last pipeline step
+
+set -eu
+
+DIFF_REF=$(git tag --sort=version:refname | tail -n2 | sed 'N;s/\n/.../')
+COUNT=$(git log "${DIFF_REF}" --no-decorate --pretty=%s | cut -d ":" -f1 | grep -c sec || true)
+
+if [[ ${COUNT} -gt 0 ]]; then
+  echo """
+annotations:
+  artifacthub.io/containsSecurityUpdates: "true"
+""" >> helm/Chart.yaml
+fi

--- a/tests/data/trust_data/redos_targets.json
+++ b/tests/data/trust_data/redos_targets.json
@@ -1,0 +1,45 @@
+{
+    "signed": {
+        "_type": "Targets",
+        "delegations": {
+            "keys": {
+                "6984a67934a29955b3f969835c58ee0dd09158f5bec43726d319515b56b0a878": {
+                    "keytype": "ecdsa",
+                    "keyval": {
+                        "private": null,
+                        "public": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEchQNiJJt4PTaEeAzaztL+TQZqTa0iM0YSf+w0LjSElobVsYgnqIbCWe6pGX3UvcCngNw7N4uGkdVNVMS2Tslg=="
+                    }
+                },
+                "70aa109003a93131c63499c70dcfc8db3ba33ca81bdd1abcd52c067a8acc0492": {
+                    "keytype": "ecdsa",
+                    "keyval": {
+                        "private": null,
+                        "public": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM0xl8F5nwIV3IAru1Pf85WCo4cfTOQ91jhxVaQ3xHMeW430q7R4H/tJmAXUZBe+nOTX8pgtmrLpT+Hu/H7pUhw=="
+                    }
+                }
+            },
+            "roles": [
+                {
+                    "keyids": [
+                        "70aa109003a93131c63499c70dcfc8db3ba33ca81bdd1abcd52c067a8acc0492"
+                    ],
+                    "name": "targets/abababababababababababababababababababababababababababababab*",
+                    "paths": [
+                        ""
+                    ],
+                    "threshold": 1
+                }
+            ]
+        },
+        "expires": "2023-01-12T16:55:17.056146761+01:00",
+        "targets": {},
+        "version": 3
+    },
+    "signatures": [
+        {
+            "keyid": "7c62922e6be165f1ea08252f77410152b9e4ec0d7bf4e69c1cc43f0e6c73da20",
+            "method": "ecdsa",
+            "sig": "ayUgIwW4LmtW+kuzHuyU7lkn8awoXlymBcXeO8j++JSAUpU3BSuFsBe7yx3SOOsxh57u+vWkCOzPdLEYVyQrqg=="
+        }
+    ]
+}

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -324,7 +324,7 @@ async def test_admit(
         (
             {
                 "target": "connaisseur.flask_application.__admit",
-                "side_effect": asyncio.TimeoutError(""),
+                "side_effect": TimeoutError(""),
             },
             "couldn't retrieve the necessary trust data for verification within 30s. most likely there was a network failure. check connectivity to external servers or retry",
             200,

--- a/tests/validators/notaryv1/test_trust_data.py
+++ b/tests/validators/notaryv1/test_trust_data.py
@@ -247,6 +247,12 @@ timestamp_hashes = {
         (fix.get_td("sample7_targets"), "targets", "TargetsData", fix.no_exc()),
         (fix.get_td("sample7_snapshot"), "snapshot", "SnapshotData", fix.no_exc()),
         (fix.get_td("missing_path"), "targets", "TargetsData", fix.no_exc()),
+        (
+            fix.get_td("redos_targets"),
+            "targets",
+            "TargetsData",
+            pytest.raises(exc.InvalidTrustDataFormatError),
+        ),
     ],
 )
 def test_trust_data_init(m_trust_data, data: dict, role: str, class_: str, exception):


### PR DESCRIPTION
<!--- Reference respective issue if it exists -->
Fixes a RE DoS in Connaisseur

## Description
This MR contains multiple commits. One fixes a RE DoS in Connaisseur's validation of TUF data. Another improves the conceptually (but technically unrelated) handling of timeouts of asynchronous function calls. The remaining commits handle a new type of commit header, which will allow us to automatically publish the Helm charts with a sec release annotation.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

