### PR TITLE
ci: remove docker package installation

### DIFF
--- a/.github/workflows/107_integration-test.yml
+++ b/.github/workflows/107_integration-test.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt update
-          sudo apt install docker notary expect
+          sudo apt install notary expect
           sudo snap install yq
       - name: Setup notary signer service
         id: signer_service


### PR DESCRIPTION
The docker package is already installed in the ubunutu version of github runners and thus doesn't need to be installed. Also the package no longer is available in the default apt repositories anyways.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
