### PR TITLE
fix: correctly place connaisseur-env-secret in deployment yaml

### DIFF
--- a/charts/connaisseur/templates/deployment.yaml
+++ b/charts/connaisseur/templates/deployment.yaml
@@ -68,15 +68,15 @@ spec:
           - secretRef:
               name: {{ include "connaisseur.redisSecret" . }}
           {{- end }}
-          env:
-          {{ if gt (dig "features" "cache" "expirySeconds" 30 .Values.application | int) 0 -}}
-          - name: REDIS_HOST
-            value: {{ include "connaisseur.redisService" . }}
-          {{- end }}
           {{ if .Values.kubernetes.deployment.envs -}}
           - secretRef:
               name: {{ include "connaisseur.envSecretName" . }}
           {{- end }}
+          env:
+          {{ if gt (dig "features" "cache" "expirySeconds" 30 .Values.application | int) 0 -}}
+          - name: REDIS_HOST
+            value: {{ include "connaisseur.redisService" . }}
+          {{- end }}       
       volumes:
         - name: certs
           secret:


### PR DESCRIPTION
From chart version 2.4, a refactor was made that places `connaisseur-env-secret` under `env` instead of under `envFrom` in the deployment.This breaks cosign validations that require custom secrets like ECR
Relevant helm template commands were run to ensure chart compiles correctly with `kubernetes.deployment.envs` values populated and not populated 

Related issue: https://github.com/sse-secure-systems/connaisseur/issues/1734
