### PR TITLE
feat: allow helm chart label customization

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -39,6 +39,9 @@ app.kubernetes.io/name: {{ include "helm.name" . }}
 helm.sh/chart: {{ include "helm.chart" . }}
 app.kubernetes.io/instance: {{ .Chart.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.kubernetes.commonLabels }}
+{{ toYaml .Values.kubernetes.commonLabels }}
+{{- end }}
 {{- end -}}
 
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/component: connaisseur-core
         app.kubernetes.io/name: {{ include "helm.name" . }}
         app.kubernetes.io/instance: {{ .Chart.Name }}
+        {{- with .Values.kubernetes.deployment.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include "getConfigChecksum" . }}
         {{- if .Values.kubernetes.deployment.annotations }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -55,6 +55,8 @@ kubernetes:
     podSecurityPolicy:
       enabled: false
       name: ["connaisseur-psp"] # list of PSPs to use, "connaisseur-psp" is the project-provided default
+    # additional labels to attach to the pods created
+    podLabels: {}
     envs: {} # dict of additional environment variables, which will be stored as a secret and injected into the Connaisseur pods
     # Extra config
     extraContainers: []
@@ -75,6 +77,8 @@ kubernetes:
     #     -----BEGIN PRIVATE KEY-----
     #     ...
     #     -----END PRIVATE KEY-----
+  # additional labels to attach to the Kubernetes resources created
+  commonLabels: {}
 
   # configure Connaisseur service
   service:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently, it's not possible to add additional labels to Deployments and Pods without referring to tools such as kustomize. Some organizations require to augment the aforementiones Kubernetes ressources with additional labels to comply with company regulations. This commit introduces additional properties to enable such label attachments.

<!--- Reference respective issue if it exists -->
Feature #1487

## Description

This MR adds two additional properties (namely podLabels as well as commonLabels) to define additional labels to be added to the K8s resources created

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)

## Remarks
I did not change the version number as I was unsure whether this minor change justified a new version number. Please let me know if you want me to increase the version number and I'll gladly do so.

