### PR TITLE
sec: Fix Notary reference registry confusion

### DIFF
--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -87,7 +87,7 @@ func (i *Image) String() string {
 // notary stores images at `docker.io/...` thus the `index.` prefix
 // needs to be removed.
 func (i *Image) NotaryReference() string {
-	if strings.HasPrefix(i.Context().String(), constants.DefaultDockerRegistry) {
+	if i.Context().RegistryStr() == constants.DefaultDockerRegistry {
 		return strings.TrimPrefix(i.Context().String(), "index.")
 	}
 	return i.Context().String()

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -270,6 +270,18 @@ func TestNotaryReference(t *testing.T) {
 			"registry.io:8080/path/to/repo/image:tag",
 			"registry.io:8080/path/to/repo/image",
 		},
+		{ // lookalike registry must not be confused for docker hub
+			"index.docker.io.attacker.example/repo:tag",
+			"index.docker.io.attacker.example/repo",
+		},
+		{ // lookalike registry with dash must not be confused for docker hub either
+			"index.docker.io-attacker.example/repo:tag",
+			"index.docker.io-attacker.example/repo",
+		},
+		{
+			"index.docker.io/library/test-image:latest",
+			"docker.io/library/test-image",
+		},
 	}
 	for _, tc := range testCases {
 		img, _ := New(tc.img)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fix Notary reference registry confusion

## Description
This commit fixes a Notary reference registry confusion, where a prefix could be unintentionally stripped from images not in the default docker registry. This could lead to the wrong registry signatures being checked against the correct key. This does not allow an attacker to validate arbitrary images. Instead, if the attacker controls part of the registry, they may serve stale, previously signed images in a downgrade or freeze attack.
<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
