### PR TITLE
fix: allow overriding and disabling serviceaccount creation

### DIFF
--- a/charts/connaisseur/templates/_helpers.tpl
+++ b/charts/connaisseur/templates/_helpers.tpl
@@ -57,7 +57,11 @@ Create the name of the service account to use
 Create the name of the service account to use
 */}}
 {{- define "connaisseur.serviceAccountName" -}}
+{{- if .Values.kubernetes.serviceaccount.name }}
+{{- .Values.kubernetes.serviceaccount.name }}
+{{- else }}
 {{- include "connaisseur.name" . }}-serviceaccount
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/connaisseur/templates/serviceaccount.yaml
+++ b/charts/connaisseur/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubernetes.serviceaccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
   annotations:
     {{- toYaml .Values.kubernetes.serviceaccount.annotations | nindent 4 }}
   {{- end }}
+{{- end -}}

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -57,7 +57,9 @@ kubernetes:
   # -----------------------------------------------------
 
   # changes to connaisseur service account
-  serviceaccount: {}
+  serviceaccount:
+    create: true
+    name: ""
   #   annotations:
   #     eks.amazonaws.com/role-arn: arn:aws:iam::XXX:role/myrole
 


### PR DESCRIPTION
The Connaisseur Helm chart hardcodes the ServiceAccount name in the helper template and always creates it, which prevents users from overriding it with custom names or using an externally managed ServiceAccount.

This PR adds two new configuration options to the `kubernetes.serviceaccount` block in `values.yaml`:
1.  `name`: Allows overriding the default ServiceAccount name.
2.  `create`: Allows toggling the creation of the ServiceAccount resource.

This change is particularly useful for users integrating Connaisseur with external infrastructure management tools (like Terraform EKS Pod Identity) where the ServiceAccount may be pre-provisioned or require a specific, deterministic name.

Fixes #2124