### PR TITLE
fix: Fix handling of undefined values in values.yaml

### DIFF
--- a/charts/connaisseur/templates/env.yaml
+++ b/charts/connaisseur/templates/env.yaml
@@ -6,17 +6,15 @@ metadata:
   labels:
     {{- include "connaisseur.labels" . | nindent 4 }}
 data:
-  {{- with .Values.application.features }}
-  AUTOMATIC_CHILD_APPROVAL: {{ print .automaticChildApproval | default "true" | quote }}
-  AUTOMATIC_UNCHANGED_APPROVAL: {{ print .automaticUnchangedApproval | default "false" | quote }}
-  DETECTION_MODE: {{ print .detectionMode | default "false" | quote }}
-  RESOURCE_VALIDATION_MODE: {{ print .resourceValidationMode | default "all" | quote }}
-  {{- with .cache }}
-  CACHE_EXPIRY_SECONDS: {{ print .expirySeconds | default 30 | quote }}
-  CACHE_ERRORS: {{ print .cacheErrors | default "true" | quote }}
+  {{- with .Values.application }}
+  AUTOMATIC_CHILD_APPROVAL: {{ dig "features" "automaticChildApproval" true . | quote }}
+  AUTOMATIC_UNCHANGED_APPROVAL: {{ dig "features" "automaticUnchangedApproval" false . | quote }}
+  DETECTION_MODE: {{ dig "features" "detectionMode" false . | quote }}
+  RESOURCE_VALIDATION_MODE: {{ dig "features" "resourceValidationMode" "all" . | quote }}
+  CACHE_EXPIRY_SECONDS: {{ dig "features" "cache" "expirySeconds" 30 . | quote }}
+  CACHE_ERRORS: {{ dig "features" "cache" "cacheErrors" true . | quote }}
+  LOG_LEVEL: {{ dig "logLevel" "info" . | quote }}
   {{- end }}
-  {{- end }}
-  LOG_LEVEL: {{ .Values.application.logLevel | default "info" | quote }}
 ---
 {{- if .Values.kubernetes.deployment.envs -}}
 apiVersion: v1

--- a/charts/connaisseur/templates/role.yaml
+++ b/charts/connaisseur/templates/role.yaml
@@ -1,4 +1,4 @@
-{{ if print .Values.application.features.automaticChildApproval | default "true" | lower | eq "true" }}
+{{ if dig "features" "automaticChildApproval" "true" .Values.application | toString | lower | eq "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/connaisseur/templates/rolebinding.yaml
+++ b/charts/connaisseur/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if print .Values.application.features.automaticChildApproval | default "true" | lower | eq "true" }}
+{{ if dig "features" "automaticChildApproval" "true" .Values.application | toString | lower | eq "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION

## Description

Before this commit, there were different cases where Connaisseur mishandled default values in its config, if their parent keys were not set in the values.yaml. Resulting errors could've been anything between inconsequential (additional log entry) and fatal (e.g. missing deployment of Role). This commit fixes handling of these values.




<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
