### PR TITLE
build: unpin ca certificates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -o /go/bin ./cmd/connaisseur
 
 FROM alpine:3 as certs
-RUN apk --update --no-cache add ca-certificates=20240226-r0
+# hadolint ignore=DL3018
+RUN apk --update --no-cache add ca-certificates
 
 FROM scratch
 


### PR DESCRIPTION
The version for the ca-certificates package, installed during an intermediate build step from an alpine image, is being unpinned. Reason for that is that alpine only ever provides a single version for their packages and once they update the ca-certificates packages, the Connaisseur build automatically fails, since the previous used version is no longer available.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
