### PR TITLE
fix: Add timeouts to http clients

### DIFF
--- a/charts/connaisseur/Chart.yaml
+++ b/charts/connaisseur/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: connaisseur
 description: Helm chart for Connaisseur - a Kubernetes admission controller to integrate container image signature verification and trust pinning into a cluster.
 type: application
-version: 2.11.0
-appVersion: 3.11.0
+version: 2.11.1
+appVersion: 3.11.1
 keywords:
   - container image
   - signature

--- a/internal/alert/channel.go
+++ b/internal/alert/channel.go
@@ -109,7 +109,7 @@ func (ch *Channel) Send(ctx context.Context, opts NotificationValues, errorChann
 			req.Header.Set(hKeyValue[0], hKeyValue[1])
 		}
 
-		client := &http.Client{}
+		client := &http.Client{Timeout: 30 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
 			errOut = fmt.Errorf(

--- a/internal/validator/notation/notation_validator.go
+++ b/internal/validator/notation/notation_validator.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/log"
@@ -100,6 +101,7 @@ func (nv *NotationValidator) ValidateImage(
 			},
 		}
 	}
+	client.Client.Timeout = 30 * time.Second
 
 	if authn := nv.Auth.LookUp(image.Context().Name()); authn.Username != "" &&
 		authn.Password != "" {


### PR DESCRIPTION
Add timeouts to http clients

## Description

- Notation is safety only as ctx timeout should apply already
- Alerting fixes a gap as detached alerting (failOnError false) runs don't run with ctx and timeout

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
