### PR TITLE
update: dependabot ignore golang update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
     commit-message:
       prefix: "update"
     target-branch: "develop"
+    ignore:
+      - dependency-name: "golang"
+        versions: ['> 1.21']
     groups:
       docker-packages:
         patterns:


### PR DESCRIPTION
Dependabot should not update the golang version, since this will break Connaisseur quite easily.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
