### PR TITLE
fix: match registry host case-insensitively in policy rules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,13 +76,28 @@ func (c Config) Validator(key string) (*validator.Validator, error) {
 	return nil, fmt.Errorf("validator \"%s\" not found", key)
 }
 
+// foldHost lowercases only the registry host of a reference or pattern; the
+// first component counts as a host if it has "." or ":" or is "localhost".
+func foldHost(ref string) string {
+	i := strings.IndexByte(ref, '/')
+	if i < 0 {
+		return ref
+	}
+	host := ref[:i]
+	if !strings.ContainsAny(host, ".:") && !strings.EqualFold(host, "localhost") {
+		return ref
+	}
+	return strings.ToLower(host) + ref[i:]
+}
+
 // Gets the most specific matching rule for a given image from the config.
 func (c Config) MatchingRule(image string) (*policy.Rule, error) {
+	image = foldHost(image)
 	// start with empty pattern
 	bestMatch := policy.NewMatch(policy.Rule{}, "")
 
 	for _, rule := range c.Rules {
-		pattern := rule.Pattern
+		pattern := foldHost(rule.Pattern)
 
 		// prepend wildcard if not present
 		if !strings.HasPrefix(pattern, "*") {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,7 @@ func TestLoad(t *testing.T) {
 	assert.NotEqual(t, &Config{}, cfg)
 
 	assert.Equal(t, 3, len(cfg.Validators))
-	assert.Equal(t, 11, len(cfg.Rules))
+	assert.Equal(t, 12, len(cfg.Rules))
 	assert.Equal(t, 2, len(cfg.Alerting.AdmitRequests.Receivers))
 	assert.Equal(t, 1, len(cfg.Alerting.RejectRequests.Receivers))
 }
@@ -99,6 +99,10 @@ func TestMatchingRule(t *testing.T) {
 		},
 		{"my.registry/test:tag", "my.registry/test"},
 		{"my.registry/abc:tag", "my.registry/*"},
+		{"REGISTRY.k8s.io/image", "registry.k8s.io/*:*"},
+		{"My.Registry/test:tag", "my.registry/test"},
+		{"localhost:1234/test:tag", "LoCaLhOst:1234/*"},
+		{"localhost/test:tag", "docker.io/*:*"}, // localhost without port is not considered a host by go-containerregistry
 		// {"docker.io/test:tag", "docker.io/test:*"}, // TODO: #1517
 	}
 
@@ -111,6 +115,26 @@ func TestMatchingRule(t *testing.T) {
 	_, err := cfg.MatchingRule("")
 	assert.NotNil(t, err)
 	assert.ErrorContains(t, err, "no matching rule")
+}
+
+func TestFoldHost(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		{"REGISTRY.IO/repo:Tag", "registry.io/repo:Tag"},
+		{"My.Registry/Repo:Tag", "my.registry/Repo:Tag"},
+		{"LocalHost/Repo:Tag", "localhost/Repo:Tag"},
+		{"[2001:DB8::1]:5000/repo:Tag", "[2001:db8::1]:5000/repo:Tag"},
+		{"MyOrg/image:Tag", "MyOrg/image:Tag"},
+		{"image:Tag", "image:Tag"},
+		{"*:MyTag", "*:MyTag"},
+		{"REGISTRY.io/*:*", "registry.io/*:*"},
+	}
+
+	for idx, tc := range testCases {
+		assert.Equalf(t, tc.want, foldHost(tc.in), "test case %d", idx+1)
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/test/testdata/config/00_sample.yaml
+++ b/test/testdata/config/00_sample.yaml
@@ -30,6 +30,7 @@ policy:
   - pattern: "my.registry/*"
   - pattern: "my.registry/test"
   - pattern: "docker.io/test:*"
+  - pattern: "LoCaLhOst:1234/*"
 
 alerting:
   clusterIdentifier: example-cluster-staging-europe # defaults to "not specified"


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fix #2130

## Description

Registry hosts are case-insensitive DNS names, but MatchingRule compared them verbatim, so an image like MyRegistry.io/... could evade a rule written for myregistry.io/... . foldHost now lowercases only the registry host of the image and the rule pattern, treating the first component as a host only when it looks like one (contains . or :, or is localhost), so tags, Docker Hub namespaces and IPv6 hosts keep their case.

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
