### PR TITLE
ci: new testimages

### DIFF
--- a/connaisseur/__main__.py
+++ b/connaisseur/__main__.py
@@ -1,6 +1,7 @@
 """
 Main method for Connaisseur. Start the web server.
 """
+
 import os
 from logging.config import dictConfig
 

--- a/connaisseur/validators/cosign/cosign_validator.py
+++ b/connaisseur/validators/cosign/cosign_validator.py
@@ -364,9 +364,9 @@ class CosignValidator(ValidatorInterface):
         # Extend the OS env vars only for passing to the subprocess below
         env["DOCKER_CONFIG"] = f"/app/connaisseur-config/{self.name}/.docker/"
         env["TUF_ROOT"] = "/app/.sigstore"
-        env[
-            "SIGSTORE_NO_CACHE"
-        ] = "1"  # Otherwise, Cosign will try to write cache files to disk
+        env["SIGSTORE_NO_CACHE"] = (
+            "1"  # Otherwise, Cosign will try to write cache files to disk
+        )
         if safe_path_func(
             os.path.exists, "/app/certs/cosign", f"/app/certs/cosign/{self.name}.crt"
         ):

--- a/scripts/get_root_key.py
+++ b/scripts/get_root_key.py
@@ -14,7 +14,7 @@ from connaisseur.validators.notaryv1.tuf_role import TUFRole
 
 async def get_pub_root_key(host: str, image: Image):
     notary = Notary("no", host, ["not_empty"])
-    async with (aiohttp.ClientSession()) as session:
+    async with aiohttp.ClientSession() as session:
         token = await notary.get_auth(session, image)
         root_td = await notary.get_trust_data(session, image, TUFRole("root"), token)
 

--- a/tests/integration/cases.yaml
+++ b/tests/integration/cases.yaml
@@ -59,7 +59,7 @@ test_cases:
   - id: rstd
     txt: Testing signed image with tag and digest...
     type: deploy
-    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
+    ref: securesystemsengineering/testimage:signed@sha256:fe542477b92fb84c38eda9c824f6566d5c2536ef30af9c47152fa8a5fadb58dd
     namespace: default
     expected_msg: pod/pod-rstd-${RAND} created
     expected_result: VALID
@@ -73,7 +73,7 @@ test_cases:
   - id: recs
     txt: Testing ephemeral container with signed image...
     type: debug
-    ref: securesystemsengineering/testimage:signed@sha256:fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b
+    ref: securesystemsengineering/testimage:signed@sha256:fe542477b92fb84c38eda9c824f6566d5c2536ef30af9c47152fa8a5fadb58dd
     namespace: default
     expected_msg: Defaulting debug container name to debugger-
     expected_result: VALID

--- a/tests/integration/integration-test.sh
+++ b/tests/integration/integration-test.sh
@@ -418,7 +418,7 @@ regular_int_test() {
 	else
 	    DEPLOYED_SHA=$(kubectl get "${POD}" -o yaml | yq e '.spec.containers[0].image' - | sed 's/.*sha256://')
         kubectl get "${POD}" -o yaml | yq e '.spec.containers[0].image' - | sed 's/.*sha256://'
-        if [[ "${DEPLOYED_SHA}" != 'fa65f55bd50c700fa691291d5b9d06b98cc7c906bc5bf4048683cb085f7c237b' ]]; then
+        if [[ "${DEPLOYED_SHA}" != 'fe542477b92fb84c38eda9c824f6566d5c2536ef30af9c47152fa8a5fadb58dd' ]]; then
 	        echo -e "${FAILED}"
 	        EXIT="1"
         else

--- a/tests/testimages/double_sig/Dockerfile
+++ b/tests/testimages/double_sig/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc@sha256:f993601701a37bef71e7f8fc1ef9410b09b15556f4371b06dcc10202cc81f9ea as builder
+
+WORKDIR /
+
+COPY main.c /main.c
+RUN gcc -o /main -static /main.c
+
+FROM scratch
+
+COPY --from=builder /main /main
+
+ENTRYPOINT ["./main"]

--- a/tests/testimages/double_sig/main.c
+++ b/tests/testimages/double_sig/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/syscall.h>
+
+const char message[] = "Double_sig.\n";
+
+int main()
+{ 
+    syscall(SYS_write, STDOUT_FILENO, message, sizeof(message) - 1);
+    pause();
+    return 0;
+}

--- a/tests/testimages/signed/Dockerfile
+++ b/tests/testimages/signed/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc@sha256:f993601701a37bef71e7f8fc1ef9410b09b15556f4371b06dcc10202cc81f9ea as builder
+
+WORKDIR /
+
+COPY main.c /main.c
+RUN gcc -o /main -static /main.c
+
+FROM scratch
+
+COPY --from=builder /main /main
+
+ENTRYPOINT ["./main"]

--- a/tests/testimages/signed/main.c
+++ b/tests/testimages/signed/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/syscall.h>
+
+const char message[] = "Signed.\n";
+
+int main()
+{ 
+    syscall(SYS_write, STDOUT_FILENO, message, sizeof(message) - 1);
+    pause();
+    return 0;
+}

--- a/tests/testimages/special_sig/Dockerfile
+++ b/tests/testimages/special_sig/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc@sha256:f993601701a37bef71e7f8fc1ef9410b09b15556f4371b06dcc10202cc81f9ea as builder
+
+WORKDIR /
+
+COPY main.c /main.c
+RUN gcc -o /main -static /main.c
+
+FROM scratch
+
+COPY --from=builder /main /main
+
+ENTRYPOINT ["./main"]

--- a/tests/testimages/special_sig/main.c
+++ b/tests/testimages/special_sig/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/syscall.h>
+
+const char message[] = "Special_sig.\n";
+
+int main()
+{ 
+    syscall(SYS_write, STDOUT_FILENO, message, sizeof(message) - 1);
+    pause();
+    return 0;
+}

--- a/tests/testimages/unsigned/Dockerfile
+++ b/tests/testimages/unsigned/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc@sha256:f993601701a37bef71e7f8fc1ef9410b09b15556f4371b06dcc10202cc81f9ea as builder
+
+WORKDIR /
+
+COPY main.c /main.c
+RUN gcc -o /main -static /main.c
+
+FROM scratch
+
+COPY --from=builder /main /main
+
+ENTRYPOINT ["./main"]

--- a/tests/testimages/unsigned/main.c
+++ b/tests/testimages/unsigned/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/syscall.h>
+
+const char message[] = "Unsigned.\n";
+
+int main()
+{ 
+    syscall(SYS_write, STDOUT_FILENO, message, sizeof(message) - 1);
+    pause();
+    return 0;
+}

--- a/tests/testimages/wrong_signer/Dockerfile
+++ b/tests/testimages/wrong_signer/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc@sha256:f993601701a37bef71e7f8fc1ef9410b09b15556f4371b06dcc10202cc81f9ea as builder
+
+WORKDIR /
+
+COPY main.c /main.c
+RUN gcc -o /main -static /main.c
+
+FROM scratch
+
+COPY --from=builder /main /main
+
+ENTRYPOINT ["./main"]

--- a/tests/testimages/wrong_signer/main.c
+++ b/tests/testimages/wrong_signer/main.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <sys/syscall.h>
+
+const char message[] = "Wrong_signer.\n";
+
+int main()
+{ 
+    syscall(SYS_write, STDOUT_FILENO, message, sizeof(message) - 1);
+    pause();
+    return 0;
+}


### PR DESCRIPTION
Because of expired signature data, new signatures needed to be created. At the same time we decided to minimize the size of our testimages.

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

