### PR TITLE
sec: Respect notary path constraints

### DIFF
--- a/internal/validator/notaryv1/notaryv1_validator.go
+++ b/internal/validator/notaryv1/notaryv1_validator.go
@@ -165,9 +165,20 @@ func (nv1v *NotaryV1Validator) ValidateImage(
 		)
 		signedTarget := repo.Targets[target].Signed
 
+		// delegations may only vouch for targets within their path restrictions;
+		// the canonical targets role has full authority and needs no such check
+		var delegationRole *data.DelegationRole
+		if target != data.CanonicalTargetsRole.String() {
+			dr, err := repo.Targets[data.CanonicalTargetsRole.String()].BuildDelegationRole(data.RoleName(target))
+			if err != nil {
+				return "", fmt.Errorf("error building delegation role %s: %s", target, err)
+			}
+			delegationRole = &dr
+		}
+
 		// search trust data for either tag or digest
 		if image.Tag() != "" {
-			digest, digestErr = searchTargetsForTag(signedTarget, image.Tag())
+			digest, digestErr = resolveAuthorizedTagInTargets(signedTarget, image.Tag(), delegationRole)
 			if digestErr != nil {
 				return "", fmt.Errorf("validated targets don't contain reference: %s", digestErr)
 			}
@@ -178,7 +189,7 @@ func (nv1v *NotaryV1Validator) ValidateImage(
 				return "", fmt.Errorf("digest %s resolved for tag %s doesn't match given digest %s", digest, image.Tag(), image.Digest())
 			}
 		} else {
-			digest, digestErr = searchTargetsForDigest(signedTarget, image.Digest())
+			digest, digestErr = resolveAuthorizedDigestInTargets(signedTarget, image.Digest(), delegationRole)
 			if digestErr != nil {
 				return "", fmt.Errorf("validated targets don't contain reference: %s", digestErr)
 			}
@@ -253,12 +264,16 @@ func toDelegationString(delegation string) string {
 	return fmt.Sprintf("targets/%s", delegation)
 }
 
-func searchTargetsForTag(targetFile data.Targets, tag string) (string, error) {
+func resolveAuthorizedTagInTargets(targetFile data.Targets, tag string, delegationRole *data.DelegationRole) (string, error) {
 	logrus.Debugf("searching targets for tag %s", tag)
 
 	for key, target := range targetFile.Targets {
 		if key != tag {
 			continue
+		}
+
+		if delegationRole != nil && !delegationRole.CheckPaths(key) {
+			return "", fmt.Errorf("delegation %s is not authorized to sign target %s", delegationRole.Name, key)
 		}
 
 		return dgst.NewDigestFromEncoded(
@@ -270,15 +285,19 @@ func searchTargetsForTag(targetFile data.Targets, tag string) (string, error) {
 	return "", fmt.Errorf("no tag '%s' found in targets", tag)
 }
 
-func searchTargetsForDigest(targetFile data.Targets, digest string) (string, error) {
+func resolveAuthorizedDigestInTargets(targetFile data.Targets, digest string, delegationRole *data.DelegationRole) (string, error) {
 	logrus.Debugf("searching targets for digest %s", digest)
 
-	for _, target := range targetFile.Targets {
+	for key, target := range targetFile.Targets {
 		targetDigest := dgst.NewDigestFromEncoded(
 			notary.SHA256,
 			hex.EncodeToString(target.Hashes[notary.SHA256]),
 		)
 		if targetDigest.String() == digest {
+			if delegationRole != nil && !delegationRole.CheckPaths(key) {
+				return "", fmt.Errorf("delegation %s is not authorized to sign target %s", delegationRole.Name, key)
+			}
+
 			return targetDigest.String(), nil
 		}
 	}

--- a/internal/validator/notaryv1/notaryv1_validator_test.go
+++ b/internal/validator/notaryv1/notaryv1_validator_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/theupdateframework/notary/tuf/data"
 	"gopkg.in/yaml.v3"
 )
 
@@ -487,36 +488,122 @@ func TestToDelegationString(t *testing.T) {
 	}
 }
 
-func TestSearchTargetsForTag(t *testing.T) {
+func TestResolveAuthorizedTagInTargets(t *testing.T) {
+	// a delegation restricted to "v1" is authorized for "v1" but not "sign",
+	// even though the delegation's own targets file signs both
+	restrictedRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/restricted"},
+		Paths:    []string{"v1"},
+	}
+
+	// a delegation with multiple paths covering both targets is authorized for either
+	fullRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/full"},
+		Paths:    []string{"v1", "sign"},
+	}
+
+	// a delegation with no paths at all is authorized for nothing
+	noPathsRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/no-paths"},
+		Paths:    []string{},
+	}
+
+	// TUF "authorized for everything" is an explicit empty-string path,
+	// since every target name has "" as a prefix
+	wildcardRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/wildcard"},
+		Paths:    []string{""},
+	}
+
 	var testCases = []struct {
-		file   string
-		tag    string
-		digest string
-		err    string
+		file           string
+		tag            string
+		delegationRole *data.DelegationRole
+		digest         string
+		err            string
 	}{
 		{
 			"sample-image/targets",
 			"v1",
+			nil,
 			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
 			"",
 		},
 		{
 			"sample-image/targets",
 			"sign",
+			nil,
 			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
 			"",
 		},
 		{
 			"sample-image/targets",
 			"no_tag",
+			nil,
 			"",
 			"no tag 'no_tag' found in targets",
+		},
+		{
+			"sample-image/targets",
+			"v1",
+			restrictedRole,
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sign",
+			restrictedRole,
+			"",
+			"delegation targets/restricted is not authorized to sign target sign",
+		},
+		{
+			"sample-image/targets",
+			"v1",
+			fullRole,
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sign",
+			fullRole,
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			"",
+		},
+		{
+			"sample-image/targets",
+			"v1",
+			noPathsRole,
+			"",
+			"delegation targets/no-paths is not authorized to sign target v1",
+		},
+		{
+			"sample-image/targets",
+			"sign",
+			noPathsRole,
+			"",
+			"delegation targets/no-paths is not authorized to sign target sign",
+		},
+		{
+			"sample-image/targets",
+			"v1",
+			wildcardRole,
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sign",
+			wildcardRole,
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			"",
 		},
 	}
 
 	for _, tc := range testCases {
 		target, _ := testhelper.TargetData(PRE + "trust_data/" + tc.file + ".json")
-		digest, err := searchTargetsForTag(target.Signed, tc.tag)
+		digest, err := resolveAuthorizedTagInTargets(target.Signed, tc.tag, tc.delegationRole)
 
 		if tc.err != "" {
 			assert.NotNil(t, err)
@@ -528,32 +615,110 @@ func TestSearchTargetsForTag(t *testing.T) {
 	}
 }
 
-func TestSearchTargetsForDigest(t *testing.T) {
+func TestResolveAuthorizedDigestInTargets(t *testing.T) {
+	// a delegation restricted to "v1" is authorized for "v1" but not "sign",
+	// even though the delegation's own targets file signs both
+	restrictedRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/restricted"},
+		Paths:    []string{"v1"},
+	}
+
+	// a delegation with multiple paths covering both targets is authorized for either
+	fullRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/full"},
+		Paths:    []string{"v1", "sign"},
+	}
+
+	// a delegation with no paths at all is authorized for nothing
+	noPathsRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/no-paths"},
+		Paths:    []string{},
+	}
+
+	// TUF "authorized for everything" is an explicit empty-string path,
+	// since every target name has "" as a prefix
+	wildcardRole := &data.DelegationRole{
+		BaseRole: data.BaseRole{Name: "targets/wildcard"},
+		Paths:    []string{""},
+	}
+
 	var testCases = []struct {
-		file   string
-		digest string
-		err    string
+		file           string
+		digest         string
+		delegationRole *data.DelegationRole
+		err            string
 	}{
 		{
 			"sample-image/targets",
 			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			nil,
 			"",
 		},
 		{
 			"sample-image/targets",
 			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			nil,
 			"",
 		},
 		{
 			"sample-image/targets",
 			"sha256:aaaaaaab8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			nil,
 			"no digest 'sha256:aaaaaaab8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf' found in targets",
+		},
+		{
+			"sample-image/targets",
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			restrictedRole,
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			restrictedRole,
+			"delegation targets/restricted is not authorized to sign target sign",
+		},
+		{
+			"sample-image/targets",
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			fullRole,
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			fullRole,
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			noPathsRole,
+			"delegation targets/no-paths is not authorized to sign target v1",
+		},
+		{
+			"sample-image/targets",
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			noPathsRole,
+			"delegation targets/no-paths is not authorized to sign target sign",
+		},
+		{
+			"sample-image/targets",
+			"sha256:799c0fa8aa4c9fbff5a99aef1b4b5c3abb9c2f34134345005982fad3489893c7",
+			wildcardRole,
+			"",
+		},
+		{
+			"sample-image/targets",
+			"sha256:a154797b8300165956ee1f16d98f3a1426301c1168f0462c73ce9bc03361cabf",
+			wildcardRole,
+			"",
 		},
 	}
 
 	for _, tc := range testCases {
 		target, _ := testhelper.TargetData(PRE + "trust_data/" + tc.file + ".json")
-		digest, err := searchTargetsForDigest(target.Signed, tc.digest)
+		digest, err := resolveAuthorizedDigestInTargets(target.Signed, tc.digest, tc.delegationRole)
 
 		if tc.err != "" {
 			assert.NotNil(t, err)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Respect notary path constraints

## Description
Previously, we did not respect path constraints in Notary, meaning a valid delegated signer with a constrained path could have signed for every path in the repo instead of only those with their prefixes
<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Mark as done if a point is not necessary. Feel free to reach out if help on any items in the checklist is needed. -->

- [x] PR is rebased to/aimed at branch `develop`
- [x] PR follows [Contributing Guide](https://github.com/sse-secure-systems/connaisseur/blob/master/docs/CONTRIBUTING.md)
- [x] Added tests (if necessary)
- [x] Extended README/Documentation (if necessary)
- [x] Adjusted versions of image and Helm chart in `Chart.yaml` (if necessary)
