### PR TITLE
feat: ability to override redis image in values.yaml

### DIFF
--- a/charts/connaisseur/templates/redis.yaml
+++ b/charts/connaisseur/templates/redis.yaml
@@ -51,7 +51,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: redis
-        image: redis:7
+        image: {{ .Values.kubernetes.redis.image.repository }}:{{ .Values.kubernetes.redis.image.tag }}
         imagePullPolicy: {{ .Values.kubernetes.redis.pullPolicy }}
         args:
           - --requirepass

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -71,6 +71,9 @@ kubernetes:
 
   # changes to redis key-value store
   redis:
+    image:
+      repository: redis
+      tag: 7
     pullPolicy: Always
     resources:
       limits:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #1794 

## Description
This commit adds the ability to override redis image repository and tag from the values.yaml file. Currently, this is hardcoded.
<!--- Provide a short description of the PR: why? how? -->


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [X] PR is rebased to/aimed at branch `develop`
- [X] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [X] Added tests (if necessary)
- [X] Extended README/Documentation (if necessary)
- [X] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
