### PR TITLE
fix: match registry host case-insensitively in policy rules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,13 +76,28 @@ func (c Config) Validator(key string) (*validator.Validator, error) {
 	return nil, fmt.Errorf("validator \"%s\" not found", key)
 }
 
+// foldHost lowercases only the registry host of a reference or pattern; the
+// first component counts as a host if it has "." or ":" or is "localhost".
+func foldHost(ref string) string {
+	i := strings.IndexByte(ref, '/')
+	if i < 0 {
+		return ref
+	}
+	host := ref[:i]
+	if !strings.ContainsAny(host, ".:") && host != "localhost" {
+		return ref
+	}
+	return strings.ToLower(host) + ref[i:]
+}
+
 // Gets the most specific matching rule for a given image from the config.
 func (c Config) MatchingRule(image string) (*policy.Rule, error) {
+	image = foldHost(image)
 	// start with empty pattern
 	bestMatch := policy.NewMatch(policy.Rule{}, "")
 
 	for _, rule := range c.Rules {
-		pattern := rule.Pattern
+		pattern := foldHost(rule.Pattern)
 
 		// prepend wildcard if not present
 		if !strings.HasPrefix(pattern, "*") {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,6 +99,8 @@ func TestMatchingRule(t *testing.T) {
 		},
 		{"my.registry/test:tag", "my.registry/test"},
 		{"my.registry/abc:tag", "my.registry/*"},
+		{"REGISTRY.k8s.io/image", "registry.k8s.io/*:*"},
+		{"My.Registry/test:tag", "my.registry/test"},
 		// {"docker.io/test:tag", "docker.io/test:*"}, // TODO: #1517
 	}
 
@@ -111,6 +113,26 @@ func TestMatchingRule(t *testing.T) {
 	_, err := cfg.MatchingRule("")
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "no matching rule")
+}
+
+func TestFoldHost(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		{"REGISTRY.IO/repo:Tag", "registry.io/repo:Tag"},
+		{"My.Registry/Repo:Tag", "my.registry/Repo:Tag"},
+		{"localhost:5000/Repo:Tag", "localhost:5000/Repo:Tag"},
+		{"[2001:DB8::1]:5000/repo:Tag", "[2001:db8::1]:5000/repo:Tag"},
+		{"MyOrg/image:Tag", "MyOrg/image:Tag"},
+		{"image:Tag", "image:Tag"},
+		{"*:MyTag", "*:MyTag"},
+		{"REGISTRY.io/*:*", "registry.io/*:*"},
+	}
+
+	for idx, tc := range testCases {
+		assert.Equalf(t, tc.want, foldHost(tc.in), "test case %d", idx+1)
+	}
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
Fixes #2130

## Description

Policy rules matched the registry host case-sensitively, so the same image referenced with a different-case host matched a different rule. Registry hosts are case-insensitive. This case-folds the registry host of both the image and the patterns before matching, leaving the repository path untouched.

## Checklist

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
