### PR TITLE
docs: Upgrade docs announcement

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -4,11 +4,10 @@
   <!-- Add your announcement here, including arbitrary HTML -->
    <header style="font-size:17px">
         <!-- <center>&#11088; <strong> If you like Connaisseur, give it a star on <a href="https://github.com/sse-secure-systems/connaisseur">GitHub</a> or share your <a href="https://github.com/sse-secure-systems/connaisseur/discussions">feedback</a>!</strong> &#11088;</center> -->
-        <center>&#128680; <strong> Connaisseur 3.0 was released! Read about all <a href="{{ '../' ~ base_url ~ '/latest/migrating_to_version_3' }}">important changes</a>! </strong> &#128680;</center>
+        <center>&#128680; <strong> Docker Content Trust has been deprecated for Docker Official Images! This might break upgrades for existing installations. Read more on the related <a href="https://github.com/sse-secure-systems/connaisseur/discussions/1990">discussion</a>! </strong> &#128680;</center>
 {% endblock %}
 
 {% block outdated %}
 You're not viewing the docs of the latest version.
 <a href="{{ '../' ~ base_url  }}"><strong>Click here to go to the latest version.</strong></a>
 {% endblock %}
-


### PR DESCRIPTION


## Description

Upgrade docs announcement to reference upgrade issue due to DCT deprecation

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
