### PR TITLE
test: fix flakey redis-cert test

### DIFF
--- a/test/integration/redis-cert/test.sh
+++ b/test/integration/redis-cert/test.sh
@@ -6,6 +6,9 @@ redis_cert_test() {
     update_with_file "redis-cert/install.yaml"
     install "make"
 
+    # wait for redis to be ready
+    wait_for_redis
+
     # create same image twice
     single_test "redis-cert-01-signed" "Testing signed nv1 image..." "deploy" "securesystemsengineering/testimage:signed" "default" "" "null"
     single_test "redis-cert-02-cached" "Testing signed nv1 image using cache..." "deploy" "securesystemsengineering/testimage:signed" "default" "" "null"
@@ -24,6 +27,9 @@ redis_cert_test() {
     update_with_file "redis-cert/update.yaml"
     upgrade "make"
 
+    # wait for redis to be ready
+    wait_for_redis
+
     # create same image twice
     single_test "redis-cert-03-signed" "Testing signed nv1 image again..." "deploy" "securesystemsengineering/testimage:signed" "default" "" "null"
     single_test "redis-cert-04-cached" "Testing signed nv1 image using cache again..." "deploy" "securesystemsengineering/testimage:signed" "default" "" "null"
@@ -38,4 +44,13 @@ redis_cert_test() {
         EXIT="1"
     fi
     rm output.log
+}
+
+wait_for_redis() {
+    timeout 30 bash -c '
+    while true; do
+        kubectl logs -n connaisseur -lapp.kubernetes.io/instance=redis --tail=-1 | grep -q  "Ready to accept connections tls" && break
+        sleep 1
+    done
+    ' || true
 }


### PR DESCRIPTION
The redis cert test tested that after upgrading a redis with a custom certificate the caching mechanism still worked. Problem was, the redis instance might have been ready on Kubernetes side, but internally not ready to receive connections. Thus the caching was tested and failed, before the newly upgraded redis was ready. This has been fixed with a wating mechanism.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
