### PR TITLE
ci: Set fallback AWS repository for ratelimited trivy DBs

### DIFF
--- a/.github/actions/trivy-config/action.yaml
+++ b/.github/actions/trivy-config/action.yaml
@@ -17,21 +17,21 @@ runs:
         helm template charts/connaisseur > deployment/deployment.yaml
       shell: bash
     - name: Scan deployment.yaml
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       if: inputs.output == 'table'
       with:
         scan-type: "config"
         scan-ref: "deployment"
         format: 'table'
     - name: Scan Dockerfiles
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       if: inputs.output == 'table'
       with:
         scan-type: "config"
         scan-ref: "build"
         format: 'table'
     - name: Scan deployment.yaml
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       if: inputs.output == 'sarif'
       with:
         scan-type: "config"
@@ -39,7 +39,7 @@ runs:
         format: 'sarif'
         output: 'reports/trivy-k8s-results.sarif'
     - name: Scan Dockerfiles
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       if: inputs.output == 'sarif'
       with:
         scan-type: "config"

--- a/.github/actions/trivy-image/action.yaml
+++ b/.github/actions/trivy-image/action.yaml
@@ -39,6 +39,9 @@ runs:
         scan-type: "image"
         format: 'sarif'
         output: 'reports/trivy-vuln-results.sarif'
+      env:
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
     - name: Run Trivy on image
       if: inputs.output == 'table'
       uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
@@ -47,6 +50,9 @@ runs:
         scan-type: "image"
         exit-code: 1
         format: 'table'
+      env:
+        TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
+        TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db # Workaround for https://github.com/aquasecurity/trivy-action/issues/389
     - name: Upload
       if: inputs.output == 'sarif'
       uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2.2.5

--- a/.github/actions/trivy-image/action.yaml
+++ b/.github/actions/trivy-image/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: sh
     - name: Run Trivy on image
       if: inputs.output == 'sarif'
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       with:
         image-ref: ${{ inputs.image }}
         scan-type: "image"
@@ -41,7 +41,7 @@ runs:
         output: 'reports/trivy-vuln-results.sarif'
     - name: Run Trivy on image
       if: inputs.output == 'table'
-      uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f # v0.12.0
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
       with:
         image-ref: ${{ inputs.image }}
         scan-type: "image"

--- a/.github/workflows/.reusable-sca.yml
+++ b/.github/workflows/.reusable-sca.yml
@@ -37,8 +37,6 @@ jobs:
     permissions:
       packages: read
       security-events: write
-    container:
-      image: docker:stable
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Description

Recently, trivy scans failed due to ratelimiting on the pull of its vulnerability DBs. See https://github.com/aquasecurity/trivy-action/issues/389. This PR adds a fallback download URI pointing to the official AWS artifacts.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
