### PR TITLE
fix: Change security context of Redis image to match redis user

### DIFF
--- a/charts/connaisseur/Chart.yaml
+++ b/charts/connaisseur/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.7.0
-appVersion: 3.7.0
+version: 2.7.1
+appVersion: 3.7.1
 keywords:
   - container image
   - signature

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -90,8 +90,8 @@ kubernetes:
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: true
-      runAsUser: 10001 # remove when using openshift or OKD 4
-      runAsGroup: 20001 # remove when using openshift or OKD 4
+      runAsUser: 999 # redis user id; remove when using openshift or OKD 4
+      runAsGroup: 999 # redis group id; remove when using openshift or OKD 4
       seccompProfile: # remove when using Kubernetes prior v1.19, openshift or OKD 4
         type: RuntimeDefault # remove when using Kubernetes prior v1.19, openshift or OKD 4
     podSecurityContext: {}


### PR DESCRIPTION
Previously, we set the default security context of the Redis to a user/group not taken. This could cause problems with permissions, resulting in error logs and shutdown delays, thus this commit changes the default user/group to reflect the built-in redis user.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #1764 

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
