### PR TITLE
CI: Disable non-OCI-compliant provenance and disable image cleanup during public Golang test

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -65,8 +65,8 @@ runs:
         labels: ${{ inputs.image_labels }}
         file: docker/Dockerfile
         build-args: COSIGN_VERSION=${{ inputs.cosign_version }}
-        sbom: true
-        provenance: true
+        sbom: false  # Duplicates SBOMs manually created below
+        provenance: false  #TODO: Set to false, as resulting format is not OCI (GHCR) compliant (https://github.com/docker/build-push-action/issues/820) and causes problems with GHCR and e.g. image deletion (https://github.com/snok/container-retention-policy/issues/63)
     - name: Create SBOM
       uses: anchore/sbom-action@5ecf649a417b8ae17dc8383dc32d46c03f2312df # v0.15.1
       with:

--- a/.github/workflows/.reusable-cleanup-registry.yml
+++ b/.github/workflows/.reusable-cleanup-registry.yml
@@ -28,13 +28,13 @@ jobs:
           account-type: org
           org-name: sse-secure-systems
           token: ${{ secrets.GHCR_PAT }}
-      - name: Cleanup all connaisseur images
-        uses: snok/container-retention-policy@b56f4ff7539c1f94f01e5dc726671cd619aa8072 # v2.2.1
-        with:
-          image-names: connaisseur
-          skip-tags: master, develop, v*, sha256-*
-          cut-off: four days ago UTC+1
-          timestamp-to-use: updated_at
-          account-type: org
-          org-name: sse-secure-systems
-          token: ${{ secrets.GHCR_PAT }}
+      # - name: Cleanup all connaisseur images
+      #   uses: snok/container-retention-policy@b56f4ff7539c1f94f01e5dc726671cd619aa8072 # v2.2.1
+      #   with:
+      #     image-names: connaisseur
+      #     skip-tags: master, develop, v*, sha256-*
+      #     cut-off: four days ago UTC+1
+      #     timestamp-to-use: updated_at
+      #     account-type: org
+      #     org-name: sse-secure-systems
+      #     token: ${{ secrets.GHCR_PAT }}


### PR DESCRIPTION
## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

