### PR TITLE
ci: Fix manual publish job

### DIFF
--- a/.github/workflows/.reusable-docs.yaml
+++ b/.github/workflows/.reusable-docs.yaml
@@ -9,6 +9,12 @@ on:
         description: "Want to skip running certain jobs 'none', 'non-required', 'all'?"
         type: string
         default: "none"
+      application_version:
+        description: "Version of the Connaisseur application (same as Git release tag, without v prefix)"
+        type: string
+      latest_docs:
+        description: "Whether the docs corresponding to the application version are to be marked as latest docs"
+        type: boolean
 
 jobs:
   deploy:
@@ -35,9 +41,22 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" == "refs/tags/v"* ]];
           then
+            echo "Releasing latest docs ${RELEASE_VERSION}..."
             mike deploy --push --update-aliases ${RELEASE_VERSION} latest
           elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
+            echo 'Releasing docs for develop...'
             mike deploy --push ${RELEASE_VERSION}
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${{ inputs.application_version }}" && -n "${{ inputs.latest_docs }}" ]]; then
+            LATEST="${{ inputs.latest_docs }}"
+            DOCS_VERSION="v${{ inputs.application_version }}" # Add v prefix
+            if [[ "${LATEST}" == "true" ]]; then
+              echo "Manual release of docs for version ${DOCS_VERSION} as latest..."
+               mike deploy --push --update-aliases ${DOCS_VERSION} latest
+            else
+              echo "Manual release of docs for version ${DOCS_VERSION}..."
+              mike deploy --push ${DOCS_VERSION}
+            fi
           else
+            echo 'Building docs...'
             mkdocs build
           fi

--- a/.github/workflows/.reusable-publish.yml
+++ b/.github/workflows/.reusable-publish.yml
@@ -4,8 +4,15 @@ on:
   workflow_call:
     inputs:
       chart_version:
-        description: "Version of the connaisseur helm chart to publish"
+        description: "Version of the Connaisseur Helm chart to publish"
         type: string
+        required: true
+      application_version:
+        description: "Version of the Connaisseur application (same as Git release tag, without v prefix)"
+        type: string
+      latest_docs:
+        description: "Whether the docs corresponding to the application version are to be marked as latest docs"
+        type: boolean
 
 permissions:
   contents: write
@@ -51,3 +58,6 @@ jobs:
     uses: ./.github/workflows/.reusable-docs.yaml
     permissions:
       contents: write
+    with:
+      application_version: ${{ inputs.application_version }}
+      latest_docs: ${{ inputs.latest_docs }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,17 @@ on:
   workflow_dispatch:
     inputs:
       chart_version:
-        description: "Version of the connaisseur helm chart to publish"
+        description: "Version of the Connaisseur Helm chart to publish"
         type: string
+        required: true
+      application_version:
+        description: "Version of the Connaisseur application (same as Git release tag, without v prefix)"
+        type: string
+        required: true
+      latest_docs:
+        description: "Whether the docs corresponding to the application version are to be marked as latest docs"
+        type: boolean
+        required: true
 
 jobs:
   publish:
@@ -16,3 +25,5 @@ jobs:
       contents: write
     with:
       chart_version: ${{ inputs.chart_version }}
+      application_version: ${{ inputs.application_version }}
+      latest_docs: ${{ inputs.latest_docs }}


### PR DESCRIPTION
## Description
This commit changes the docs workflow to also publish docs when the manual publish job is used. Previously, the manual publish job did run the docs publishing job, which then only built but did not deploy the documentation.


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
