### PR TITLE
docs: Update nv1/nv2 mentions following notation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Based on the result, it either accepts or denies those requests.
 Connaisseur is developed under three core values: *Security*, *Usability*, *Compatibility*.
 It is built to be extendable and currently aims to support the following signing solutions:
 
-- [Notary V1](https://github.com/theupdateframework/notary) / [Docker Content Trust](https://docs.docker.com/engine/security/trust/)
+- [Notary](https://github.com/theupdateframework/notary) / [Docker Content Trust](https://docs.docker.com/engine/security/trust/)
 - [Sigstore](https://sigstore.dev/) / [Cosign](https://github.com/sigstore/cosign)
-- [Notary V2](https://github.com/notaryproject/nv2) (PLANNED)
+- [Notation](https://github.com/notaryproject/notation)
 
 It provides several additional features such as:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Based on the result, it either accepts or denies those requests.
 Connaisseur is developed under three core values: *Security*, *Usability*, *Compatibility*.
 It is built to be extendable and currently aims to support the following signing solutions:
 
-- [Notary (V1)](https://github.com/theupdateframework/notary) / [Docker Content Trust](https://docs.docker.com/engine/security/trust/)
+- [Notary](https://github.com/theupdateframework/notary) / [Docker Content Trust](https://docs.docker.com/engine/security/trust/)
 - [sigstore](https://sigstore.dev/) / [Cosign](https://github.com/sigstore/cosign)
 - [Notation](https://github.com/notaryproject/notation)
 
@@ -86,7 +86,7 @@ On a very basic level, this requires two steps:
 2. Verifying the image signatures *before deployment*
 
 Connaisseur aims to solve step two.
-This is achieved by implementing several *validators*, i.e. configurable signature verification modules for different signing solutions (e.g. Notary V1).
+This is achieved by implementing several *validators*, i.e. configurable signature verification modules for different signing solutions (e.g. Notary).
 While the detailed security considerations mainly depend on the applied solution, Connaisseur in general verifies the signature over the container image content against a trust anchor or *trust root* (e.g. public key) and thus let's you ensure that images have not been tampered with (integrity) and come from a valid source (provenance).
 
 ![](./assets/sign-verify.png)
@@ -155,8 +155,8 @@ Connaisseur supports Kubernets v1.16 and higher. It is expected to be compatible
 - [SysEleven MetaKube](https://docs.syseleven.de/metakube) ✅
 
 All registry interactions use the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) that is based on the [Docker Registry HTTP API V2](https://docs.docker.com/registry/spec/api/) which is the standard for all common image registries.
-For using Notary (V1) as a signature solution, only some registries provide the required Notary server attached to the registry with e.g. shared authentication.
-Connaisseur has been tested with the following Notary (V1) supporting image registries:
+For using Notary as a signature solution, only some registries provide the required Notary server attached to the registry with e.g. shared authentication.
+Connaisseur has been tested with the following Notary supporting image registries:
 
 - [Docker Hub](https://hub.docker.com/) ✅
 - [Harbor](https://goharbor.io/) ✅

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,7 @@ You will learn how to:
 4. [Test Connaisseur](#test-connaisseur) *(and sign images)*
 5. [Cleanup](#cleanup)
 
-In the tutorial, you can choose to use either Notary (V1) via Docker Content Trust (DCT) or Cosign from the sigstore project as a signing solution referred to as DCT and Cosign from here on.
+In the tutorial, you can choose to use either Notary via Docker Content Trust (DCT) or Cosign from the sigstore project as a signing solution referred to as DCT and Cosign from here on.
 Furthermore we will work with public images on [Docker Hub](https://hub.docker.com/) as a container registry and a Kubernetes test cluster which might for example be [MicroK8s](https://microk8s.io/) or [minikube](https://minikube.sigs.k8s.io/docs/) for local setups.
 However, feel free to bring your own solutions for registry or cluster and check out our notes on [compatibility](./README.md#compatibility).
 

--- a/docs/validators/README.md
+++ b/docs/validators/README.md
@@ -2,11 +2,10 @@
 
 Connaisseur is built to be extendable and currently aims to support the following signing solutions:
 
-- [Docker Content Trust (DCT)](https://docs.docker.com/engine/security/trust/) / [Notary V1](https://github.com/theupdateframework/notary)
+- [Docker Content Trust (DCT)](https://docs.docker.com/engine/security/trust/) / [Notary (V1)](https://github.com/theupdateframework/notary)
 - [sigstore](https://sigstore.dev/) / [Cosign](https://github.com/sigstore/cosign)
 - [Notation](https://github.com/notaryproject/notation)
 
 Feel free to use any or a combination of all solutions.
 The integration with Connaisseur is detailed on the following pages.
 For advantages and disadvantages of each solution, please refer to the respective docs.
-

--- a/docs/validators/notaryv1.md
+++ b/docs/validators/notaryv1.md
@@ -4,7 +4,8 @@
 [Docker Content Trust (DCT)](https://docs.docker.com/engine/security/trust/) is a client implementation by Docker to manage such trust data for container images like signing images or verifying the corresponding signatures.
 It is part of the standard Docker CLI (`docker`) and for example provides the [`docker trust`](https://docs.docker.com/engine/reference/commandline/trust/) commands.
 
-[^1]: Notary does traditionally not carry the version number. However, in differentiation to the new [Notary V2 project](https://github.com/notaryproject/notaryproject) we decided to add a careful "(V1)" whenever we refer to the original project.
+[^1]: Notary does traditionally not carry the version number. However, in differentiation to the new [Notary V2 project](https://github.com/notaryproject/specifications) we decided to add a careful "(V1)" whenever we refered to the original project.
+Since then, the name Notation has formed for Notary V2, so we usually use only Notary and Notation, but the `v1` suffix has been kept in the config.
 
 Using DCT, the trust data is per default pushed to the Notary server associated to the container registry.
 However, not every public container registry provides an associated Notary server and thus support for DCT must be checked for the provider in question.
@@ -47,7 +48,7 @@ How to extract the public root key for any image is described [below](#getting-t
 
 ### Creating signatures
 
-Before you can start validating images using the Notary (V1) validator, you'll first need an image which has been signed using DCT.
+Before you can start validating images using the Notary validator, you'll first need an image which has been signed using DCT.
 Easiest way to do this is by pushing an image of your choice (e.g. `busybox:stable`) to your Docker Hub repository with DCT activated (either set the environment variable `DOCKER_CONTENT_TRUST=1` or use the `--disable-content-trust=false` flag).
 If you haven't created any signatures for images in the current repository yet, you'll be asked to enter a passphrase for a root key and targets key, which get generated on your machine.
 Have a look into the [TUF documentation](https://theupdateframework.github.io/specification/latest/#roles-and-pki) to read more about TUF roles and their meanings.
@@ -175,7 +176,7 @@ For more information on TUF roles, please refer to [TUF's documentation](https:/
 
 ## Configuration options
 
-`.application.validators[*]` in `charts/connaisseur/values.yaml` supports the following keys for Notary (V1) (refer to [basics](../basics.md#validators) for more information on default keys):
+`.application.validators[*]` in `charts/connaisseur/values.yaml` supports the following keys for Notary (refer to [basics](../basics.md#validators) for more information on default keys):
 
 | Key | Default | Required | Description |
 | - | - | - | - |
@@ -190,7 +191,7 @@ For more information on TUF roles, please refer to [TUF's documentation](https:/
 | `auth.password` | - | - | Password or access token to authenticate with[^2]. |
 | `cert` | - | - | Self-signed certificate of the Notary instance, if used. Certificate must be supplied in `.pem` format. |
 
-`.application.policy[*]` in `charts/connaisseur/values.yaml` supports the following additional keys for Notary (V1) (refer to [basics](../basics.md#image-policy) for more information on default keys):
+`.application.policy[*]` in `charts/connaisseur/values.yaml` supports the following additional keys for Notary (refer to [basics](../basics.md#image-policy) for more information on default keys):
 
 | Key | Default | Required | Description |
 | - | - | - | - |
@@ -230,7 +231,7 @@ For more information on TUF roles, please refer to [TUF's documentation](https:/
 
 ### Enforcing delegations
 
-Notary (V1) offers the functionality to delegate trust.
+Notary offers the functionality to delegate trust.
 To better understand this feature, it's best to have a basic understanding of the TUF key hierarchy, or more specifically the purpose of the root, targets and delegation keys.
 If you are more interested in this topic, please read the [TUF documentation](https://theupdateframework.github.io/specification/latest/#roles-and-pki).
 


### PR DESCRIPTION


## Description
With the introduction of notation support, we added its documentation, but didn't change existing docs which references nv1 or nv2 as planned. This PR fixes various places in the docs and updates references.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
