### PR TITLE
ci: Deparallelize publish jobs

### DIFF
--- a/.github/workflows/.reusable-publish.yml
+++ b/.github/workflows/.reusable-publish.yml
@@ -56,6 +56,7 @@ jobs:
 
   publish_docs:
     uses: ./.github/workflows/.reusable-docs.yaml
+    needs: [publish_chart]
     permissions:
       contents: write
     with:


### PR DESCRIPTION
Before, both publish jobs tried to change the gh-pages branch simultaneously, often leading to failed jobs which needed to be retried manually. This commit adds a dependency such that the jobs run after one another.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
