### PR TITLE
fix: error handling for DER formated keys

### DIFF
--- a/internal/validator/notaryv1/notaryv1_validator.go
+++ b/internal/validator/notaryv1/notaryv1_validator.go
@@ -215,6 +215,9 @@ func (nv1v *NotaryV1Validator) trustRootKeys(keyRef string) ([]data.PublicKey, e
 
 	for _, tr := range trs {
 		pubDecode, rest := pem.Decode([]byte(tr.Key))
+		if pubDecode == nil {
+			return nil, fmt.Errorf("error decoding public key %s: wrong format, provide a PEM encoded public key", tr.Name)
+		}
 		pub, err := x509.ParsePKIXPublicKey(pubDecode.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing public key %s: %s", tr.Name, err)

--- a/internal/validator/notaryv1/notaryv1_validator_test.go
+++ b/internal/validator/notaryv1/notaryv1_validator_test.go
@@ -277,6 +277,14 @@ func TestValidateImage(t *testing.T) {
 			"",
 			"doesn't match given digest",
 		},
+		{ // 16: Root key in DER format
+			"15_DER_key_format",
+			"never-expire-image:sign",
+			"default",
+			[]string{},
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			"wrong format, provide a PEM encoded public key",
+		},
 	}
 
 	for idx, tc := range testCases {

--- a/test/testdata/notaryv1/15_DER_key_format.yaml
+++ b/test/testdata/notaryv1/15_DER_key_format.yaml
@@ -1,0 +1,8 @@
+name: default
+type: notaryv1
+host: notary.docker.io
+trustRoots:
+  - name: default
+    key: |
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUaqgujac1VCdaGHKQMKoDn6/deWJ
+      8cCzsnDqGDgjPBayhJCQiI/qN+iBWEUPM7BkrCyDS878h+qd/MdZS22XwA==


### PR DESCRIPTION
When using a nv1 validator and provide DER formated keys, Connaisseur panics as it tries to load a nil key. This has been fix with a fitting error message.

fixes #1594

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
