### PR TITLE
fix: Allow redis image to be deployed by digest and only allow current digest by default

### DIFF
--- a/charts/connaisseur/templates/redis.yaml
+++ b/charts/connaisseur/templates/redis.yaml
@@ -51,7 +51,11 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: redis
+        {{- if .Values.kubernetes.redis.image.digest }}
+        image: {{ .Values.kubernetes.redis.image.repository }}@sha256:{{ .Values.kubernetes.redis.image.digest }}
+        {{- else }}
         image: {{ .Values.kubernetes.redis.image.repository }}:{{ .Values.kubernetes.redis.image.tag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.kubernetes.redis.pullPolicy }}
         args:
           - --requirepass

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -74,6 +74,8 @@ kubernetes:
     image:
       repository: redis
       tag: 7
+      # digest supersedes tag
+      digest: "83edc2b8e9ffb1781a67bdab260a94674f802881838e20bba0f9a69d8cb40d70" # https://hub.docker.com/layers/library/redis/7/images/sha256-83edc2b8e9ffb1781a67bdab260a94674f802881838e20bba0f9a69d8cb40d70
     pullPolicy: Always
     resources:
       limits:
@@ -133,9 +135,9 @@ application:
   policy:
     - pattern: "*:*"
       validator: deny
-    # since Docker Content Trust is deprecated, we need to statically allow redis:7 which used to be signed by Docker Hub
+    # since Docker Content Trust is deprecated, we need to statically allow redis which used to be signed by Docker Hub
     # only required if caching is enabled
-    - pattern: "docker.io/library/redis:7"
+    - pattern: "docker.io/library/redis@sha256:83edc2b8e9ffb1781a67bdab260a94674f802881838e20bba0f9a69d8cb40d70"
       validator: allow
     - pattern: "docker.io/securesystemsengineering/*:*"
       validator: dockerhub

--- a/test/integration/redis-cert/install.yaml
+++ b/test/integration/redis-cert/install.yaml
@@ -21,5 +21,7 @@ application:
     validator: allow
   - pattern: "redis:*"
     validator: allow
+  - pattern: "redis@sha256:*"
+    validator: allow
   - pattern: "securesystemsengineering/testimage:*"
     validator: notaryv1

--- a/test/integration/redis-cert/update.yaml
+++ b/test/integration/redis-cert/update.yaml
@@ -75,5 +75,7 @@ application:
       validator: allow
     - pattern: "redis:*"
       validator: allow
+    - pattern: "redis@sha256:*"
+      validator: allow
     - pattern: "securesystemsengineering/testimage:*"
       validator: notaryv1


### PR DESCRIPTION


## Description

This allows deploying redis by digest, which in turn allows us to pin one specifc digest in our default values.yaml, which is a secure (though cumbersome) bandaid fix for docker official images currently not being signed

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
