### PR TITLE
feat: allow overriding and disabling serviceaccount creation

### DIFF
--- a/charts/connaisseur/Chart.yaml
+++ b/charts/connaisseur/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.10.0
-appVersion: 3.10.0
+version: 2.11.0
+appVersion: 3.11.0
 keywords:
   - container image
   - signature

--- a/charts/connaisseur/templates/_helpers.tpl
+++ b/charts/connaisseur/templates/_helpers.tpl
@@ -57,7 +57,11 @@ Create the name of the service account to use
 Create the name of the service account to use
 */}}
 {{- define "connaisseur.serviceAccountName" -}}
+{{- if .Values.kubernetes.serviceaccount.name }}
+{{- .Values.kubernetes.serviceaccount.name }}
+{{- else }}
 {{- include "connaisseur.name" . }}-serviceaccount
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/connaisseur/templates/serviceaccount.yaml
+++ b/charts/connaisseur/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubernetes.serviceaccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
   annotations:
     {{- toYaml .Values.kubernetes.serviceaccount.annotations | nindent 4 }}
   {{- end }}
+{{- end -}}

--- a/charts/connaisseur/values.yaml
+++ b/charts/connaisseur/values.yaml
@@ -57,7 +57,9 @@ kubernetes:
   # -----------------------------------------------------
 
   # changes to connaisseur service account
-  serviceaccount: {}
+  serviceaccount:
+    create: true
+    name: "" # defaults to connaisseur-serviceaccount
   #   annotations:
   #     eks.amazonaws.com/role-arn: arn:aws:iam::XXX:role/myrole
 


### PR DESCRIPTION
This update adds the ability to both override the ServiceAccount name and disable its creation via values.yaml. This is essential for environments where the ServiceAccount is managed externally (e.g., via Terraform EKS Pod Identity).

<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #2124

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
