### PR TITLE
fix: Added oneliner to fix issues with minikube

### DIFF
--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -106,6 +106,7 @@ if [[ "${CLUSTER:-"minikube"}" == "minikube" ]]; then
   echo "Building docker image..."
   make docker > /dev/null
   echo "Done building docker image!"
+  eval $(minikube docker-env -u)
   NETWORK=$(docker container inspect minikube | jq -r '.[].NetworkSettings.Networks | to_entries | .[].key')
 else
   if [[ "$(docker inspect kind-control-plane | jq -r .[].State.Status || echo 'container not found')" != "running" ]]; then


### PR DESCRIPTION
## Description
Executing the run_integration_tests script hasn't worked for minikube users so far. This issue has now been fixed with a simple oneliner.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

