### PR TITLE
docs: Fix error showing trustRoot as required in policy for Cosign va…

### DIFF
--- a/docs/validators/sigstore_cosign.md
+++ b/docs/validators/sigstore_cosign.md
@@ -110,7 +110,7 @@ kubectl run altsigned --image=docker.io/securesystemsengineering/testimage:co-si
 
 | Key | Default | Required | Description |
 | - | - | - | - |
-| `with.trustRoot` | - | :heavy_check_mark: | Setting the name of trust root to `"*"` enables verification of multiple trust roots. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
+| `with.trustRoot` | - | - | Setting the name of trust root to `"*"` enables verification of multiple trust roots. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
 | `with.threshold` | - | - | Minimum number of signatures required in case `with.trustRoot` is set to `"*"`. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
 | `with.required` | `[]` | - | Array of required trust roots referenced by name in case `with.trustRoot` is set to `"*"`. Refer to section on [multi-signature verification](#multi-signature-verification) for more information. |
 | `with.verifyInTransparencyLog` | `true` | - | Whether to include the verification using the Rekor tranparency log in the verification process. Refer to [Tranparency log verification](#transparency-log-verification) for more information. |
@@ -381,7 +381,7 @@ host:
     -----BEGIN PUBLIC KEY-----
     ...
     -----END PUBLIC KEY-----
-  ctLogPubkey: | 
+  ctLogPubkey: |
     -----BEGIN PUBLIC KEY-----
     ...
     -----END PUBLIC KEY-----


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->


## Description
Fixes a small cosign documentation error, which indicated policy referencing a cosign validator required trustRoot, whereas in practice this defaults to the default trustRoot
<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
