### PR TITLE
build: removed safety

### DIFF
--- a/.github/actions/safety/action.yaml
+++ b/.github/actions/safety/action.yaml
@@ -1,33 +1,16 @@
 name: safety
-description: 'Run Safety on image'
-inputs:
-  image:
-    description: 'Image name'
-    required: true
-  registry:
-    description: 'Registry to login to pull image, e.g. "ghcr.io" for GHCR, leave empty if image is public'
-    required: false
-  repo_owner:
-    description: 'Name of repository owner, e.g. "github.repository_owner" for ghcr.io'
-    required: false
-  repo_token:
-    description: 'Access token for repository owner, e.g. "secrets.GITHUB_TOKEN" for ghcr.io'
-    required: false
+description: "Run Safety on image"
 runs:
   using: "composite"
   steps:
-    - name: Login with registry
-      if: inputs.registry != ''
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
-      with:
-        registry: ${{ inputs.registry }}
-        username: ${{ inputs.repo_owner }}
-        password: ${{ inputs.repo_token }}
-    - name: Scan
+    - name: Install safety
       run: |
-        docker run --user 0 -v ${PWD}:/results ${{ inputs.image }} /bin/ash -c \
-          'safety check --full-report -o screen --save-json /results/safety-report.json'
-      shell: sh
+        pip3 install safety
+      shell: bash
+    - name: Run safety
+      run: |
+        safety check --file requirements.txt --file requirements_dev.txt --full-report -o screen --save-json safety-report.json
+      shell: bash
     - name: Upload
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure()

--- a/.github/workflows/.reusable-sca.yml
+++ b/.github/workflows/.reusable-sca.yml
@@ -35,11 +35,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run
         uses: ./.github/actions/safety
-        with:
-          image: ${{ inputs.image }}
-          registry: ${{ inputs.registry }}
-          repo_owner: ${{ inputs.repo_owner }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   trivy-image-scan:
     name: trivy image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,12 +7,8 @@ RUN mkdir /install
 WORKDIR /install
 COPY requirements.txt /requirements.txt
 
-# Have to upgrade pip and install extra packages due to error when installing frozenlist
-# Since we run inside an alpine based container, we cannot compile yarl and multidict
-# also: safety needs gcc no properly install. gcc can't be installed in the final image,
-# since apk is no longer available, so safety is added as package to the final image
-RUN apk add --no-cache musl-dev gcc \
-  && pip install --no-cache-dir --upgrade pip~=23.3 \
+# Have to upgrade pip due to error when installing frozenlist
+RUN pip install --no-cache-dir --upgrade pip~=23.3 \
   && YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip install --no-cache-dir --prefix=/install -r /requirements.txt
 
 # Load and verify Cosign

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ PyYAML~=6.0
 requests~=2.31.0
 rfc3339-validator~=0.1.4
 rsa~=4.9
-safety~=3.0.1


### PR DESCRIPTION
Due to confusion of a developer, the safety package was part of the Connaisseur container. This is no longer the case, the package is now installed during the CI, where it is exclusivly needed.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

