### PR TITLE
update: Update k8s image registry in default policy

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -143,13 +143,13 @@ kubectl get all -n connaisseur
     pod/connaisseur-deployment-78d8975596-42tkw   1/1     Running   0          22s
     pod/connaisseur-deployment-78d8975596-5c4c6   1/1     Running   0          22s
     pod/connaisseur-deployment-78d8975596-kvrj6   1/1     Running   0          22s
-    
+
     NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
     service/connaisseur-svc   ClusterIP   10.108.220.34   <none>        443/TCP   22s
-    
+
     NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
     deployment.apps/connaisseur-deployment   3/3     3            3           22s
-    
+
     NAME                                                DESIRED   CURRENT   READY   AGE
     replicaset.apps/connaisseur-deployment-78d8975596   3         3         3       22s
     ```
@@ -414,7 +414,7 @@ Now deploying the following images we would get the matchings:
 Connaisseur ships with a few rules pre-configured.
 There is two rules that should remain intact in some form in order to not brick the Kubernetes cluster:
 
-- `k8s.gcr.io`: This is an `allow` rule for Kubernetes images (`k8s.gcr.io`) in order to not block cluster relevant images. These cannot be validated currently.
+- `registry.k8s.io`: This is an `allow` rule for Kubernetes images (`registry.k8s.io`) in order to not block cluster relevant images. These images are signed with keyless Cosign signatures, which Connaisseur doesn't support yet. Thus, they cannot be validated currently.
 - `docker.io/securesystemsengineering/*:*`: This rule is used to validate the Connaisseur images with the respective validator and removal can break the Connaisseur deployment. It is, however, possible to use the static `allow` validator.
 
 #### Configuration options
@@ -494,7 +494,7 @@ This is likely the most common case in simple settings by which only self-built 
 
       policy:
       - pattern: "*:*"
-      - pattern: "k8s.gcr.io/*:*"
+      - pattern: "registry.k8s.io/*:*"
         validator: allow
       - pattern: "docker.io/securesystemsengineering/*:*"
         validator: dockerhub_basics
@@ -543,7 +543,7 @@ This configuration achieves the same as the one above, but is faster as trust da
       - pattern: "*:*"
         validator: deny
       - pattern: "docker.io/myrepo/*:*"
-      - pattern: "k8s.gcr.io/*:*"
+      - pattern: "registry.k8s.io/*:*"
         validator: allow
       - pattern: "docker.io/securesystemsengineering/*:*"
         validator: dockerhub_basics
@@ -592,7 +592,7 @@ In case only validated Docker Hub official images should be admitted to the clus
         validator: dockerhub_basics
         with:
           trustRoot: docker_official
-      - pattern: "k8s.gcr.io/*:*"
+      - pattern: "registry.k8s.io/*:*"
         validator: allow
       - pattern: "docker.io/securesystemsengineering/*:*"
         validator: dockerhub_basics
@@ -638,7 +638,7 @@ In case only Docker Hub official images should be validated while all others are
         validator: dockerhub_basics
         with:
           trustRoot: docker_official
-      - pattern: "k8s.gcr.io/*:*"
+      - pattern: "registry.k8s.io/*:*"
         validator: allow
       - pattern: "docker.io/securesystemsengineering/*:*"
         validator: dockerhub_basics
@@ -667,7 +667,7 @@ As a matter of fact, Connaisseur can also be used to restrict the allowed regist
         validator: deny
       - pattern: "docker.io/myrepo/*:*"
         validator: allow
-      - pattern: "k8s.gcr.io/*:*"
+      - pattern: "registry.k8s.io/*:*"
         validator: allow
       - pattern: "docker.io/securesystemsengineering/*:*"
         validator: allow

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.3.1
-appVersion: 3.3.1
+version: 2.3.2
+appVersion: 3.3.2
 keywords:
   - container image
   - signature

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -159,18 +159,24 @@ application:
   ### IMAGE POLICY ###
   # the image policy ties validators and images together whereby always only the most specific rule (pattern)
   # is applied. specify if and how images should be validated by which validator via the validator name.
+  #
+  # below is a starting configuration, which you can fully customize to your liking
   policy:
+    # use the 'default' validator as a fallback
     - pattern: "*:*"
+    # validate official docker images using docker's public key
     - pattern: "docker.io/library/*:*"
       validator: dockerhub-basics
       with:
         trustRoot: docker-official
-    - pattern: "k8s.gcr.io/*:*"
-      validator: allow
+    # validate Connaisseur images using SSE's public key
     - pattern: "docker.io/securesystemsengineering/*:*"
       validator: dockerhub-basics
       with:
         trustRoot: securesystemsengineering-official
+    # simply allow any images of Kubernetes projects
+    - pattern: "registry.k8s.io/*:*"
+      validator: allow
 
   features:
     # in detection mode, deployment will not be denied, but only prompted

--- a/tests/data/config/err2.yaml
+++ b/tests/data/config/err2.yaml
@@ -54,7 +54,7 @@ policy:
   validator: dockerhub
   with:
     delegations: ["phbelitz"]
-- pattern: "k8s.gcr.io/*:*"
+- pattern: "registry.k8s.io/*:*"
   validator: allow
 - pattern: "gcr.io/*:*"
   validator: allow

--- a/tests/data/config/err3.yaml
+++ b/tests/data/config/err3.yaml
@@ -54,7 +54,7 @@ policy:
   validator: dockerhub
   with:
     delegations: ["phbelitz"]
-- pattern: "k8s.gcr.io/*:*"
+- pattern: "registry.k8s.io/*:*"
   validator: allow
 - pattern: "gcr.io/*:*"
   validator: allow

--- a/tests/data/config/err4.yaml
+++ b/tests/data/config/err4.yaml
@@ -54,7 +54,7 @@ policy:
   validator: dockerhub
   with:
     delegations: ["phbelitz"]
-- pattern: "k8s.gcr.io/*:*"
+- pattern: "registry.k8s.io/*:*"
   validator: allow
 - pattern: "gcr.io/*:*"
   validator: allow

--- a/tests/data/config/sample_config.yaml
+++ b/tests/data/config/sample_config.yaml
@@ -87,7 +87,7 @@ policy:
   validator: dockerhub
   with:
     delegations: ["phbelitz"]
-- pattern: "k8s.gcr.io/*:*"
+- pattern: "registry.k8s.io/*:*"
   validator: allow
 - pattern: "gcr.io/*:*"
   validator: allow

--- a/tests/integration/update-for-workloads.yaml
+++ b/tests/integration/update-for-workloads.yaml
@@ -47,7 +47,7 @@ application:
       validator: dockerhub-basics
       with:
         trustRoot: docker-official
-    - pattern: "k8s.gcr.io/*:*"
+    - pattern: "registry.k8s.io/*:*"
       validator: allow
     - pattern: "docker.io/rancher/library-busybox:*" # Allow PVC creation helper of k3s
       validator: allow

--- a/tests/integration/update-self-hosted-notary.yaml
+++ b/tests/integration/update-self-hosted-notary.yaml
@@ -58,7 +58,7 @@ application:
     validator: dockerhub-basics
     with:
       trustRoot: securesystemsengineering-official
-  - pattern: "k8s.gcr.io/*:*"
+  - pattern: "registry.k8s.io/*:*"
     validator: allow
   - pattern: docker.io/securesystemsengineering/connaisseur:*
     validator: allow

--- a/tests/integration/update.yaml
+++ b/tests/integration/update.yaml
@@ -89,7 +89,7 @@ application:
     validator: dockerhub-basics
     with:
       trustRoot: securesystemsengineering-official
-  - pattern: "k8s.gcr.io/*:*"
+  - pattern: "registry.k8s.io/*:*"
     validator: allow
   - pattern: docker.io/securesystemsengineering/connaisseur:*
     validator: allow

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ static_config = {
             "validator": "dockerhub",
             "with": {"delegations": ["phbelitz"]},
         },
-        {"pattern": "k8s.gcr.io/*:*", "validator": "allow"},
+        {"pattern": "registry.k8s.io/*:*", "validator": "allow"},
         {"pattern": "gcr.io/*:*", "validator": "allow"},
         {
             "pattern": "docker.io/securesystemsengineering/*:*",
@@ -191,7 +191,7 @@ def test_match_compare(rule1: str, rule2: str, image: str):
     [
         ("image:tag", "docker.io/*:*"),
         ("reg.io/image:tag", "*:*"),
-        ("k8s.gcr.io/path/image", "k8s.gcr.io/*:*"),
+        ("registry.k8s.io/path/image", "registry.k8s.io/*:*"),
         (
             "docker.io/securesystemsengineering/sample:v4",
             "docker.io/securesystemsengineering/sample:v4",

--- a/tests/test_flask_application.py
+++ b/tests/test_flask_application.py
@@ -33,7 +33,7 @@ def m_config(monkeypatch, sample_nv1):
                 "validator": "dockerhub",
                 "with": {"delegations": ["phbelitz"]},
             },
-            {"pattern": "k8s.gcr.io/*:*", "validator": "allow"},
+            {"pattern": "registry.k8s.io/*:*", "validator": "allow"},
             {"pattern": "gcr.io/*:*", "validator": "allow"},
             {
                 "pattern": "docker.io/securesystemsengineering/*:*",

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -88,11 +88,11 @@ from . import conftest as fix
             fix.no_exc(),
         ),
         (
-            "master-node:5000/k8s.gcr.io/library/kube-apiserver:v1.18.6",
+            "master-node:5000/registry.k8s.io/library/kube-apiserver:v1.18.6",
             "kube-apiserver",
             "v1.18.6",
             None,
-            "k8s.gcr.io/library",
+            "registry.k8s.io/library",
             "master-node:5000",
             fix.no_exc(),
         ),


### PR DESCRIPTION
Context: https://kubernetes.io/blog/2023/03/10/image-registry-redirect/


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

