### PR TITLE
feat: build multi-arch docker image for connaisseur

### DIFF
--- a/.github/workflows/101_build.yml
+++ b/.github/workflows/101_build.yml
@@ -163,7 +163,6 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: build/Dockerfile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

  <!--- Reference respective issue if it exists -->
  Fixes #1984 

  ## Description

  This PR adds support for building multi-architecture Docker images for Connaisseur, enabling deployment on both AMD64 and ARM64 platforms.

  ### Why?
  Currently, Connaisseur Docker images are built only for the host architecture. This limits deployment options, particularly for ARM-based systems such as:
  - Apple Silicon (M1/M2/M3 Macs)
  - AWS Graviton instances
  - ARM-based Kubernetes clusters
  - Raspberry Pi and other ARM servers

  ### How?
  - **Makefile**: Added new `docker-multiarch` target for local multi-platform builds with explicit platform specification (`linux/amd64`, `linux/arm64`)
  - **CI/CD**: Updated `.github/workflows/101_build.yml` to build and push multi-arch images automatically by adding `platforms: linux/amd64,linux/arm64` to the build-push-action
  - **Backward Compatibility**: Maintained the existing `docker` target for single-platform local builds used in development workflows

 
  ## Checklist
  <!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

  - [ ] PR is rebased to/aimed at branch `develop`
  - [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
  - [x] Added tests (if necessary) - No new tests needed; existing integration tests cover functionality
  - [x] Extended README/Documentation (if necessary) - Makefile comments added; no user-facing documentation changes needed
  - [ ] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary) - Not necessary for this change