### PR TITLE
ci: Limit PR workflow to one concurrent run per branch

### DIFF
--- a/.github/workflows/01_pr.yml
+++ b/.github/workflows/01_pr.yml
@@ -8,6 +8,10 @@ on:
       - master
       - develop
 
+concurrency:
+  group: pr-${{ github.head_ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
Limit PR workflow to one concurrent run per branch

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
