### PR TITLE
fix: correctly place connaisseur-env-secret in deployment yaml

### DIFF
--- a/charts/connaisseur/Chart.yaml
+++ b/charts/connaisseur/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.6.0
+version: 2.6.1
 appVersion: 3.6.0
 keywords:
   - container image

--- a/charts/connaisseur/templates/deployment.yaml
+++ b/charts/connaisseur/templates/deployment.yaml
@@ -68,15 +68,15 @@ spec:
           - secretRef:
               name: {{ include "connaisseur.redisSecret" . }}
           {{- end }}
-          env:
-          {{ if gt (dig "features" "cache" "expirySeconds" 30 .Values.application | int) 0 -}}
-          - name: REDIS_HOST
-            value: {{ include "connaisseur.redisService" . }}
-          {{- end }}
           {{ if .Values.kubernetes.deployment.envs -}}
           - secretRef:
               name: {{ include "connaisseur.envSecretName" . }}
           {{- end }}
+          env:
+          {{ if gt (dig "features" "cache" "expirySeconds" 30 .Values.application | int) 0 -}}
+          - name: REDIS_HOST
+            value: {{ include "connaisseur.redisService" . }}
+          {{- end }}       
       volumes:
         - name: certs
           secret:


### PR DESCRIPTION
Duplicate of #1735 because of pipeline permission issues ... 😞 

From chart version 2.4, a refactor was made that places connaisseur-env-secret under 'env' instead of under 'envFrom' in the deployment.This breaks cosign validations that require custom secrets like ECR


Fixes #1734

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
