### PR TITLE
fix: Report notary auth failure

### DIFF
--- a/connaisseur/exceptions.py
+++ b/connaisseur/exceptions.py
@@ -120,6 +120,10 @@ class UnreachableError(BaseConnaisseurException):
     pass
 
 
+class UnauthorizedError(BaseConnaisseurException):
+    pass
+
+
 class AlertingException(Exception):
     message: str
 

--- a/connaisseur/validators/notaryv1/notary.py
+++ b/connaisseur/validators/notaryv1/notary.py
@@ -11,6 +11,7 @@ from connaisseur.exceptions import (
     InvalidFormatException,
     NotFoundException,
     PathTraversalError,
+    UnauthorizedError,
     UnknownTypeException,
 )
 from connaisseur.image import Image
@@ -125,6 +126,9 @@ class Notary:
                     "'www-authenticate' header for notary {notary_name}."
                 )
                 raise NotFoundException(message=msg, notary_name=self.name)
+            elif status == 401 and token:
+                msg = "Unable to get root trust data from {notary_name} due to faulty authentication."
+                raise UnauthorizedError(message=msg, notary_name=self.name)
             else:
                 response.raise_for_status()
                 data = await response.text()
@@ -149,6 +153,14 @@ class Notary:
             if status == 404:
                 msg = "Unable to get {tuf_role} trust data from {notary_name}."
                 raise NotFoundException(
+                    message=msg, notary_name=self.name, tuf_role=str(role)
+                )
+            if status == 401:
+                msg = (
+                    "Unable to get {tuf_role} trust data from {notary_name}"
+                    "due to faulty authentication."
+                )
+                raise UnauthorizedError(
                     message=msg, notary_name=self.name, tuf_role=str(role)
                 )
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.3.2
-appVersion: 3.3.2
+version: 2.3.3
+appVersion: 3.3.3
 keywords:
   - container image
   - signature

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,12 +145,16 @@ def mock_request_notary(match: re.Match, **kwargs):
     if kwargs.get("headers") and kwargs.get("headers").get("Authorization"):
         if registry == "empty.io":
             return MockResponse({}, status_code=404)
-
-        return MockResponse(get_td(f"{image}/{role}"))
+        elif registry == "deny.io":
+            return MockResponse({}, status_code=401)
+        else:
+            return MockResponse(get_td(f"{image}/{role}"))
     elif registry == "empty.io":
         return MockResponse({}, status_code=401)
     elif registry == "notary_wo_auth.io":
         return MockResponse(get_td(f"{image}/{role}"))
+    elif registry == "fail.io":
+        return MockResponse({}, status_code=500)
     else:
         return MockResponse(
             {},


### PR DESCRIPTION
## Description

Previously, auth failures when retrieving TUF trust data were raised as exceptions, but never handled, thus leading to opaque 'unknown error' messages. This commit introduces handling for 401s, thus making the admission review clearer.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

