### PR TITLE
ci: add manual publish job

### DIFF
--- a/.github/workflows/.reusable-publish.yml
+++ b/.github/workflows/.reusable-publish.yml
@@ -1,0 +1,54 @@
+name: publish
+
+on:
+  workflow_call:
+    inputs:
+      chart_version:
+        description: "Version of the connaisseur helm chart to publish"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish_chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install Helm and Git
+        run: |
+          curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+          sudo apt-get install apt-transport-https --yes
+          echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install helm git
+      - name: Checkout code
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 0
+      - name: Lint Helm chart
+        run: helm lint charts/connaisseur
+      - name: Add annotation if it's a security release
+        run: bash scripts/security_annotation.sh
+      - name: Package and upload Helm chart
+        run: |
+          git config user.name "versioning_user"
+          git config user.email "connaisseur@securesystems.dev"
+          CHART_VERSION="${{ inputs.chart_version }}"
+          helm package charts/connaisseur
+          git checkout . # Remove changes to Chart for git checkout
+          mkdir -p tmp_charts
+          mv connaisseur*.tgz ./tmp_charts
+          git checkout gh-pages
+          cd tmp_charts
+          helm repo index . --url https://sse-secure-systems.github.io/connaisseur/charts
+          cd ..
+          git add ./tmp_charts
+          git commit -m "Publish helm chart ${CHART_VERSION}"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/sse-secure-systems/connaisseur.git
+
+  publish_docs:
+    uses: ./.github/workflows/.reusable-docs.yaml
+    permissions:
+      contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: publish
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: "Version of the connaisseur helm chart to publish"
+        type: string
+
+jobs:
+  publish:
+    uses: ./.github/workflows/.reusable-publish.yml
+    permissions:
+      contents: write
+    with:
+      chart_version: ${{ needs.build.outputs.chart_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,46 +62,10 @@ jobs:
       skip: ${{ needs.conditionals.outputs.skip_integration_tests }}
       cosign_public_key: ${{ needs.build.outputs.cosign_public_key }}
 
-  publish_chart:
-    runs-on: ubuntu-latest
+  publish:
+    uses: ./.github/workflows/.reusable-publish.yml
     needs: [build, version-match, integration-test]
     permissions:
       contents: write
-    steps:
-      - name: Install Helm and Git
-        run: |
-          curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-          sudo apt-get install apt-transport-https --yes
-          echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt-get update
-          sudo apt-get install helm git
-      - name: Checkout code
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-        with:
-          fetch-depth: 0
-      - name: Lint Helm chart
-        run: helm lint charts/connaisseur
-      - name: Add annotation if it's a security release
-        run: bash scripts/security_annotation.sh
-      - name: Package and upload Helm chart
-        run: |
-          git config user.name "versioning_user"
-          git config user.email "connaisseur@securesystems.dev"
-          CHART_VERSION="${{ needs.build.outputs.chart_version }}"
-          helm package charts/connaisseur
-          git checkout . # Remove changes to Chart for git checkout
-          mkdir -p tmp_charts
-          mv connaisseur*.tgz ./tmp_charts
-          git checkout gh-pages
-          cd tmp_charts
-          helm repo index . --url https://sse-secure-systems.github.io/connaisseur/charts
-          cd ..
-          git add ./tmp_charts
-          git commit -m "Publish helm chart ${CHART_VERSION}"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/sse-secure-systems/connaisseur.git
-
-  publish_docs:
-    needs: [build, version-match, integration-test]
-    uses: ./.github/workflows/.reusable-docs.yaml
-    permissions:
-      contents: write
+    with:
+      chart_version: ${{ needs.build.outputs.chart_version }}


### PR DESCRIPTION
Allows a manual publish action to run the last stage of the release pipeline manually, circumventing prior checks.