### PR TITLE
fix: validation mode lower case

### DIFF
--- a/internal/handler/validation/validation.go
+++ b/internal/handler/validation/validation.go
@@ -9,7 +9,6 @@ import (
 	"connaisseur/internal/utils"
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -161,7 +160,7 @@ func ValidateImage(ctx context.Context, in ValidationInput, out chan<- Validatio
 	logrus.Debugf("validator: %s", validatorName)
 
 	// get validation mode
-	switch strings.ToLower(rule.With.ValidationMode) {
+	switch rule.With.ValidationMode {
 	case constants.MutateMode:
 		validationMode = constants.MutateMode
 	case constants.ValidateMode:


### PR DESCRIPTION
The check on the validation mode is done by lower casing the input and comparing it to a constant. Unfortunately the constant wasn\'t entirely lower case. This has been fixed.

fixes #1816

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
