### PR TITLE
docs: fix secret file reference

### DIFF
--- a/docs/validators/notaryv1.md
+++ b/docs/validators/notaryv1.md
@@ -185,7 +185,7 @@ For more information on TUF roles, please refer to [TUF's documentation](https:/
 | `trustRoots[*].name` | - | :heavy_check_mark: | See [basics](../basics.md#validators). Setting the name of trust root to "*" implements a logical `and` and enables multiple signature verification under any trust root in the validator.  |
 | `trustRoots[*].key` | - | :heavy_check_mark: | See [basics](../basics.md#validators). TUF public root key. |
 | `auth` | - | - | Authentication credentials for the Notary server in case the trust data is not public. |
-| `auth.secretName` | - | - | (Preferred over `username` + `password` combination.) Name of a Kubernetes secret that must exist in Connaisseur namespace beforehand. Create a file `auth.yaml` containing:<br/>&nbsp; `username: <user>` <br/>&nbsp; `password: <password>` <br/>Run `kubectl create secret generic <kube-secret-name> --from-file auth.yaml -n connaisseur` to create the secret.|
+| `auth.secretName` | - | - | (Preferred over `username` + `password` combination.) Name of a Kubernetes secret that must exist in Connaisseur namespace beforehand. Create a file `secret.yaml` containing:<br/>&nbsp; `username: <user>` <br/>&nbsp; `password: <password>` <br/>Run `kubectl create secret generic <kube-secret-name> --from-file secret.yaml -n connaisseur` to create the secret.|
 | `auth.username` | - | - | Username to authenticate with[^2]. |
 | `auth.password` | - | - | Password or access token to authenticate with[^2]. |
 | `cert` | - | - | Self-signed certificate of the Notary instance, if used. Certificate must be supplied in `.pem` format. |


### PR DESCRIPTION
With the switch to Golang the authentication secrets require to be named `secret.yaml` instead of the previous `auth.yaml`. This has been fixed in the documentation.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
