### PR TITLE
test: Replace official Docker images with custom images

### DIFF
--- a/.github/workflows/104_sast.yml
+++ b/.github/workflows/104_sast.yml
@@ -161,8 +161,15 @@ jobs:
           scan-ref: build
           format: ${{ inputs.output }}
           output: ${{ inputs.output == 'sarif' && 'reports/trivy-docker-results.sarif' || '' }}
-      - name: Upload
+      - name: Upload k8s report
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         if: inputs.output == 'sarif'
         with:
-          sarif_file: 'reports'
+          sarif_file: 'reports/trivy-k8s-results.sarif'
+          category: 'k8s'
+      - name: Upload docker report
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        if: inputs.output == 'sarif'
+        with:
+          sarif_file: 'reports/trivy-docker-results.sarif'
+          category: 'docker'

--- a/charts/connaisseur/Chart.yaml
+++ b/charts/connaisseur/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.8.4
-appVersion: 3.8.4
+version: 2.8.5
+appVersion: 3.8.5
 keywords:
   - container image
   - signature

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -121,12 +121,6 @@ application:
     - name: dockerhub
       type: notaryv1
       trustRoots:
-        - name: default # root from dockerhub
-          key: |
-            -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
-            -----END PUBLIC KEY-----
         - name: sse # root from sse
           key: |
             -----BEGIN PUBLIC KEY-----
@@ -139,8 +133,10 @@ application:
   policy:
     - pattern: "*:*"
       validator: deny
-    - pattern: "docker.io/library/*:*"
-      validator: dockerhub
+    # since Docker Content Trust is deprecated, we need to statically allow redis:7 which used to be signed by Docker Hub
+    # only required if caching is enabled
+    - pattern: "docker.io/library/redis:7"
+      validator: allow
     - pattern: "docker.io/securesystemsengineering/*:*"
       validator: dockerhub
       with:

--- a/test/integration/common_functions.sh
+++ b/test/integration/common_functions.sh
@@ -69,13 +69,13 @@ search_for_minikube() {
 }
 
 ## INSTALLATIONS ---------------------------------------------- ##
-install() { # $1: helm or make, $2: namespace, $3: additional helm args $4: create ns flag
+install() { # $1: helm, make or release, $2: namespace, $3: additional helm args $4: create ns flag
     ARGS=$(printf '%s --set kubernetes.additionalLabels.use=connaisseur-integration-test' "${3:-}")
 
     if ghcr_case; then
         create_ghcr_image_pull_secret ${2:-connaisseur} ${4:-true}
     fi
-    
+
     echo -n "Installing Connaisseur using $1..."
     case $1 in
     "helm")
@@ -195,7 +195,7 @@ single_test() { # ID TXT TYP REF NS MSG RES
     echo -n "[$1] $2"
     i=0                                                              # intialize iterator
     export RAND=$(head -c 5 /dev/urandom | hexdump -ve '1/1 "%.2x"') # creating a random index to label the pods and avoid name collision for repeated runs
-    
+
     if [[ "$6" == "" ]]; then
         MSG="pod/pod-$1-${RAND} created"
     else

--- a/test/integration/complexity/complex_deployment.yaml
+++ b/test/integration/complexity/complex_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: redis-with-many-instances
+  name: no-longer-redis-with-many-instances
   labels:
     use: connaisseur-integration-test
 spec:
@@ -15,8 +15,8 @@ spec:
         app: redis
     spec:
       containers:
-        - name: redis
-          image: redis
+        - name: no-longer-redis
+          image: securesystemsengineering/testimage:signed
 ---
 apiVersion: v1
 kind: Pod
@@ -27,20 +27,20 @@ metadata:
 spec:
   containers:
     - name: container1
-      image: busybox
+      image: securesystemsengineering/testimage:signed
       command: ['sh', '-c', 'sleep 3600']
     - name: container2
-      image: redis
+      image: securesystemsengineering/testimage:signed2
     - name: container3
-      image: mongo
+      image: securesystemsengineering/testimage:signed3
     - name: container4
-      image: nginx
+      image: securesystemsengineering/testimage:signed4
     - name: container5
-      image: rabbitmq
+      image: securesystemsengineering/testimage:signed5
     - name: container6
-      image: elasticsearch
+      image: securesystemsengineering/testimage:signed6
     - name: container7
-      image: sonarqube
+      image: securesystemsengineering/testimage:signed7
 ---
 apiVersion: v1
 kind: Pod
@@ -51,27 +51,27 @@ metadata:
 spec:
   containers:
     - name: container1
-      image: busybox
+      image: securesystemsengineering/testimage:signed
       command: ['sh', '-c', 'sleep 3600']
     - name: container2
-      image: redis
+      image: securesystemsengineering/testimage:signed2
     - name: container3
-      image: mongo
+      image: securesystemsengineering/testimage:signed3
     - name: container4
-      image: nginx
+      image: securesystemsengineering/testimage:signed4
     - name: container5
-      image: rabbitmq
+      image: securesystemsengineering/testimage:signed5
     - name: container6
-      image: elasticsearch
+      image: securesystemsengineering/testimage:signed6
     - name: container7
-      image: sonarqube
+      image: securesystemsengineering/testimage:signed7
   initContainers:
     - name: init2
-      image: maven
+      image: securesystemsengineering/testimage:signed8
     - name: init3
-      image: vault
+      image: securesystemsengineering/testimage:signed9
     - name: init4
-      image: postgres
+      image: securesystemsengineering/testimage:signed10
 ---
 apiVersion: v1
 kind: Pod
@@ -82,21 +82,21 @@ metadata:
 spec:
   containers:
     - name: container1
-      image: busybox
+      image: securesystemsengineering/testimage:signed
       command: ['sh', '-c', 'sleep 3600']
     - name: container2
-      image: redis
+      image: securesystemsengineering/testimage:signed2
     - name: container3
-      image: mongo
+      image: securesystemsengineering/testimage:signed3
     - name: container4
-      image: nginx
+      image: securesystemsengineering/testimage:signed4
   initContainers:
     - name: container5
-      image: rabbitmq
+      image: securesystemsengineering/testimage:signed5
     - name: container6
-      image: elasticsearch
+      image: securesystemsengineering/testimage:signed6
     - name: container7
-      image: sonarqube
+      image: securesystemsengineering/testimage:signed7
 ---
 apiVersion: v1
 kind: Pod
@@ -107,17 +107,17 @@ metadata:
 spec:
   containers:
     - name: container1
-      image: busybox
+      image: securesystemsengineering/testimage:signed
       command: ['sh', '-c', 'sleep 3600']
     - name: container2
-      image: redis
+      image: securesystemsengineering/testimage:signed2
     - name: container3
-      image: mongo
+      image: securesystemsengineering/testimage:signed3
   initContainers:
     - name: init1
-      image: busybox
+      image: securesystemsengineering/testimage:signed4
       command: ['sh', '-c', 'sleep 3600']
     - name: init2
-      image: redis
+      image: securesystemsengineering/testimage:signed5
     - name: init3
-      image: mongo
+      image: securesystemsengineering/testimage:signed6

--- a/test/integration/complexity/install.yaml
+++ b/test/integration/complexity/install.yaml
@@ -7,8 +7,8 @@ application:
         - name: default
           key: |
             -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+            d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
             -----END PUBLIC KEY-----
   policy:
     - pattern: "*:*"

--- a/test/integration/complexity/test.sh
+++ b/test/integration/complexity/test.sh
@@ -11,7 +11,7 @@ complexity_test() {
 create_complexity() {
     echo -n 'Testing Connaisseur with complex requests...'
     kubectl apply -f test/integration/complexity/complex_deployment.yaml >output.log 2>&1 || true
-    if [[ ! ("$(cat output.log)" =~ 'deployment.apps/redis-with-many-instances created' && "$(cat output.log)" =~ 'pod/pod-with-many-containers created' && "$(cat output.log)" =~ 'pod/pod-with-many-containers-and-init-containers created' && "$(cat output.log)" =~ 'pod/pod-with-some-containers-and-init-containers created' && "$(cat output.log)" =~ 'pod/pod-with-coinciding-containers-and-init-containers created') ]]; then
+    if [[ ! ("$(cat output.log)" =~ 'deployment.apps/no-longer-redis-with-many-instances created' && "$(cat output.log)" =~ 'pod/pod-with-many-containers created' && "$(cat output.log)" =~ 'pod/pod-with-many-containers-and-init-containers created' && "$(cat output.log)" =~ 'pod/pod-with-some-containers-and-init-containers created' && "$(cat output.log)" =~ 'pod/pod-with-coinciding-containers-and-init-containers created') ]]; then
         echo -e ${FAILED}
         echo "::group::Output"
         cat output.log

--- a/test/integration/deployment/deployments/deployment_i1.yaml
+++ b/test/integration/deployment/deployments/deployment_i1.yaml
@@ -16,7 +16,7 @@ spec:
         app: i1
     spec:
       containers:
-        - name: nginx
-          image: nginx:1.14.2
+        - name: no-longer-nginx
+          image: securesystemsengineering/testimage:signed
           ports:
             - containerPort: 80

--- a/test/integration/deployment/deployments/deployment_i2.yaml
+++ b/test/integration/deployment/deployments/deployment_i2.yaml
@@ -16,8 +16,8 @@ spec:
         app: i2
     spec:
       containers:
-        - name: nginx
-          image: nginx:1.14.2
+        - name: no-longer-nginx
+          image: securesystemsengineering/testimage:signed
           ports:
             - containerPort: 80
         - name: signed-testimg

--- a/test/integration/deployment/deployments/deployment_i2i.yaml
+++ b/test/integration/deployment/deployments/deployment_i2i.yaml
@@ -16,13 +16,13 @@ spec:
         app: i2i
     spec:
       containers:
-        - name: nginx
-          image: nginx:1.14.2
+        - name: no-longer-nginx
+          image: securesystemsengineering/testimage:signed
           ports:
             - containerPort: 80
         - name: signed-testimg
           image: securesystemsengineering/testimage:co-signed
       initContainers:
         - name: waiter
-          image: busybox:1.28
+          image: securesystemsengineering/testimage:signed
           command: ['sh', '-c', 'sleep 10']

--- a/test/integration/deployment/deployments/deployment_i2ui.yaml
+++ b/test/integration/deployment/deployments/deployment_i2ui.yaml
@@ -16,8 +16,8 @@ spec:
         app: i2-uinit
     spec:
       containers:
-        - name: nginx
-          image: nginx:1.14.2
+        - name: no-longer-nginx
+          image: securesystemsengineering/testimage:signed
           ports:
             - containerPort: 80
         - name: signed-testimg

--- a/test/integration/deployment/install.yaml
+++ b/test/integration/deployment/install.yaml
@@ -1,14 +1,14 @@
 application:
   validators:
-    - name: dockerhub
+    - name: no-longer-dockerhub
       type: notaryv1
       host: notary.docker.io
       trustRoots:
-        - name: docker
+        - name: no-longer-docker
           key: |
             -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+            d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
             -----END PUBLIC KEY-----
         - name: sse
           key: |
@@ -27,11 +27,11 @@ application:
             -----END PUBLIC KEY-----
   policy:
     - pattern: "*:*"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
-        trustRoot: docker
+        trustRoot: no-longer-docker
     - pattern: "securesystemsengineering/testimage"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: sse
     - pattern: "securesystemsengineering/testimage:co-*"

--- a/test/integration/load/install.yaml
+++ b/test/integration/load/install.yaml
@@ -7,8 +7,8 @@ application:
         - name: default
           key: |
             -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+            d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
             -----END PUBLIC KEY-----
   policy:
     - pattern: "*:*"

--- a/test/integration/load/load.yaml
+++ b/test/integration/load/load.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: redis-${index}
+  name: no-longer-redis-${index}
   labels:
     use: connaisseur-integration-test
 spec:
@@ -15,5 +15,5 @@ spec:
         use: connaisseur-integration-test
     spec:
       containers:
-        - name: redis
-          image: redis
+        - name: no-longer-redis
+          image: securesystemsengineering/testimage:signed

--- a/test/integration/load/test.sh
+++ b/test/integration/load/test.sh
@@ -5,7 +5,7 @@ create_load() {
     NUMBER_OF_INSTANCES=100
     echo -n 'Testing Connaisseur with many requests...'
     parallel --jobs 20 test/integration/load/cause_load.sh {1} :::: <(seq ${NUMBER_OF_INSTANCES}) >output.log 2>&1 || true
-    NUMBER_CREATED=$(cat output.log | grep "deployment[.]apps/redis-[0-9]* created" | wc -l || echo "0")
+    NUMBER_CREATED=$(cat output.log | grep "deployment[.]apps/no-longer-redis-[0-9]* created" | wc -l || echo "0")
     if [[ ${NUMBER_CREATED} != "${NUMBER_OF_INSTANCES}" ]]; then
         echo -e ${FAILED}
         echo "::group::Output"

--- a/test/integration/notaryv1/cases.yaml
+++ b/test/integration/notaryv1/cases.yaml
@@ -24,7 +24,7 @@
 - id: diff-designated-signer
   txt: Testing image with differing designated signers...
   ref: securesystemsengineering/testimage:double_sig
-  expected_msg: validator dockerhub found 2 digests for image double_sig, expected 1
+  expected_msg: validator no-longer-dockerhub found 2 digests for image double_sig, expected 1
 
 # init container tests
 - id: signed-init-signed

--- a/test/integration/notaryv1/install.yaml
+++ b/test/integration/notaryv1/install.yaml
@@ -1,14 +1,14 @@
 application:
   validators:
-    - name: dockerhub
+    - name: no-longer-dockerhub
       type: notaryv1
       host: notary.docker.io
       trustRoots:
-        - name: docker
+        - name: no-longer-docker
           key: |
             -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+            d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
             -----END PUBLIC KEY-----
         - name: sse
           key: |
@@ -18,21 +18,21 @@ application:
             -----END PUBLIC KEY-----
   policy:
     - pattern: "*:*"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: "sse"
     - pattern: "securesystemsengineering/testimage:special_sig"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: "sse"
         delegations: ["starkteetje"]
     - pattern: "securesystemsengineering/testimage:wrong_signer"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: "sse"
         delegations: ["belitzphilipp"]
     - pattern: "securesystemsengineering/testimage:double_sig"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: "sse"
         delegations: ["belitzphilipp", "starkteetje"]

--- a/test/integration/pre-config/cases.yaml
+++ b/test/integration/pre-config/cases.yaml
@@ -7,13 +7,13 @@
   txt: Testing signed sse testimage...
   ref: securesystemsengineering/testimage:signed
 
-# testing docker official images
+# testing no-longer-docker official images
 - id: signed-docker-official
-  txt: Testing signed official docker image...
-  ref: docker.io/library/nginx
+  txt: Testing signed no-longer-official docker image...
+  ref: securesystemsengineering/testimage:signed
 - id: unsigned-docker-official
-  txt: Testing unsigned official docker image...
-  ref: docker.io/library/node
+  txt: Testing unsigned no-longer-official docker image...
+  ref: securesystemsengineering/testimage:unsigned
   expected_msg: error during notaryv1 validation
 
 # testing static deny

--- a/test/integration/self-hosted-notary/install.yaml
+++ b/test/integration/self-hosted-notary/install.yaml
@@ -9,15 +9,15 @@ application:
   - name: deny
     type: static
     approve: false
-  - name: dockerhub-basics
+  - name: no-longer-dockerhub-basics
     type: notaryv1
     host: notary.docker.io
     trustRoots:
-    - name: docker-official
+    - name: no-longer-docker-official
       key: |
         -----BEGIN PUBLIC KEY-----
-        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-        QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+        d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
         -----END PUBLIC KEY-----
     - name: securesystemsengineering-official
       key: |
@@ -53,11 +53,11 @@ application:
       -----END CERTIFICATE-----
   policy:
   - pattern: "*:*"
-    validator: dockerhub-basics
+    validator: no-longer-dockerhub-basics
     with:
-      trustRoot: "docker-official"
+      trustRoot: "no-longer-docker-official"
   - pattern: "docker.io/securesystemsengineering/*:*"
-    validator: dockerhub-basics
+    validator: no-longer-dockerhub-basics
     with:
       trustRoot: "securesystemsengineering-official"
   - pattern: "registry.k8s.io/*:*"

--- a/test/integration/workload/install.yaml
+++ b/test/integration/workload/install.yaml
@@ -6,14 +6,14 @@ application:
     - name: deny
       type: static
       approve: false
-    - name: dockerhub
+    - name: no-longer-dockerhub
       type: notaryv1
       trustRoots:
-        - name: default # root from dockerhub
+        - name: default # root no longer from dockerhub
           key: |
             -----BEGIN PUBLIC KEY-----
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOXYta5TgdCwXTCnLU09W5T4M4r9f
-            QQrqJuADP6U7g5r9ICgPSmZuRHP/1AYUfOQW3baveKsT969EfELKj1lfCA==
+            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsx28WV7BsQfnHF1kZmpdCTTLJaWe
+            d0CA+JOi8H4REuBaWSZ5zPDe468WuOJ6f71E7WFg3CVEVYHuoZt2UYbN/Q==
             -----END PUBLIC KEY-----
         - name: sse # root from sse
           key: |
@@ -25,9 +25,9 @@ application:
     - pattern: "*:*"
       validator: deny
     - pattern: "docker.io/library/*:*"
-      validator: dockerhub
+      validator: no-longer-dockerhub
     - pattern: "docker.io/securesystemsengineering/*:*"
-      validator: dockerhub
+      validator: no-longer-dockerhub
       with:
         trustRoot: sse
     - pattern: "registry.k8s.io/*:*"


### PR DESCRIPTION


## Description

The official Docker Content Trust certs started to expire, see https://www.docker.com/blog/retiring-docker-content-trust/. Since they will not be updated, all tests including previously signed official images fail. This commit adapts our tests to use our own test images instead


## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
