### PR TITLE
ci: Adapt workflow files to new attestation permission

### DIFF
--- a/.github/workflows/.reusable-ci.yml
+++ b/.github/workflows/.reusable-ci.yml
@@ -119,10 +119,11 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
+      attestations: read
     secrets: inherit
     with:
       skip: ${{ needs.conditionals.outputs.skip_compliance_checks }}
- 
+
   unit-test:
     uses: ./.github/workflows/.reusable-unit-test.yml
     needs: [conditionals]

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
+      attestations: read
     secrets: inherit
     with:
       skip_build: "none"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
+      attestations: read
     secrets: inherit
     with:
       skip_build: "none"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
+      attestations: read
     secrets: inherit
     with:
       skip_build: 'none'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
+      attestations: read
     secrets: inherit
     with:
       skip_build: "none"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes the CI after a new permission was added that is now missing from our default-deny list

Context: https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
